### PR TITLE
Added Initilization to Deploy-FinOpsHub before Download

### DIFF
--- a/src/powershell/Public/Deploy-FinOpsHub.ps1
+++ b/src/powershell/Public/Deploy-FinOpsHub.ps1
@@ -88,6 +88,10 @@ function Deploy-FinOpsHub
         {
             New-Directory -Path $toolkitPath
         }
+        if($PSCmdlet.ShouldProcess('FinOps Toolkit Init','Initialization'))
+        {
+            Initialize-FinOpsToolkit 
+        }
 
         if ($PSCmdlet.ShouldProcess($Version, 'DownloadTemplate'))
         {

--- a/src/powershell/Public/Deploy-FinOpsHub.ps1
+++ b/src/powershell/Public/Deploy-FinOpsHub.ps1
@@ -88,7 +88,7 @@ function Deploy-FinOpsHub
         {
             New-Directory -Path $toolkitPath
         }
-        if($PSCmdlet.ShouldProcess('FinOps Toolkit Init','Initialization'))
+        if($PSCmdlet.ShouldProcess('FinOps hub deployment','Initialize'))
         {
             Initialize-FinOpsToolkit 
         }


### PR DESCRIPTION


## 🛠️ Description
The Deploy-FinOpsHub command creates a new FinOps hub instance. The FinOps hub template is downloaded from GitHub.

FinOps hubs has certain prerequisites that must be met before the template can be deployed. The Deploy-FinOpsHub command will internally call Initialize-FinOpsHubDeployment to validate and apply these requirements. Initialization must be done by a subscription contributor due to resource provider registration. Resource group contributors can execute the Deploy-FinOpsHub command but it will fail if these requirements are not met.


Fixes #145 

### 🔬 How did you test this change?

> - [x] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Yes (required for `dev` PRs)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [ ] ❎ Not needed (small/internal change)
