### PR TITLE
Reduce workbook parsing in Build-Workbook

### DIFF
--- a/.github/policies/pulls-00-file-paths.yml
+++ b/.github/policies/pulls-00-file-paths.yml
@@ -257,6 +257,8 @@ configuration:
                   - filesMatchPattern:
                       pattern: ^docs\/[^-]+-workbook\/.*
                   - filesMatchPattern:
+                      pattern: ^src\/scripts\/Build-Workbook.ps1$
+                  - filesMatchPattern:
                       pattern: ^src\/workbooks\/.*
             then:
               - addLabel:
@@ -266,6 +268,8 @@ configuration:
                   - or:
                       - filesMatchPattern:
                           pattern: ^docs\/optimization-workbook\/.*
+                      - filesMatchPattern:
+                          pattern: ^src\/scripts\/Build-Workbook.ps1$
                       - filesMatchPattern:
                           pattern: ^src\/workbooks\/(\.scaffold|optimization)\/.*
                   - not:
@@ -282,6 +286,8 @@ configuration:
                       - filesMatchPattern:
                           pattern: ^docs\/governance-workbook\/.*
                       - filesMatchPattern:
+                          pattern: ^src\/scripts\/Build-Workbook.ps1$
+                      - filesMatchPattern:
                           pattern: ^src\/workbooks\/(\.scaffold|governance)\/.*
                   - not:
                       isActivitySender:
@@ -296,6 +302,8 @@ configuration:
                   - or:
                       - filesMatchPattern:
                           pattern: ^docs\/optimization-workbook\/.*
+                      - filesMatchPattern:
+                          pattern: ^src\/scripts\/Build-Workbook.ps1$
                       - filesMatchPattern:
                           pattern: ^src\/workbooks\/(\.scaffold|optimization)\/.*
                   - not:


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
Moved the nested template ingestion to be done after the workbook is read for template generation so we don't have to parse it twice. (Slows down the build script.)

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [ ] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Yes (required for `dev` PRs)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)
