### PR TITLE
Deprecate FOCUS PowerShell commands

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,11 @@ Legend:
 🛠️✨ Patch
 🪛⬆️ Update
 🌱 Pre-release
+
+➕ Added
+✏️ Changed
+🛠️ Fixed
+🗑️ Removed
 -->
 
 ## 🔄️ Unreleased
@@ -81,6 +86,12 @@ Legend:
 >
 > 1. New-FinOpsCostExport
 > 2. Remove-FinOpsHubScope
+>
+> 🗑️ Removed:
+>
+> 1. `ConvertTo-FinOpsSchema` and `Invoke-FinOpsSchemaTransform` are no longer being maintained and will be removed in a future update.
+>    - With native support for FOCUS 1.0 preview in Cost Management, we are deprecating both commands, which only support FOCUS 0.5.
+>    - If you would like to see the PowerShell commands updated to 1.0 preview, please let us know in discussions or via a GitHub issue.
 
 🌐 Open data
 {: .fs-5 .fw-500 .mt-4 mb-0 }

--- a/docs/powershell/focus/ConvertTo-FinOpsSchema.md
+++ b/docs/powershell/focus/ConvertTo-FinOpsSchema.md
@@ -27,6 +27,10 @@ Converts Cost Management cost data to the FinOps Open Cost and Usage Specificati
 
 ---
 
+<blockquote class="warning" markdown="1">
+    _The ConvertTo-FinOpsSchema command was implemented before Microsoft Cost Management supported a native FOCUS export. Going forward, we recommend using the native export. The ConvertTo-FinOpsSchema command will remain available but will not be updated to support FOCUS 1.0-preview. If you have a scenario where you need a PowerShell converter, please leave feedback at https://aka.ms/ftk._
+</blockquote>
+
 The **ConvertTo-FinOpsSchema** command returns an object that adheres to the [FinOps Open Cost and Usage Specification (FOCUS)](https://focus.finops.org) schema.
 
 ConvertTo-FinOpsSchema currently understands how to convert Cost Management cost data using the latest schemas as of September 2023. Older schemas may not be fully supported. Please review output and report any issues to https://aka.ms/ftk.

--- a/docs/powershell/focus/Invoke-FinOpsSchemaTransform.md
+++ b/docs/powershell/focus/Invoke-FinOpsSchemaTransform.md
@@ -27,6 +27,10 @@ Loads a Cost Management CSV file, converts it to the FinOps Open Cost and Usage 
 
 ---
 
+<blockquote class="warning" markdown="1">
+    _The Invoke-FinOpsSchemaTransform command was implemented before Microsoft Cost Management supported a native FOCUS export. Going forward, we recommend using the native export. The Invoke-FinOpsSchemaTransform command will remain available but will not be updated to support FOCUS 1.0-preview. If you have a scenario where you need a PowerShell converter, please leave feedback at https://aka.ms/ftk._
+</blockquote>
+
 The **Invoke-FinOpsSchemaTransform** command reads actual and amortized cost data from files via Import-Csv, converts them to the FinOps Open Cost and Usage Specification (FOCUS) schema via [ConvertTo-FinOpsSchema](./ConvertTo-FinOpsSchema.md), and then saves the result to a CSV file using Export-Csv.
 
 This command is a simple helper to simplify chaining these commands together. If you do not want to read from a CSV file or write to a CSV file, use the ConvertTo-FinOpsSchema command.

--- a/src/powershell/Public/ConvertTo-FinOpsSchema.ps1
+++ b/src/powershell/Public/ConvertTo-FinOpsSchema.ps1
@@ -12,6 +12,8 @@
 
     You can pipe objects to ConvertTo-FinOpsSchema from an exported or downloaded CSV file using Import-Csv or ConvertFrom-Csv and pipe to Export-Csv to save as a CSV file. Or use the Invoke-FinOpsSchemaTransform command to simplify the process.
 
+    The ConvertTo-FinOpsSchema command was implemented before Microsoft Cost Management supported a native FOCUS export. Going forward, we recommend using the native export. The ConvertTo-FinOpsSchema command will remain available but will not be updated to support FOCUS 1.0-preview. If you have a scenario where you need a PowerShell converter, please leave feedback at https://aka.ms/ftk.
+
     .PARAMETER ActualCost
     Required. Specifies the actual cost data to be converted. Object must be a supported Microsoft Cost Management schema.
 

--- a/src/powershell/Public/Invoke-FinOpsSchemaTransform.ps1
+++ b/src/powershell/Public/Invoke-FinOpsSchemaTransform.ps1
@@ -12,6 +12,8 @@
 
     Invoke-FinOpsSchemaTransform inherits the same schema constraints as ConvertTo-FinOpsSchema. Refer to that documentation for details.
 
+    The Invoke-FinOpsSchemaTransform command was implemented before Microsoft Cost Management supported a native FOCUS export. Going forward, we recommend using the native export. The Invoke-FinOpsSchemaTransform command will remain available but will not be updated to support FOCUS 1.0-preview. If you have a scenario where you need a PowerShell converter, please leave feedback at https://aka.ms/ftk.
+
     .PARAMETER ActualCostPath
     Required. Specifies the path to the actual cost data file. File must be a supported Microsoft Cost Management schema.
 


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
Given native support for FOCUS in Cost Management, we are deprecating the FOCUS PowerShell commands. 

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [ ] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [x] ✅ Yes (required for `dev` PRs)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [ ] ❎ Not needed (small/internal change)

### 📖 Did you update documentation?

> - [x] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [ ] ❎ Not needed (small/internal change)
