### PR TITLE
Fix Split-AzureResourceId tests

### DIFF
--- a/src/powershell/Tests/Unit/Split-AzureResourceId.Tests.ps1
+++ b/src/powershell/Tests/Unit/Split-AzureResourceId.Tests.ps1
@@ -1,18 +1,17 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# Load the function into the current context
-. "$PSScriptRoot/../../Private/Split-AzureResourceId.ps1"
-
-$subId = (New-Guid).Guid
-$rg = 'testRg'
-$rp = 'Microsoft.Cloud'
-$type1 = 'hubs'
-$name1 = 'hub1'
-$type2 = 'scopes'
-$name2 = 'scope2'
-
 Describe 'Split-AzureResourceId' {
+    BeforeAll {
+        . "$PSScriptRoot/../../Private/Split-AzureResourceId.ps1"
+        $subId = (New-Guid).Guid
+        $rg = 'testRg'
+        $rp = 'Microsoft.Cloud'
+        $type1 = 'hubs'
+        $name1 = 'hub1'
+        $type2 = 'scopes'
+        $name2 = 'scope2'
+    }
     It 'Should parse tenant' {
         $id = "/tenants/$subId"
         $result = Split-AzureResourceId -Id $id


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
Fix the tests for Split-AzureResourceId

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [x] 💪 Unit tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Yes (required for `dev` PRs)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)
