### PR TITLE
PS module to add EA permissions to FinOps toolkit service principal

### DIFF
--- a/src/powershell/FinOpsToolkit.psm1
+++ b/src/powershell/FinOpsToolkit.psm1
@@ -430,7 +430,7 @@ Function Add-FinOpsHubScope {
         [Parameter()]
         [string]
         [ValidateNotNullOrEmpty()]
-        $ResourceGroupName,    
+        $ResourceGroupName,
         [Parameter()]
         [String]
         [ValidateNotNullOrEmpty()]

--- a/src/powershell/FinOpsToolkit.psm1
+++ b/src/powershell/FinOpsToolkit.psm1
@@ -392,11 +392,11 @@ function Add-FinOpsServicePrincipal {
     
     try {
         Invoke-RestMethod -Uri $restUri -Method Put -Headers $authHeader -Body $body
-        Write-Host ($LocalizedData.SuccessMessage1 -f $BillingScope)
+        Write-Output ($LocalizedData.SuccessMessage1 -f $BillingScope)
     }
     catch {
         if ($_.Exception.Response.StatusCode -eq 409) {
-            Write-Host ($LocalizedData.AlreadyGrantedMessage1 -f $BillingScope)
+            Write-Output ($LocalizedData.AlreadyGrantedMessage1 -f $BillingScope)
         }
         else {
             $body

--- a/src/powershell/FinOpsToolkit.psm1
+++ b/src/powershell/FinOpsToolkit.psm1
@@ -339,7 +339,7 @@ function Add-FinOpsServicePrincipal {
         [Parameter(Mandatory = $false)]
         [string]$DepartmentId
     )
-  
+
     $azContext = get-azcontext
     switch ($BillingScope) {
         'Enrollment' {
@@ -348,14 +348,13 @@ function Add-FinOpsServicePrincipal {
                 Write-Output ''
                 exit 1
             }
-  
+
             $roleDefinitionId = "/providers/Microsoft.Billing/billingAccounts/{0}/billingRoleDefinitions/24f8edb6-1668-4659-b5e2-40bb5f3a7d7e" -f $BillingAccountId
             $restUri = "{0}providers/Microsoft.Billing/billingAccounts/{1}/billingRoleAssignments/{2}?api-version=2019-10-01-preview" -f $azContext.Environment.ResourceManagerUrl, $BillingAccountId, (New-Guid).Guid
-            $body = '{"properties": { "PrincipalId": "{0}", "PrincipalTenantId": "{1}", "roleDefinitionId": "{2}" } }' 
+            $body = '{"properties": { "PrincipalId": "{0}", "PrincipalTenantId": "{1}", "roleDefinitionId": "{2}" } }'
             $body = $body.Replace("{0}", $ObjectId)
             $body = $body.Replace("{1}", $TenantId)
             $body = $body.Replace("{2}", $roleDefinitionId)
-  
         }
         'Department' {
             if ([string]::IsNullOrEmpty($BillingAccountId)) {
@@ -368,20 +367,19 @@ function Add-FinOpsServicePrincipal {
                 Write-Output ''
                 exit 1
             }
-  
+
             $roleDefinitionId = "/providers/Microsoft.Billing/billingAccounts/{0}/departments/{1}/billingRoleDefinitions/db609904-a47f-4794-9be8-9bd86fbffd8a" -f $BillingAccountId, $DepartmentId
             $restUri = "{0}providers/Microsoft.Billing/billingAccounts/{1}/departments/{2}/billingRoleAssignments/{3}?api-version=2019-10-01-preview" -f $azContext.Environment.ResourceManagerUrl, $BillingAccountId, $DepartmentId, (New-Guid).Guid
             $body = '{"properties": { "PrincipalId": "{0}", "PrincipalTenantId": "{1}", "roleDefinitionId": "{2}" } }'
             $body = $body.Replace("{0}", $ObjectId)
             $body = $body.Replace("{1}", $TenantId)
             $body = $body.Replace("{2}", $roleDefinitionId)
-  
         }
         default {
             throw ($LocalizedData.InvalidBillingScope -f $BillingScope)
         }
     }
-    
+
     $azProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
     $profileClient = New-Object -TypeName Microsoft.Azure.Commands.ResourceManager.Common.RMProfileClient -ArgumentList ($azProfile)
     $token = $profileClient.AcquireAccessToken($azContext.Subscription.TenantId)
@@ -389,7 +387,7 @@ function Add-FinOpsServicePrincipal {
         'Content-Type'  = 'application/json'
         'Authorization' = 'Bearer ' + $token.AccessToken
     }
-    
+
     try {
         Invoke-RestMethod -Uri $restUri -Method Put -Headers $authHeader -Body $body
         Write-Output ($LocalizedData.SuccessMessage1 -f $BillingScope)

--- a/src/powershell/FinOpsToolkit.psm1
+++ b/src/powershell/FinOpsToolkit.psm1
@@ -323,7 +323,7 @@ Add-FinOpsServicePrincipal -ObjectId 00000000-0000-0000-0000-000000000000 -Tenan
 Grants department reader permissions to the specified service principal or managed identity
 
 #>
-function Add-FinOpsServicePrincipal {
+function Add-FinOpsHubServicePrincipal {
     param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -405,4 +405,5 @@ function Add-FinOpsServicePrincipal {
 
 #endregion Public functions
 
-Export-ModuleMember -Function 'Get-FinOpsToolkitVersions', 'Deploy-FinOpsHub', 'Add-FinOpsServicePrincipal'
+Export-ModuleMember -Function 'Get-FinOpsToolkitVersions', 'Deploy-FinOpsHub', 'Add-FinOpsHubServicePrincipal {
+    '

--- a/src/powershell/FinOpsToolkit.psm1
+++ b/src/powershell/FinOpsToolkit.psm1
@@ -316,10 +316,10 @@ The billing Account ID (enrollment id) to grant permissions against.
 The department id to grant permissions against.
 
 .EXAMPLE
-Add-FinOpsServicePrincipal -ObjectId 00000000-0000-0000-0000-000000000000 -TenantId 00000000-0000-0000-0000-000000000000 -BillingScope Enrollment -BillingAccountId 12345
+Add-FinOpsHubServicePrincipal -ObjectId 00000000-0000-0000-0000-000000000000 -TenantId 00000000-0000-0000-0000-000000000000 -BillingScope Enrollment -BillingAccountId 12345
 Grants EA Reader permissions to the specified service principal or managed identity
 
-Add-FinOpsServicePrincipal -ObjectId 00000000-0000-0000-0000-000000000000 -TenantId 00000000-0000-0000-0000-000000000000 -BillingScope Department -BillingAccountId 12345 -DepartmentId 67890
+Add-FinOpsHubServicePrincipal -ObjectId 00000000-0000-0000-0000-000000000000 -TenantId 00000000-0000-0000-0000-000000000000 -BillingScope Department -BillingAccountId 12345 -DepartmentId 67890
 Grants department reader permissions to the specified service principal or managed identity
 
 #>
@@ -403,7 +403,105 @@ function Add-FinOpsHubServicePrincipal {
     }
 }
 
+<#
+.SYNOPSIS
+Adds an export scope configuration to the specified Resource group.
+
+.PARAMETER ResourceGroupName
+The name of the Resource group.
+
+.PARAMETER Scope
+The Export Scope to add to the Resource group configuration.
+
+.PARAMETER TenantId
+The Azure AD Tenant linked to the export scope.
+
+.PARAMETER Cloud
+The Azure Cloud the export scope belongs to.
+
+.EXAMPLE
+Add-FinOpsHubScope -ResourceGroupName ftk-FinOps-Hub -Scope "/providers/Microsoft.Billing/billingAccounts/1234567"
+
+Adds an export scope configuration to the specified Resource group.
+#>
+Function Add-FinOpsHubScope {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string]
+        [ValidateNotNullOrEmpty()]
+        $ResourceGroupName,    
+        [Parameter()]
+        [String]
+        [ValidateNotNullOrEmpty()]
+        $Scope
+    )
+    $ErrorActionPreference = 'Stop'
+    [string]$operation = 'create'
+
+    # Main
+    Write-Output ''
+    Write-Output ("{0}    Starting" -f (Get-Date))
+
+    if (!$Scope.StartsWith('/')) {
+        $Scope = '/' + $Scope
+    }
+
+    if ($Scope.EndsWith('/')) {
+        $Scope = $Scope.Substring(0, $Scope.Length - 1)
+    }
+
+    Write-Output ("{0}    Export Scope to add: {1}" -f (Get-Date), $Scope)
+
+    $tagSuffix = "Microsoft.Cloud/hubs/$ResourceGroupName"
+    $hubResource = Get-AzResource -ResourceType 'Microsoft.Storage/storageAccounts' -TagName 'cm-resource-parent' | Where-Object {$_.Tags['cm-resource-parent'].EndsWith($tagSuffix) }
+    if ($null -eq $hubResource) {
+        Write-Output ("{0}    Hub not found" -f (Get-Date))
+        Throw ("Hub not found")
+    }
+
+    if ($hubResource.Count -gt 1) {
+        Write-Output ("{0}    Multiple hubs found" -f (Get-Date))
+        Throw ("Multiple hubs found")
+    }
+
+    $storageAccount = Get-AzStorageAccount -ResourceGroupName $hubResource.ResourceGroupName -Name $hubResource.Name -ErrorAction SilentlyContinue
+    if ($null -eq $storageAccount) {
+        Write-Output ("{0}    Storage account not found" -f (Get-Date))
+        Throw ("Storage account not found")
+    }
+
+    $storageContext = $StorageAccount.Context
+    Get-AzStorageBlob -Container 'config' -Blob 'settings.json' -Context $storageContext | Get-AzStorageBlobContent -Force | Out-Null
+    $settings = Get-Content 'settings.json' | ConvertFrom-Json
+
+    # To deal with the case where there's nothing but a blank export scope in the settings.json file
+    if (($settings.exportScopes.Count -eq 1) -and ([string]::IsNullOrEmpty($settings.exportScopes[0]))) {
+        $settings.exportScopes = @()
+        $operation = 'create'
+        Write-Output ("{0}    No export scopes defined" -f (Get-Date), $Scope)
+    }
+
+    foreach ($exportScope in $settings.exportScopes) {
+        if ($exportScope.scope -eq $Scope) {
+            Write-Output ("{0}    Export scope {1} already exists" -f (Get-Date), $Scope)
+            $operation = 'none'
+        }
+    }
+
+    if ($operation -eq 'create') {
+        Write-Output ("{0}    Adding export scope {1} with tenant ID {2}" -f (Get-Date), $Scope, $TenantId)
+        [PSCustomObject]$ScopeToAdd = @{scope = $Scope}
+        $settings.exportScopes += $ScopeToAdd
+        Write-Output ("{0}    Saving settings.json" -f (Get-Date))
+        $settings | ConvertTo-Json -Depth 100 | Set-Content 'settings.json' -Force | Out-Null
+        Set-AzStorageBlobContent -Container 'config' -File 'settings.json' -Context $storageContext -Force | Out-Null
+    }
+
+    Write-Output ("{0}    Finished" -f (Get-Date))
+    Write-Output ''
+}
+
 #endregion Public functions
 
-Export-ModuleMember -Function 'Get-FinOpsToolkitVersions', 'Deploy-FinOpsHub', 'Add-FinOpsHubServicePrincipal {
-    '
+Export-ModuleMember -Function 'Get-FinOpsToolkitVersions', 'Deploy-FinOpsHub', 'Add-FinOpsHubServicePrincipal', 'Add-FinOpsHubScope'

--- a/src/powershell/FinOpsToolkit.strings.psd1
+++ b/src/powershell/FinOpsToolkit.strings.psd1
@@ -9,4 +9,9 @@ ConvertFrom-StringData -StringData @'
     FoundLatestRelease = Found latest release '{0}'.
     NewDirectory = Creating directory '{0}'.
     TemplateNotFound = Could not find template 'main.bicep' at path '{0}'.
+    BillingAccountNotSpecifiedForDept = Billing account ID is required when billing scope = Department.
+    DeptIdNotSpecified = Department ID is required when billing scope = Department.
+    InvalidBillingScope = Invalid billing scope: '{0}'.
+    SuccessMessage1 = Successfully granted {0} Reader permissions to the specified Service Principal.
+    AlreadyGrantedMessage1 = Service Principal already has {0} Reader permissions for the specified billing scope.
 '@

--- a/src/powershell/FinOpsToolkit.strings.psd1
+++ b/src/powershell/FinOpsToolkit.strings.psd1
@@ -11,7 +11,8 @@ ConvertFrom-StringData -StringData @'
     TemplateNotFound = Could not find template 'main.bicep' at path '{0}'.
     BillingAccountNotSpecifiedForDept = Billing account ID is required when billing scope = Department.
     DeptIdNotSpecified = Department ID is required when billing scope = Department.
+    BillingAccountNotSpecified = A billing account ID is required.
     InvalidBillingScope = Invalid billing scope: '{0}'.
-    SuccessMessage1 = Successfully granted {0} Reader permissions to the specified Service Principal.
-    AlreadyGrantedMessage1 = Service Principal already has {0} Reader permissions for the specified billing scope.
+    SSuccessMessage1 = Successfully granted {0} Reader permissions to the specified service principal.
+    AlreadyGrantedMessage1 = Service principal already has {0} Reader permissions for the specified billing scope.
 '@


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Make sure you have a user-friendly PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below and remove the TODO lines after.
3. Internal PRs: Add applicable labels: Type, Micro PR, Breaking change

**PRO TIP**: Smaller PRs are closed faster. Try submitting multiple, small PRs.
-->

## 🛠️ Description
PS module to add EA permissions to FinOps toolkit service principal.
PS module to add scopes to settings.json for use by managed exports.

Usage:

```` Powershell
# Grants EA reader permissions to the specified service principal
Add-finOpsServicePrincipal -ObjectId 00000000-0000-0000-0000-000000000000 -TenantId 00000000-0000-0000-0000-000000000000 -BillingScope Enrollment -BillingAccountId 1234567

# Adds a Cost Management scope to settings.json
Add-FinOpsHubScope -ResourceGroupName "ftk-FinOps-Hub" -Scope "/providers/Microsoft.Billing/billingAccounts/1234567"
````
Fixes #(issue)


## 📷 Screenshots


## 🔬 How has this been tested?
<!-- TODO: Check [x] all that apply. Leave the rest. -->
- [ ] 🫰 PS -WhatIf / az validate
- [ ] 👍 Manually deployed + verified
- [ ] 💪 Unit tests
