### PR TITLE
Add new troubleshooting steps

### DIFF
--- a/docs/resources/troubleshooting.md
+++ b/docs/resources/troubleshooting.md
@@ -97,7 +97,7 @@ This error typically indicates that data was not ingested into the **ingestion**
 
 ---
 
-## Deployment error: The resource write operation failed to complete successfully, because it reached terminal provisioning state 'Failed'. (Code: ResourceDeploymentFailure, Target: /subscriptions/subscription/resourceGroups/resourcegroup/providers/Microsoft.Resources/deployments/storage)
+## FinOps hubs: Deployment failed with RoleAssignmentUpdateNotPermitted error
 
 If you've deleted FinOps Hubs and are attempting to redeploy it with the same values, including the Managed Identity name, you might encounter the following known issue:
 

--- a/docs/resources/troubleshooting.md
+++ b/docs/resources/troubleshooting.md
@@ -25,6 +25,7 @@ Here are a few simple solutions to issues you may have faced:
 - [Power BI: The remote name could not be resolved: '\<storage-account\>.dfs.core.windows.net'](#power-bi-the-remote-name-could-not-be-resolved-storage-accountdfscorewindowsnet)
 - [Power BI: We cannot convert the value null to type Logical](#power-bi-we-cannot-convert-the-value-null-to-type-logical)
 - [FinOps hubs: We cannot convert the value null to type Table](#finops-hubs-we-cannot-convert-the-value-null-to-type-table)
+- [Deployment failed "code": "RoleAssignmentUpdateNotPermitteA"](#deployment-failed-code-roleassignmentupdatenotpermittea)
 
 Didn't find what you're looking for?
 
@@ -93,6 +94,27 @@ Applicable versions: **0.1 - 0.1.1** (fixed in **0.1.2**)
 ## FinOps hubs: We cannot convert the value null to type Table
 
 This error typically indicates that data was not ingested into the **ingestion** container. See [Reports are empty (no data)](#reports-are-empty-no-data) for details.
+
+---
+
+## Deployment error: The resource write operation failed to complete successfully, because it reached terminal provisioning state 'Failed'. (Code: ResourceDeploymentFailure, Target: /subscriptions/subscription/resourceGroups/resourcegroup/providers/Microsoft.Resources/deployments/storage)
+
+If you've deleted FinOps Hubs and are attempting to redeploy it with the same values, including the Managed Identity name, you might encounter the following known issue:
+
+```json
+"code": "RoleAssignmentUpdateNotPermitted",
+"message": "Tenant ID, application ID, principal ID, and scope are not allowed to be updated."
+```
+
+### Resolution Options:
+
+1. **Remove Stale Identity:**
+   - Navigate to "Storage Account >> Access Control IAM" >> "Role assignments."
+   - Identify a role assignment with an "unknown" identity and delete it.
+
+2. **Update Role Assignment Name (GUID):**
+   - Choose a GUID that hasn't been used previously.
+   - Retry the deployment with the updated role assignment name.
 
 ---
 

--- a/docs/resources/troubleshooting.md
+++ b/docs/resources/troubleshooting.md
@@ -25,7 +25,7 @@ Here are a few simple solutions to issues you may have faced:
 - [Power BI: The remote name could not be resolved: '\<storage-account\>.dfs.core.windows.net'](#power-bi-the-remote-name-could-not-be-resolved-storage-accountdfscorewindowsnet)
 - [Power BI: We cannot convert the value null to type Logical](#power-bi-we-cannot-convert-the-value-null-to-type-logical)
 - [FinOps hubs: We cannot convert the value null to type Table](#finops-hubs-we-cannot-convert-the-value-null-to-type-table)
-- [Deployment failed "code": "RoleAssignmentUpdateNotPermitteA"](#deployment-failed-code-roleassignmentupdatenotpermittea)
+- [FinOps hubs: Deployment failed with RoleAssignmentUpdateNotPermitted error](#finops-hubs-deployment-failed-with-roleassignmentupdatenotpermitted-error)
 
 Didn't find what you're looking for?
 

--- a/docs/resources/troubleshooting.md
+++ b/docs/resources/troubleshooting.md
@@ -105,16 +105,11 @@ If you've deleted FinOps Hubs and are attempting to redeploy it with the same va
 "code": "RoleAssignmentUpdateNotPermitted",
 "message": "Tenant ID, application ID, principal ID, and scope are not allowed to be updated."
 ```
-
-### Resolution Options:
-
-1. **Remove Stale Identity:**
+To fix that issue you will have to remove the stale identity:
    - Navigate to "Storage Account >> Access Control IAM" >> "Role assignments."
    - Identify a role assignment with an "unknown" identity and delete it.
 
-2. **Update Role Assignment Name (GUID):**
-   - Choose a GUID that hasn't been used previously.
-   - Retry the deployment with the updated role assignment name.
+
 
 ---
 


### PR DESCRIPTION
Added troubleshooting steps to clean up stale  role assignments after deleting a managed identity. This issue happen when there is a failed Hubs deployment and the customer's try the deployment again. 
