### PR TITLE
Update Build-Toolkit to remove scope from Bicep Registry modules

### DIFF
--- a/src/scripts/Build-Toolkit.ps1
+++ b/src/scripts/Build-Toolkit.ps1
@@ -26,7 +26,7 @@ $outDir = "../../release"
 ./New-Directory $outDir
 
 # Generate Bicep Registry modules
-Get-ChildItem ..\bicep-registry\$Template* -Directory -ErrorAction SilentlyContinue `
+Get-ChildItem "..\bicep-registry\$($Template -replace '(subscription|resourceGroup|managementGroup|tenant)-', '')*" -Directory -ErrorAction SilentlyContinue `
 | Where-Object { $_.Name -ne '.scaffold' }
 | ForEach-Object {
     ./Build-Bicep $_.Name


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Make sure you have a user-friendly PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below and remove the TODO lines after.
3. Internal PRs: Add applicable labels: Type, Micro PR, Breaking change

**PRO TIP**: Smaller PRs are closed faster. Try submitting multiple, small PRs.
-->

## 🛠️ Description
Update the `Build-Toolkit` script to remove scope when looking for Bicep Registry modules.

This is needed because `Deploy-Toolkit` needs the final output name for the module (e.g., `subscription-scheduled-action`), but when `-Build` is used, `Build-Toolkit` doesn't understand it. With this change, both will understand the long-form module name.

In the future, we need to also add support for the short-form module name (e.g., `scheduled-action`) where `Deploy-Toolkit` deploys to the default scope automatically. This PR does not address that.

## 🔬 How has this been tested?
<!-- TODO: Check [x] all that apply. Leave the rest. -->
- [ ] 🫰 PS -WhatIf / az validate
- [X] 👍 Manually deployed + verified
- [ ] 💪 Unit tests
