### PR TITLE
Split-AzureResourceId

### DIFF
--- a/src/powershell/Private/Split-AzureResourceId.ps1
+++ b/src/powershell/Private/Split-AzureResourceId.ps1
@@ -3,10 +3,24 @@
 
 <#
     .SYNOPSIS
-    Returns the specified part of an Azure resource ID.
+    Parses an Azure resource ID and returns an object that includes resource details.
 
     .PARAMETER Id
     Azure resource ID to parse.
+
+    .DESCRIPTION
+    The Split-AzureResourceId command parses an Azure resource ID and returns an object with properties based on what is parseable from the resource ID string.
+    This command does not call any APIs and does not validate the resource exists.
+
+    Split-AzureResourceId will fix invalid resource IDs in the following cases:
+    - Adds a leading slash, if missing.
+    - Removes a trailing slash, if present.
+    - Removes the last segment if the resource ID has an odd number of segments.
+
+    .EXAMPLE
+    Split-AzureResourceId -Id '/subscriptions/##-#-#-#-###/resourceGroups/foo/providers/Microsoft.Bar/bazes/baz1'
+
+    Parses the resource ID and returns an object with resource details.
 #>
 function Split-AzureResourceId {
     [CmdletBinding()]

--- a/src/powershell/Private/Split-AzureResourceId.ps1
+++ b/src/powershell/Private/Split-AzureResourceId.ps1
@@ -26,13 +26,19 @@ function Split-AzureResourceId {
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true, Position = 0)]
+        [AllowNull]
+        [AllowEmptyString]
+        [Parameter(Mandatory = $true)]
         [string]
         $Id
     )
 
     if ($Id) {
-        Write-Verbose "Parsing resource ID: $Id"
+        Write-Verbose "Parsing resource ID: '$Id'"
+
+        if (-not $Id) {
+            return @{ ResourceId = $null }
+        }
 
         # Add leading slash
         if (-not $Id.StartsWith('/')) {

--- a/src/powershell/Private/Split-AzureResourceId.ps1
+++ b/src/powershell/Private/Split-AzureResourceId.ps1
@@ -60,7 +60,7 @@ function Split-AzureResourceId {
         $isTenant = $parts[1].ToLower() -eq 'tenants'
 
         Write-Verbose "Root? $isRoot"
-        Write-Verbose "Subscription? $isSubResource"
+        Write-Verbose "Subscription resource? $isSubResource"
         Write-Verbose "Resource group resource? $isRGResource"
         Write-Verbose "Resource group? $isRG"
         Write-Verbose "Tenant resource? $isTenantResource"
@@ -89,7 +89,7 @@ function Split-AzureResourceId {
             ResourceGroupId        = if ($isRGResource) { $parts[0..4] -Join '/' } else { $null }
             ResourceGroupName      = if ($isRGResource) { $parts[4] } else { $null }
             Provider               = $leafParts[0]
-            ResourceType           = @($leafParts[0]) + $leafParts[(1..($leafParts.Count - 1)).Where{ $_ % 2 -eq 1 }] -join '/'
+            Type                   = @($leafParts[0]) + $leafParts[(1..($leafParts.Count - 1)).Where{ $_ % 2 -eq 1 }] -join '/'
             Name                   = if ($isRG) { $leafParts[-1] } else { @($leafParts[(2..($leafParts.Count - 1)).Where{ $_ % 2 -eq 0 }]) -join '/' }
         }
     }

--- a/src/powershell/Private/Split-AzureResourceId.ps1
+++ b/src/powershell/Private/Split-AzureResourceId.ps1
@@ -1,0 +1,82 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+    .SYNOPSIS
+    Returns the specified part of an Azure resource ID.
+
+    .PARAMETER Id
+    Azure resource ID to parse.
+#>
+function Split-AzureResourceId {
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string]
+        $Id
+    )
+
+    if ($Id) {
+        Write-Verbose "Parsing resource ID: $Id"
+
+        # Add leading slash
+        if (-not $Id.StartsWith('/')) {
+            $Id = "/$Id"
+        }
+
+        # Remove trailing slash
+        $parts = $Id.TrimEnd('/').Split('/')
+        
+        # Check for odd number of segments
+        if ($parts.Count % 2 -eq 0) {
+            Write-Verbose "Resource ID has odd number of segments and is invalid: $Id"
+            $Id = ($parts[0..($parts.Count - 2)] -join '/')
+            Write-Verbose "  Parsing trimmed resource ID: $Id"
+            return Split-AzureResourceId -Id $Id
+        }
+
+        # Check basic format
+        $isRoot = $Id -eq '/'
+        $isSubResource = -not $isRoot -and $parts[1].ToLower() -eq 'subscriptions'
+        $isRGResource = $isSubResource -and $parts.Count -gt 3 -and $parts[3].ToLower() -eq 'resourcegroups'
+        $isRG = $isRGResource -and $parts.Count -eq 5
+        $isTenantResource = $parts[1].ToLower() -eq 'providers'
+        $isProvider = $isTenantResource -and $parts.Count -eq 3
+        $isTenant = $parts[1].ToLower() -eq 'tenants'
+
+        Write-Verbose "Root? $isRoot"
+        Write-Verbose "Subscription? $isSubResource"
+        Write-Verbose "Resource group resource? $isRGResource"
+        Write-Verbose "Resource group? $isRG"
+        Write-Verbose "Tenant resource? $isTenantResource"
+        Write-Verbose "Provider? $isProvider"
+        Write-Verbose "Tenant? $isTenant"
+
+        # Add implicit Microsoft.Resources RP before we check the resource details
+        if ($isProvider) {
+            # -or $isTenant
+            # Prepend implicit RP name
+            $leafParts = @('Microsoft.Resources') + $parts[1..($parts.Count - 1)]
+        } else {
+            # Prepend implicit RP name
+            $leafParts = @($parts[0], 'providers', 'Microsoft.Resources') + $parts[1..($parts.Count - 1)]
+
+            # Find last providers segment
+            $leafParts = (($leafParts -replace '/PROVIDERS/', '/providers/') -Join '/').Split('/providers/')[-1].Split('/')        
+        }
+
+        Write-Verbose "Leaf resource: $($leafParts -Join '/')"
+ 
+        return @{
+            ResourceId             = $Id
+            SubscriptionId         = if ($isSubResource) { $parts[2] } else { $null }
+            SubscriptionResourceId = if ($isSubResource) { $parts[0..2] -Join '/' } else { $null }
+            ResourceGroupId        = if ($isRGResource) { $parts[0..4] -Join '/' } else { $null }
+            ResourceGroupName      = if ($isRGResource) { $parts[4] } else { $null }
+            Provider               = $leafParts[0]
+            ResourceType           = @($leafParts[0]) + $leafParts[(1..($leafParts.Count - 1)).Where{ $_ % 2 -eq 1 }] -join '/'
+            Name                   = if ($isRG) { $leafParts[-1] } else { @($leafParts[(2..($leafParts.Count - 1)).Where{ $_ % 2 -eq 0 }]) -join '/' }
+        }
+    }
+}

