### PR TITLE
Rename open data commands to distinguish from public commands

### DIFF
--- a/src/powershell/Private/Get-OpenDataPricingUnits.ps1
+++ b/src/powershell/Private/Get-OpenDataPricingUnits.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-function Get-FinOpsPricingUnitsData {
+function Get-OpenDataPricingUnits {
     return [PSCustomObject]@(
         [PSCustomObject]@{ UnitOfMeasure = '1'; AccountTypes = 'MCA, EA'; PricingBlockSize = 1; DistinctUnits = 'Units'; }
         ,[PSCustomObject]@{ UnitOfMeasure = '1 '; AccountTypes = 'EA'; PricingBlockSize = 1; DistinctUnits = 'Units'; }

--- a/src/powershell/Private/Get-OpenDataRegions.ps1
+++ b/src/powershell/Private/Get-OpenDataRegions.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-function Get-FinOpsRegionsData {
+function Get-OpenDataRegions {
     return [PSCustomObject]@(
         [PSCustomObject]@{ OriginalValue = 'AE Central'; RegionId = 'uaecentral'; RegionName = 'UAE Central'; }
         ,[PSCustomObject]@{ OriginalValue = 'AE North'; RegionId = 'uaenorth'; RegionName = 'UAE North'; }

--- a/src/powershell/Private/Get-OpenDataServices.ps1
+++ b/src/powershell/Private/Get-OpenDataServices.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-function Get-FinOpsServicesData {
+function Get-OpenDataServices {
     return [PSCustomObject]@(
         [PSCustomObject]@{ ConsumedService = 'Citrix.Services'; ResourceType = 'citrix.services/xenappessentials'; ServiceName = 'Citrix Virtual App Essentials'; ServiceCategory = 'Compute'; PublisherName = 'Citrix'; PublisherType = 'Marketplace'; }
         ,[PSCustomObject]@{ ConsumedService = 'Citrix.Services'; ResourceType = 'citrix.services/xendesktopessentials'; ServiceName = 'Citrix Virtual Desktop Essentials'; ServiceCategory = 'Compute'; PublisherName = 'Citrix'; PublisherType = 'Marketplace'; }

--- a/src/powershell/Tests/Unit/Get-OpenDataPricingUnits.Tests.ps1
+++ b/src/powershell/Tests/Unit/Get-OpenDataPricingUnits.Tests.ps1
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Describe 'Get-FinOpsPricingUnitsData' {
+Describe 'Get-OpenDataPricingUnits' {
     It 'Should return same rows as the CSV file' {
         # Arrange
-        . "$PSScriptRoot/../../Private/Get-FinOpsPricingUnitsData.ps1"
+        . "$PSScriptRoot/../../Private/Get-OpenDataPricingUnits.ps1"
         $csv = Import-Csv "$PSScriptRoot/../../../open-data/PricingUnits.csv"
 
         # Act
-        $cmd = Get-FinOpsPricingUnitsData
+        $cmd = Get-OpenDataPricingUnits
 
         # Assert
         $cmd.Count | Should -Be $csv.Count

--- a/src/powershell/Tests/Unit/Get-OpenDataRegions.Tests.ps1
+++ b/src/powershell/Tests/Unit/Get-OpenDataRegions.Tests.ps1
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Describe 'Get-FinOpsRegionsData' {
+Describe 'Get-OpenDataRegions' {
     It 'Should return same rows as the CSV file' {
         # Arrange
-        . "$PSScriptRoot/../../Private/Get-FinOpsRegionsData.ps1"
+        . "$PSScriptRoot/../../Private/Get-OpenDataRegions.ps1"
         $csv = Import-Csv "$PSScriptRoot/../../../open-data/Regions.csv"
 
         # Act
-        $cmd = Get-FinOpsRegionsData
+        $cmd = Get-OpenDataRegions
 
         # Assert
         $cmd.Count | Should -Be $csv.Count

--- a/src/powershell/Tests/Unit/Get-OpenDataServices.Tests.ps1
+++ b/src/powershell/Tests/Unit/Get-OpenDataServices.Tests.ps1
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Describe 'Get-FinOpsServicesData' {
+Describe 'Get-OpenDataServices' {
     It 'Should return same rows as the CSV file' {
         # Arrange
-        . "$PSScriptRoot/../../Private/Get-FinOpsServicesData.ps1"
+        . "$PSScriptRoot/../../Private/Get-OpenDataServices.ps1"
         $csv = Import-Csv "$PSScriptRoot/../../../open-data/Services.csv"
 
         # Act
-        $cmd = Get-FinOpsServicesData
+        $cmd = Get-OpenDataServices
 
         # Assert
         $cmd.Count | Should -Be $csv.Count

--- a/src/scripts/Build-OpenData.ps1
+++ b/src/scripts/Build-OpenData.ps1
@@ -81,7 +81,7 @@ Get-ChildItem "$srcDir/*.csv" `
 | ForEach-Object {
     $file = $_
     $dataType = $file.BaseName
-    $command = "Get-FinOps$($dataType)Data"
+    $command = "Get-OpenData$($dataType)"
     
     Write-Verbose "Generating $command from $dataType.csv..."
     Write-Command -Command $command -File $file  | Out-File "$outDir/Private/$command.ps1"          -Append:$false


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
Rename the Get-FinOps*Data private commands to Get-OpenData* so they don't get confused with the public Get-FinOps* commands.

## 📷 Screenshots
<!-- TODO: Add screenshots of the new experience or remove section if not applicable -->

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [x] 💪 Unit tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Yes (required for `dev` PRs)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)
