### PR TITLE
Don't include main when syncing feature branches

### DIFF
--- a/src/scripts/Merge-DevBranch.ps1
+++ b/src/scripts/Merge-DevBranch.ps1
@@ -55,7 +55,7 @@ if ($Branch -eq "*") {
     $success = @()
     $failure = @()
     $longestBranchName = ($featureBranches | Measure-Object -Maximum -Property Length).Maximum
-    @("main"; $featureBranches) | ForEach-Object {
+    @($featureBranches) | ForEach-Object {
         $branchName = $_
         Write-Host "  $branchName".PadRight($longestBranchName + 5, ".") -NoNewline
         ./Merge-DevBranch $branchName -Silent

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -201,7 +201,8 @@ Examples:
   ./Merge-DevBranch features/foo -TortoiseGit
   ```
 
-- Merge the `dev` branch into main and all feature branches. Does not resolve conflicts.
+- Merge the `dev` branch into all feature branches. Does not resolve conflicts.
+
   ```powershell
   ./Merge-DevBranch *
   ```


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
Don't include `main` when syncing feature branches

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

- [ ] 🤞 PS -WhatIf / az validate
- [x] 👍 Manually deployed + verified
- [ ] 💪 Unit tests

### 🙋‍♀️ Do any of the following that apply?

- [ ] 🚨 This is a breaking change.
- [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

- [ ] ✅ Yes (required for `dev` PRs)
- [ ] ➡️ Will cover in a future PR (feature branch PRs only)
- [x] ❎ Not needed (small/internal change)

### 📖 Did you update documentation?

- [ ] ✅ Public docs in `docs` (required for `dev`)
- [x] ✅ Internal dev docs in `src` (required for `dev`)
- [ ] ➡️ Will cover in a future PR (feature branch PRs only)
- [ ] ❎ Not needed (small/internal change)
