### PR TITLE
Remove-FinOpsHubScope

### DIFF
--- a/src/powershell/Public/Deploy-FinOpsHub.ps1
+++ b/src/powershell/Public/Deploy-FinOpsHub.ps1
@@ -98,7 +98,7 @@ function Deploy-FinOpsHub
         }
         if($PSCmdlet.ShouldProcess('FinOps hub deployment','Initialize'))
         {
-            Initialize-FinOpsToolkit 
+            Initialize-FinOpsHubDeployment
         }
 
         if ($PSCmdlet.ShouldProcess($Version, 'DownloadTemplate'))

--- a/src/powershell/Public/Remove-FinOpsHubScope.ps1
+++ b/src/powershell/Public/Remove-FinOpsHubScope.ps1
@@ -44,30 +44,29 @@ function Remove-FinOpsHubScope {
         
 
         $hub = Get-FinOpsHub -Name $HubName
-        $storageAccountId = $hub.StorageAccountId
+        $storageAccount = $hub.Resources | Where-Object { $_.Type.ToLower() -eq 'microsoft.storage/storageaccounts' }
+        $storageAccountId = $storageAccount.ResourceId
 
-        #Get all exports for the scope that are pointed to the included storage account and the msexports container
-        $exports = Get-FinOpsCostExport -Scope $Id | Where-Object { $_.StorageAccountId -eq $storageAccountId } 
+        $exports = Get-FinOpsCostExport -Scope $Id | Where-Object { $storageAccountId -contains $_.StorageAccountId }
 
         # Delete the exports
         foreach ($export in $exports) 
         {
-            if($PSCmdlet.ShouldProcess("Cost Management Export","Delete"))
+            if($PSCmdlet.ShouldProcess("$($export.Name) export","Delete"))
             {
-                Write-Verbose -Message "Deleting Cost Management export $($export.Name) from storage account $($export.StorageAccountId.Split("/")[-1])."
+                Write-Verbose -Message "Deleting Cost Management export $($export.Name) from storage account $($storageAccount.Name)."
                 Remove-FinOpsCostExport -Scope $Id -Name $export.Name -RemoveData:$RemoveData
                 Write-Verbose -Message "Complete: Deleted Cost Management export $($export.Name) from storage account $($export.StorageAccountId.Split("/")[-1])."
             }
+        }
 
-            # Delete the data if requested
-            if ($RemoveData) 
-            {
-                # This can use the standard storage Az commands
-                if($PSCmdlet.ShouldProcess("Cost Management Export Data","Delete"))
-                {
-                    
+        # Delete the data if requested
+        if ($RemoveData) {
+            foreach ($export in $exports) {
+                if ($PSCmdlet.ShouldProcess("Cost Management Export Data","Delete")) {
                     $storageAccountName = $export.StorageAccountId.Split("/")[-1]
-                    $storageAccountKey = (Get-AzStorageAccountKey -ResourceGroupName (Get-AzResource -ResourceId $export.StorageAccountId).ResourceGroupName -Name $storageAccountName).Value[0]
+                    $resourceGroup = (Get-AzResource -ResourceType "Microsoft.Storage/storageAccounts" -Name $storageAccountName).ResourceGroupName
+                    $storageAccountKey = (Get-AzStorageAccountKey -ResourceGroupName $resourceGroup -Name $storageAccountName).Value[0]
                     $context = New-AzStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageAccountKey
                     Write-Verbose -Message "Deleting data for Cost Management export $($export.Name) in storage account $($export.StorageAccountId.Split("/")[-1]) at path $($export.StoragePath)."
                     Remove-AzDataLakeGen2Item -FileSystem "ingestion" -Path $export.StoragePath -Context $context -Force

--- a/src/powershell/Public/Remove-FinOpsHubScope.ps1
+++ b/src/powershell/Public/Remove-FinOpsHubScope.ps1
@@ -16,9 +16,12 @@
 
     .EXAMPLE
     Remove-FinOpsHubScope -Id "/providers/Microsoft.Billing/billingAccounts/123" -HubName "FooHub" 
+
     Deletes the exports configured to use the FooHub hub instance. Existing data is retained in the storage account.
     
+    .EXAMPLE
     Remove-FinOpsHubScope -Id "/subscriptions/##-#-#-#-###" -HubName "FooHub" -RemoveData
+    
     Deletes the exports configured to use the FooHub hub instance and removes data for that scope.
     
     .LINK

--- a/src/powershell/Public/Remove-FinOpsHubScope.ps1
+++ b/src/powershell/Public/Remove-FinOpsHubScope.ps1
@@ -1,0 +1,82 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+    .SYNOPSIS
+    Delete a Cost Management export and optionally data associated with the export.
+
+    .PARAMETER Id
+    Required resource ID of the scope to remove.
+
+    .PARAMETER HubName
+    Optional. Name of the hub instance to update.
+
+    .PARAMETER RemoveData
+    Optional. Indicates whether to remove data for this scope from storage. Default = false
+
+    .EXAMPLE
+    Remove-FinOpsHubScope -Id "/providers/Microsoft.Billing/billingAccounts/123" -HubName "FooHub" 
+    Deletes the exports configured to use the FooHub hub instance. Existing data is retained in the storage account.
+    
+    Remove-FinOpsHubScope -Id "/subscriptions/##-#-#-#-###" -HubName "FooHub" -RemoveData
+    Deletes the exports configured to use the FooHub hub instance and removes data for that scope.
+    
+    .LINK
+    https://aka.ms/ftk/Remove-FinOpsHubScope
+#>
+
+
+function Remove-FinOpsHubScope {
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Id,
+        [Parameter()]
+        [string]
+        $HubName,
+        [Parameter()]
+        [switch]
+        $RemoveData
+    )
+
+    try {
+        
+
+        $hub = Get-FinOpsHub -Name $HubName
+        $storageAccountId = $hub.StorageAccountId
+
+        #Get all exports for the scope that are pointed to the included storage account and the msexports container
+        $exports = Get-FinOpsCostExport -Scope $Id | Where-Object { $_.StorageAccountId -eq $storageAccountId } 
+
+        # Delete the exports
+        foreach ($export in $exports) 
+        {
+            if($PSCmdlet.ShouldProcess("Cost Management Export","Delete"))
+            {
+                Write-Verbose -Message "Deleting Cost Management export $($export.Name) from storage account $($export.StorageAccountId.Split("/")[-1])."
+                Remove-FinOpsCostExport -Scope $Id -Name $export.Name -RemoveData:$RemoveData
+                Write-Verbose -Message "Complete: Deleted Cost Management export $($export.Name) from storage account $($export.StorageAccountId.Split("/")[-1])."
+            }
+
+            # Delete the data if requested
+            if ($RemoveData) 
+            {
+                # This can use the standard storage Az commands
+                if($PSCmdlet.ShouldProcess("Cost Management Export Data","Delete"))
+                {
+                    
+                    $storageAccountName = $export.StorageAccountId.Split("/")[-1]
+                    $storageAccountKey = (Get-AzStorageAccountKey -ResourceGroupName (Get-AzResource -ResourceId $export.StorageAccountId).ResourceGroupName -Name $storageAccountName).Value[0]
+                    $context = New-AzStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageAccountKey
+                    Write-Verbose -Message "Deleting data for Cost Management export $($export.Name) in storage account $($export.StorageAccountId.Split("/")[-1]) at path $($export.StoragePath)."
+                    Remove-AzDataLakeGen2Item -FileSystem "ingestion" -Path $export.StoragePath -Context $context -Force
+                    Write-Verbose -Message "Complete: Deleted data for Cost Management export $($export.Name) in storage account $($export.StorageAccountId.Split("/")[-1]) at path $($export.StoragePath)."          
+                }
+            }
+        }
+    }
+    catch {
+        throw $_.Exception.Message
+    }
+}


### PR DESCRIPTION


## 🛠️ Description
The Remove-FinOpsHubScope command removes a scope from being monitored by a FinOps hub instance. Data related to that scope is kept by default. To remove the data, use the -RemoveData option.

Fixes #235 


### 🔬 How did you test this change?

> - [x] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [ ] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Yes (required for `dev` PRs)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)
