### PR TITLE
Add support for building single-scoped Bicep Registry modules

### DIFF
--- a/src/scripts/Build-Bicep.ps1
+++ b/src/scripts/Build-Bicep.ps1
@@ -34,7 +34,7 @@ Param (
 $Debug = $DebugPreference -eq "Continue"
 
 $scopeList = '(subscription|resourceGroup|managementGroup|tenant)';
-$scopeDirective = "//(\s*@$scopeList)+";
+$scopeDirective = "(//(\s*@$scopeList)+|targetScope = '$scopeList')";
 
 $outDir = "../../release"
 $registryDir = "../bicep-registry"
@@ -52,6 +52,7 @@ Get-ChildItem "$registryDir/$Module*" -Directory `
     function Build-Modules([string] $Path, [switch] $CopySupportingFiles) {
         # Confirm path
         if (-not (Test-Path (Join-Path $srcDir $Path))) {
+            Write-Error "$srcDir/$Path not found"
             return;
         }
         


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Make sure you have a user-friendly PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below and remove the TODO lines after.
3. Internal PRs: Add applicable labels: Type, Micro PR, Breaking change

**PRO TIP**: Smaller PRs are closed faster. Try submitting multiple, small PRs.
-->

## 🛠️ Description
Add support for building Bicep Registry modules that only target a single scope and do not have any custom scope directives.

## 🔬 How has this been tested?
<!-- TODO: Check [x] all that apply. Leave the rest. -->
- [ ] 🫰 PS -WhatIf / az validate
- [X] 👍 Manually deployed + verified
- [ ] 💪 Unit tests