--- a/src/powershell/Tests/Unit/Split-AzureResourceId.Tests.ps1
+++ b/src/powershell/Tests/Unit/Split-AzureResourceId.Tests.ps1
@@ -129,4 +129,30 @@ Describe 'Split-AzureResourceId' {
         $result.Type | Should -Be "$rp/$type1/$type2"
         $result.ResourceId | Should -Be ($id.Split('/')[0..($id.Split('/').Count - 2)] -Join '/')
     }
+
+    It 'Should handle empty resource ID' {
+        $id = ""
+        $result = Split-AzureResourceId -Id $id
+        $result.SubscriptionId | Should -Be $null
+        $result.SubscriptionResourceId | Should -Be $null
+        $result.ResourceGroupId | Should -Be $null
+        $result.ResourceGroupName | Should -Be $null
+        $result.Provider | Should -Be $null
+        $result.Name | Should -Be $null
+        $result.Type | Should -Be $null
+        $result.ResourceId | Should -Be $null
+    }
+
+    It 'Should handle null resource ID' {
+        $id = $null
+        $result = Split-AzureResourceId -Id $id
+        $result.SubscriptionId | Should -Be $null
+        $result.SubscriptionResourceId | Should -Be $null
+        $result.ResourceGroupId | Should -Be $null
+        $result.ResourceGroupName | Should -Be $null
+        $result.Provider | Should -Be $null
+        $result.Name | Should -Be $null
+        $result.Type | Should -Be $null
+        $result.ResourceId | Should -Be $null
+    }
 }

