### PR TITLE
Initialize-FinOpsHubDeployment -Feature

### DIFF
--- a/src/powershell/Public/Initialize-FinOpsHubDeployment.ps1
+++ b/src/powershell/Public/Initialize-FinOpsHubDeployment.ps1
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+    .SYNOPSIS
+    Initialize a FinOps hub deployment in order to enable resource group owners to deployment hubs via the portal.
+
+    .PARAMETER WhatIf
+    Optional. Shows what would happen if the command runs without actually running it.
+
+    .EXAMPLE
+    Initialize-FinOpsHubDeployment `
+    [-WhatIf]
+
+    Shows what would happen if the command runs without actually running it.
+
+    .Description
+    The Initialize-FinOpsHubDeployment command performs any initialization tasks required for a resource group contributor to be able to deploy a FinOps hub instance in Azure, like registering resource providers. To view the full list of tasks performed, run the command with the -WhatIf option.
+#>
+
+
+function Initialize-FinOpsHubDeployment {
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
+
+    if ($PSCmdlet.ShouldProcess('Initialization Tasks for FinOpsHub')) {
+        if ($WhatIf) {
+            Write-Output 'WhatIf:'+ $LocalizedData.FinOpsHubInitialization
+        }
+        else {
+            # Register required resource providers
+            Write-Output $LocalizedData.FinOpsHubInitialization
+            Register-FinOpsHubProviders
+        }
+
+        # Other initialization tasks go here
+    }
+}

--- a/src/powershell/Public/Initialize-FinOpsHubDeployment.ps1
+++ b/src/powershell/Public/Initialize-FinOpsHubDeployment.ps1
@@ -9,13 +9,16 @@
     Optional. Shows what would happen if the command runs without actually running it.
 
     .EXAMPLE
-    Initialize-FinOpsHubDeployment `
-    [-WhatIf]
+    Initialize-FinOpsHubDeployment -WhatIf
 
     Shows what would happen if the command runs without actually running it.
 
-    .Description
+    .DESCRIPTION
     The Initialize-FinOpsHubDeployment command performs any initialization tasks required for a resource group contributor to be able to deploy a FinOps hub instance in Azure, like registering resource providers. To view the full list of tasks performed, run the command with the -WhatIf option.
+
+    .LINK
+    https://aka.ms/ftk/Initialize-FinOpsHubDeployment
+
 #>
 
 
@@ -23,16 +26,15 @@ function Initialize-FinOpsHubDeployment {
     [CmdletBinding(SupportsShouldProcess)]
     param()
 
-    if ($PSCmdlet.ShouldProcess('Initialization Tasks for FinOpsHub')) {
+    if ($PSCmdlet.ShouldProcess('Required resource providers', 'Register')) {
         if ($WhatIf) {
-            Write-Output 'WhatIf:'+ $LocalizedData.FinOpsHubInitialization
+            Write-Verbose "Registering required resource providers for FinOps Hub deployment." 
         }
         else {
             # Register required resource providers
             Write-Output $LocalizedData.FinOpsHubInitialization
-            Register-FinOpsHubProviders
+            Register-FinOpsHubProviders -WhatIf:$WhatIfPreference
         }
 
-        # Other initialization tasks go here
     }
 }

--- a/src/powershell/Public/Initialize-FinOpsHubDeployment.ps1
+++ b/src/powershell/Public/Initialize-FinOpsHubDeployment.ps1
@@ -27,14 +27,8 @@ function Initialize-FinOpsHubDeployment {
     param()
 
     if ($PSCmdlet.ShouldProcess('Required resource providers', 'Register')) {
-        if ($WhatIf) {
-            Write-Verbose "Registering required resource providers for FinOps Hub deployment." 
-        }
-        else {
             # Register required resource providers
-            Write-Output $LocalizedData.FinOpsHubInitialization
+            Write-Verbose "Registering required resource providers for FinOps Hub deployment."
             Register-FinOpsHubProviders -WhatIf:$WhatIfPreference
         }
-
-    }
 }

--- a/src/powershell/Public/Initialize-FinOpsHubDeployment.ps1
+++ b/src/powershell/Public/Initialize-FinOpsHubDeployment.ps1
@@ -29,6 +29,6 @@ function Initialize-FinOpsHubDeployment {
     if ($PSCmdlet.ShouldProcess('Required resource providers', 'Register')) {
             # Register required resource providers
             Write-Verbose "Registering required resource providers for FinOps Hub deployment."
-            Register-FinOpsHubProviders -WhatIf:$WhatIfPreference
+            Register-FinOpsHubProviders -WhatIf:$WhatIfPreference -Verbose:$VerbosePreference
         }
 }

--- a/src/powershell/Public/Initialize-FinOpsHubDeployment.ps1
+++ b/src/powershell/Public/Initialize-FinOpsHubDeployment.ps1
@@ -5,9 +5,6 @@
     .SYNOPSIS
     Initialize a FinOps hub deployment in order to enable resource group owners to deployment hubs via the portal.
 
-    .PARAMETER WhatIf
-    Optional. Shows what would happen if the command runs without actually running it.
-
     .EXAMPLE
     Initialize-FinOpsHubDeployment -WhatIf
 
@@ -29,6 +26,6 @@ function Initialize-FinOpsHubDeployment {
     if ($PSCmdlet.ShouldProcess('Required resource providers', 'Register')) {
             # Register required resource providers
             Write-Verbose "Registering required resource providers for FinOps Hub deployment."
-            Register-FinOpsHubProviders -WhatIf:$WhatIfPreference -Verbose:$VerbosePreference
+            Register-FinOpsHubProviders 
         }
 }

--- a/src/powershell/en-US/FinOpsToolkit.strings.psd1
+++ b/src/powershell/en-US/FinOpsToolkit.strings.psd1
@@ -19,4 +19,5 @@ ConvertFrom-StringData -StringData @'
     DeleteFinOpsHub = FinOps hub could not be deleted. {0}.
     ErrorResponse = {0} (Code: {1}).
     FinOpsHubNotFound = FinOps hub '{0}' not found.
+    FinOpsHubInitialization = Initializing FinOps pre-deployment tasks.
 '@

--- a/src/powershell/en-US/FinOpsToolkit.strings.psd1
+++ b/src/powershell/en-US/FinOpsToolkit.strings.psd1
@@ -19,5 +19,4 @@ ConvertFrom-StringData -StringData @'
     DeleteFinOpsHub = FinOps hub could not be deleted. {0}.
     ErrorResponse = {0} (Code: {1}).
     FinOpsHubNotFound = FinOps hub '{0}' not found.
-    FinOpsHubInitialization = Initializing FinOps pre-deployment tasks.
 '@


### PR DESCRIPTION
## 🛠️ Description
The Initialize-FinOpsHubDeployment command performs any initialization tasks required for a resource group contributor to be able to deploy a FinOps hub instance in Azure, like registering resource providers. To view the full list of tasks performed, run the command with the -WhatIf option.

Fixes #247  


### 🔬 How did you test this change?

> - [x] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Yes (required for `dev` PRs)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)
