### PR TITLE
Add -AsDotNetVersion option to the Get-Version script

### DIFF
--- a/src/scripts/Get-Version.ps1
+++ b/src/scripts/Get-Version.ps1
@@ -18,7 +18,21 @@
 
     Gets the current version number.
 #>
-return (Get-Content (Join-Path $PSScriptRoot ../../package.json) | ConvertFrom-Json).version `
+param(
+    [switch]
+    $AsDotNetVersion
+)
+
+$ver = (Get-Content (Join-Path $PSScriptRoot ../../package.json) | ConvertFrom-Json).version `
     -replace '^[^\d]*((\d+\.\d+)(\.\d+)?(-[a-z]+)?(\.\d+)?)[^\d]*$', '$1' `
     -replace '^(\d+\.\d+)(\.\d+)?(-[a-z]+)?(\.0)?$', '$1$2$3' `
     -replace '^(\d+\.\d+)(\.0)?(-[a-z]+)?(\.\d+)?$', '$1$3$4'
+
+if ($AsDotNetVersion -and $ver.Contains('-'))
+{
+    $arr = (($ver -replace '-[^\.0-9]+', '') -split '\.') + @(0, 0)
+    $arr[3] += 1000000000
+    return $arr[0..3] -Join '.'
+}
+
+return $ver


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
Add Get-Version -AsDotNetVersion to return a version number that does not use a prerelease name to avoid errors with .NET based build number systems.

## 📋 Checklist

### 🔬 How did you test this change?

> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [ ] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Yes (required for `dev` PRs)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)