--- a/src/powershell/Tests/Unit/Split-AzureResourceId.Tests.ps1
+++ b/src/powershell/Tests/Unit/Split-AzureResourceId.Tests.ps1
@@ -1,0 +1,132 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Load the function into the current context
+. "$PSScriptRoot/../../Private/Split-AzureResourceId.ps1"
+
+$subId = (New-Guid).Guid
+$rg = 'testRg'
+$rp = 'Microsoft.Cloud'
+$type1 = 'hubs'
+$name1 = 'hub1'
+$type2 = 'scopes'
+$name2 = 'scope2'
+
+Describe 'Split-AzureResourceId' {
+    It 'Should parse tenant' {
+        $id = "/tenants/$subId"
+        $result = Split-AzureResourceId -Id $id
+        $result.SubscriptionId | Should -Be $null
+        $result.SubscriptionResourceId | Should -Be $null
+        $result.ResourceGroupId | Should -Be $null
+        $result.ResourceGroupName | Should -Be $null
+        $result.Provider | Should -Be 'Microsoft.Resources'
+        $result.Name | Should -Be $subId
+        $result.ResourceId | Should -Be $id
+        $result.ResourceType | Should -Be "Microsoft.Resources/tenants"
+    }
+
+    It 'Should parse tenant resource' {
+        $id = "/providers/$rp/$type1/$name1"
+        $result = Split-AzureResourceId -Id $id
+        $result.SubscriptionId | Should -Be $null
+        $result.SubscriptionResourceId | Should -Be $null
+        $result.ResourceGroupId | Should -Be $null
+        $result.ResourceGroupName | Should -Be $null
+        $result.Provider | Should -Be $rp
+        $result.Name | Should -Be $name1
+        $result.ResourceId | Should -Be $id
+        $result.ResourceType | Should -Be "$rp/$type1"
+    }
+
+    It 'Should parse tenant nested resource' {
+        $id = "/providers/$rp/$type1/$name1/$type2/$name2"
+        $result = Split-AzureResourceId -Id $id
+        $result.SubscriptionId | Should -Be $null
+        $result.SubscriptionResourceId | Should -Be $null
+        $result.ResourceGroupId | Should -Be $null
+        $result.ResourceGroupName | Should -Be $null
+        $result.Provider | Should -Be $rp
+        $result.Name | Should -Be "$name1/$name2"
+        $result.ResourceId | Should -Be $id
+        $result.ResourceType | Should -Be "$rp/$type1/$type2"
+    }
+
+    It 'Should parse subscription' {
+        $id = "/subscriptions/$subId"
+        $result = Split-AzureResourceId -Id $id
+        $result.SubscriptionId | Should -Be $subId
+        $result.SubscriptionResourceId | Should -Be "/subscriptions/$subId"
+        $result.ResourceGroupId | Should -Be $null
+        $result.ResourceGroupName | Should -Be $null
+        $result.Provider | Should -Be 'Microsoft.Resources'
+        $result.Name | Should -Be $subId
+        $result.ResourceId | Should -Be $id
+        $result.ResourceType | Should -Be "Microsoft.Resources/subscriptions"
+    }
+
+    It 'Should parse subscription resource' {
+        $id = "/subscriptions/$subId/providers/$rp/$type1/$name1"
+        $result = Split-AzureResourceId -Id $id
+        $result.SubscriptionId | Should -Be $subId
+        $result.SubscriptionResourceId | Should -Be "/subscriptions/$subId"
+        $result.ResourceGroupId | Should -Be $null
+        $result.ResourceGroupName | Should -Be $null
+        $result.Provider | Should -Be $rp
+        $result.Name | Should -Be $name1
+        $result.ResourceId | Should -Be $id
+        $result.ResourceType | Should -Be "$rp/$type1"
+    }
+
+    It 'Should parse resource group' {
+        $id = "/subscriptions/$subId/resourceGroups/$rg"
+        $result = Split-AzureResourceId -Id $id
+        $result.SubscriptionId | Should -Be $subId
+        $result.SubscriptionResourceId | Should -Be "/subscriptions/$subId"
+        $result.ResourceGroupId | Should -Be $id.Substring(0, $id.IndexOf("/resourceGroups/$rg") + "/resourceGroups/$rg".Length)
+        $result.ResourceGroupName | Should -Be $rg
+        $result.Provider | Should -Be 'Microsoft.Resources'
+        $result.Name | Should -Be $rg
+        $result.ResourceId | Should -Be $id
+        $result.ResourceType | Should -Be "Microsoft.Resources/subscriptions/resourceGroups"
+    }
+
+    It 'Should parse resource group resource' {
+        $id = "/subscriptions/$subId/resourceGroups/$rg/providers/$rp/$type1/$name1"
+        $result = Split-AzureResourceId -Id $id
+        $result.SubscriptionId | Should -Be $subId
+        $result.SubscriptionResourceId | Should -Be "/subscriptions/$subId"
+        $result.ResourceGroupId | Should -Be $id.Substring(0, $id.IndexOf("/resourceGroups/$rg") + "/resourceGroups/$rg".Length)
+        $result.ResourceGroupName | Should -Be $rg
+        $result.Provider | Should -Be $rp
+        $result.Name | Should -Be $name1
+        $result.ResourceId | Should -Be $id
+        $result.ResourceType | Should -Be "$rp/$type1"
+    }
+
+    It 'Should parse nested resource group resource' {
+        $id = "/subscriptions/$subId/resourceGroups/$rg/providers/$rp/$type1/$name1/$type2/$name2"
+        $result = Split-AzureResourceId -Id $id
+        $result.SubscriptionId | Should -Be $subId
+        $result.SubscriptionResourceId | Should -Be "/subscriptions/$subId"
+        $result.ResourceGroupId | Should -Be $id.Substring(0, $id.IndexOf("/resourceGroups/$rg") + "/resourceGroups/$rg".Length)
+        $result.ResourceGroupName | Should -Be $rg
+        $result.Provider | Should -Be $rp
+        $result.Name | Should -Be "$name1/$name2"
+        $result.ResourceId | Should -Be $id
+        $result.ResourceType | Should -Be "$rp/$type1/$type2"
+    }
+
+    It 'Should parse and fix invalid resource ID' {
+        $id = "/subscriptions/$subId/resourceGroups/$rg/providers/$rp/$type1/$name1/$type2/$name2/INVALID"
+        $result = Split-AzureResourceId -Id $id
+        $result.SubscriptionId | Should -Be $subId
+        $result.SubscriptionResourceId | Should -Be "/subscriptions/$subId"
+        $result.ResourceGroupId | Should -Be $id.Substring(0, $id.IndexOf("/resourceGroups/$rg") + "/resourceGroups/$rg".Length)
+        $result.ResourceGroupName | Should -Be $rg
+        $result.Provider | Should -Be $rp
+        $result.Name | Should -Be "$name1/$name2"
+        $result.ResourceId | Should -Be ($id.Split('/')[0..($id.Split('/').Count - 2)] -Join '/')
+        $result.ResourceType | Should -Be "$rp/$type1/$type2"
+    }
+}

