### PR TITLE
Add Register-FinOpsProvider

### DIFF
--- a/src/powershell/Public/Register-FinOpsHubProviders.ps1
+++ b/src/powershell/Public/Register-FinOpsHubProviders.ps1
@@ -1,24 +1,20 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
 <#
     .SYNOPSIS
-        Registers Azure resource providers required for FinOps hub.
+    Registers Azure resource providers required for FinOps hub.
 
     .PARAMETER WhatIf
-        Optional. Shows what would happen if the command runs without actually running it.
+    Optional. Shows what would happen if the command runs without actually running it.
 
     .EXAMPLE
-        Register-FinOpsHubProviders -WhatIf
+    Register-FinOpsHubProviders -WhatIf
 
-        Shows what would happen if the command runs without actually running it.
+    Shows what would happen if the command runs without actually running it.
 
     .Description
-        The Register-FinOpsHubProviders command registers the Azure resource providers required to deploy 
-        and operate a FinOps hub instance. To register a resource provider, you must have 
-        Contributor access (or the /register permission for each resource provider) for the entire subscription. 
-        Subscription readers can check the status of the resource providers but cannot register them. 
-        If you do not have access to register resource providers, please contact a subscription contributor 
-        or owner to run the Register-FinOpsHubProviders command.
+    The Register-FinOpsHubProviders command registers the Azure resource providers required to deploy and operate a FinOps hub instance. To register a resource provider, you must have Contributor access (or the /register permission for each resource provider) for the entire subscription. Subscription readers can check the status of the resource providers but cannot register them. If you do not have access to register resource providers, please contact a subscription contributor or owner to run the Register-FinOpsHubProviders command.
 #>
 function Register-FinOpsHubProviders {
     [CmdletBinding(SupportsShouldProcess)]
@@ -45,11 +41,12 @@ function Register-FinOpsHubProviders {
             }
             # If the provider is already registered, logging a message saying so
             else {
-                Write-Verbose -Message $($LocalizedData.ResourceProviderExists -f $provider)
+                Write-Verbose -Message $($LocalizedData.ResourceProviderRegistered -f $provider)
             }
         }
     }
-    catch [Microsoft.Azure.PowerShell.Cmdlets.ResourceManager.Runtime.AzurePowerShellException] {
+    catch {
         Write-Verbose -Message $($LocalizedData.ErrorRegisteringProvider -f $_.Exception.Message)
+        throw $_.Exception.Message
     }
 }

--- a/src/powershell/Public/Register-FinOpsHubProviders.ps1
+++ b/src/powershell/Public/Register-FinOpsHubProviders.ps1
@@ -1,0 +1,55 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+<#
+    .SYNOPSIS
+        Registers Azure resource providers required for FinOps hub.
+
+    .PARAMETER WhatIf
+        Optional. Shows what would happen if the command runs without actually running it.
+
+    .EXAMPLE
+        Register-FinOpsHubProviders -WhatIf
+
+        Shows what would happen if the command runs without actually running it.
+
+    .Description
+        The Register-FinOpsHubProviders command registers the Azure resource providers required to deploy 
+        and operate a FinOps hub instance. To register a resource provider, you must have 
+        Contributor access (or the /register permission for each resource provider) for the entire subscription. 
+        Subscription readers can check the status of the resource providers but cannot register them. 
+        If you do not have access to register resource providers, please contact a subscription contributor 
+        or owner to run the Register-FinOpsHubProviders command.
+#>
+function Register-FinOpsHubProviders {
+    [CmdletBinding(SupportsShouldProcess)]
+    param ()
+
+    # Define the resource providers to register
+    $providers = "Microsoft.EventGrid", "Microsoft.CostManagementExports"
+
+    try {
+        # Loop through each provider and check if it's already registered
+        foreach ($provider in $providers) {
+            $registered = Get-AzResourceProvider -ProviderNamespace $provider 
+
+            # If the provider is not registered, register it
+            if ($registered.RegistrationState -eq "NotRegistered") {
+                
+                if ($WhatIf) {
+                    Write-Verbose "WhatIf:"+ $($LocalizedData.RegisterProvider -f $provider)
+                }
+                else {
+                    Write-Verbose -Message $($LocalizedData.RegisterProvider -f $provider)
+                    Register-AzResourceProvider -ProviderNamespace $provider   
+                }
+            }
+            # If the provider is already registered, logging a message saying so
+            else {
+                Write-Verbose -Message $($LocalizedData.ResourceProviderExists -f $provider)
+            }
+        }
+    }
+    catch [Microsoft.Azure.PowerShell.Cmdlets.ResourceManager.Runtime.AzurePowerShellException] {
+        Write-Verbose -Message $($LocalizedData.ErrorRegisteringProvider -f $_.Exception.Message)
+    }
+}

--- a/src/powershell/en-US/FinOpsToolkit.strings.psd1
+++ b/src/powershell/en-US/FinOpsToolkit.strings.psd1
@@ -10,6 +10,9 @@ ConvertFrom-StringData -StringData @'
     NewDirectory = Creating directory '{0}'.
     TemplateNotFound = Could not find template 'main.bicep' at path '{0}'.
     ContextNotFound = Could not retrieve Az context. Run Az-Login.
+    RegisterProvider =  Registering resource provider {0}.
+    ResourceProviderExists =  Resource provider {0} is already registered. 
+    ErrorRegisteringProvider =  Error registering resource provider: {0}.
     DeleteCostExportFailed = Delete Cost Management export operation failed with message: '{0}' (Code: {1}).
     GetCostExportNotFound = Cost Management export not found. Operation failed with message: '{0}' (Code: {1}).
     DeleteCostExportFilesFailed = Delete export files operation failed.

--- a/src/powershell/en-US/FinOpsToolkit.strings.psd1
+++ b/src/powershell/en-US/FinOpsToolkit.strings.psd1
@@ -11,7 +11,7 @@ ConvertFrom-StringData -StringData @'
     TemplateNotFound = Could not find template 'main.bicep' at path '{0}'.
     ContextNotFound = Could not retrieve Az context. Run Az-Login.
     RegisterProvider =  Registering resource provider {0}.
-    ResourceProviderExists =  Resource provider {0} is already registered. 
+    ResourceProviderRegistered =  Resource provider {0} is already registered. 
     ErrorRegisteringProvider =  Error registering resource provider: {0}.
     DeleteCostExportFailed = Delete Cost Management export operation failed with message: '{0}' (Code: {1}).
     GetCostExportNotFound = Cost Management export not found. Operation failed with message: '{0}' (Code: {1}).


### PR DESCRIPTION
## 🛠️ Description
Added script for Register-FinOpsProvider functionality.

### Context : 
The Register-FinOpsHubProviders command registers the Azure resource providers required to deploy and operate a FinOps hub instance. To register a resource provider, you must have Contributor access (or the /register permission for each resource provider) for the entire subscription. Subscription readers can check the status of the resource providers but cannot register them. If you do not have access to register resource providers, please contact a subscription contributor or owner to run the Register-FinOpsHubProviders command.

Fixes #248 


## 🔬 How has this been tested?
- [x] 🫰 PS -WhatIf / az validate
- [x] 👍 Manually deployed + verified