--- a/src/powershell/Tests/Unit/Split-AzureResourceId.Tests.ps1
+++ b/src/powershell/Tests/Unit/Split-AzureResourceId.Tests.ps1
@@ -22,8 +22,8 @@ Describe 'Split-AzureResourceId' {
         $result.ResourceGroupName | Should -Be $null
         $result.Provider | Should -Be 'Microsoft.Resources'
         $result.Name | Should -Be $subId
+        $result.Type | Should -Be "Microsoft.Resources/tenants"
         $result.ResourceId | Should -Be $id
-        $result.ResourceType | Should -Be "Microsoft.Resources/tenants"
     }
 
     It 'Should parse tenant resource' {
@@ -35,8 +35,8 @@ Describe 'Split-AzureResourceId' {
         $result.ResourceGroupName | Should -Be $null
         $result.Provider | Should -Be $rp
         $result.Name | Should -Be $name1
+        $result.Type | Should -Be "$rp/$type1"
         $result.ResourceId | Should -Be $id
-        $result.ResourceType | Should -Be "$rp/$type1"
     }
 
     It 'Should parse tenant nested resource' {
@@ -48,8 +48,8 @@ Describe 'Split-AzureResourceId' {
         $result.ResourceGroupName | Should -Be $null
         $result.Provider | Should -Be $rp
         $result.Name | Should -Be "$name1/$name2"
+        $result.Type | Should -Be "$rp/$type1/$type2"
         $result.ResourceId | Should -Be $id
-        $result.ResourceType | Should -Be "$rp/$type1/$type2"
     }
 
     It 'Should parse subscription' {
@@ -61,8 +61,8 @@ Describe 'Split-AzureResourceId' {
         $result.ResourceGroupName | Should -Be $null
         $result.Provider | Should -Be 'Microsoft.Resources'
         $result.Name | Should -Be $subId
+        $result.Type | Should -Be "Microsoft.Resources/subscriptions"
         $result.ResourceId | Should -Be $id
-        $result.ResourceType | Should -Be "Microsoft.Resources/subscriptions"
     }
 
     It 'Should parse subscription resource' {
@@ -74,8 +74,8 @@ Describe 'Split-AzureResourceId' {
         $result.ResourceGroupName | Should -Be $null
         $result.Provider | Should -Be $rp
         $result.Name | Should -Be $name1
+        $result.Type | Should -Be "$rp/$type1"
         $result.ResourceId | Should -Be $id
-        $result.ResourceType | Should -Be "$rp/$type1"
     }
 
     It 'Should parse resource group' {
@@ -87,8 +87,8 @@ Describe 'Split-AzureResourceId' {
         $result.ResourceGroupName | Should -Be $rg
         $result.Provider | Should -Be 'Microsoft.Resources'
         $result.Name | Should -Be $rg
+        $result.Type | Should -Be "Microsoft.Resources/subscriptions/resourceGroups"
         $result.ResourceId | Should -Be $id
-        $result.ResourceType | Should -Be "Microsoft.Resources/subscriptions/resourceGroups"
     }
 
     It 'Should parse resource group resource' {
@@ -100,8 +100,8 @@ Describe 'Split-AzureResourceId' {
         $result.ResourceGroupName | Should -Be $rg
         $result.Provider | Should -Be $rp
         $result.Name | Should -Be $name1
+        $result.Type | Should -Be "$rp/$type1"
         $result.ResourceId | Should -Be $id
-        $result.ResourceType | Should -Be "$rp/$type1"
     }
 
     It 'Should parse nested resource group resource' {
@@ -113,8 +113,8 @@ Describe 'Split-AzureResourceId' {
         $result.ResourceGroupName | Should -Be $rg
         $result.Provider | Should -Be $rp
         $result.Name | Should -Be "$name1/$name2"
+        $result.Type | Should -Be "$rp/$type1/$type2"
         $result.ResourceId | Should -Be $id
-        $result.ResourceType | Should -Be "$rp/$type1/$type2"
     }
 
     It 'Should parse and fix invalid resource ID' {
@@ -126,7 +126,7 @@ Describe 'Split-AzureResourceId' {
         $result.ResourceGroupName | Should -Be $rg
         $result.Provider | Should -Be $rp
         $result.Name | Should -Be "$name1/$name2"
+        $result.Type | Should -Be "$rp/$type1/$type2"
         $result.ResourceId | Should -Be ($id.Split('/')[0..($id.Split('/').Count - 2)] -Join '/')
-        $result.ResourceType | Should -Be "$rp/$type1/$type2"
     }
 }


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
Adds a `Split-AzureResourceId` command that parses an Azure resource ID to extract resource details. This will be used for parsing resource names and types for the `ConvertTo-FinOpsSchema` command.

## 📷 Screenshots
![Screenshot of passing tests and example output](https://github.com/microsoft/finops-toolkit/assets/399533/0b078b2d-858c-4618-a840-1d9e2fae32e7)

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [x] 💪 Unit tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [ ] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Yes (required for `dev` PRs)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)
