### PR TITLE
Fix broken links to Open data Regions and Resource types

### DIFF
--- a/docs/_includes/tools.md
+++ b/docs/_includes/tools.md
@@ -11,6 +11,6 @@
 - 🦾 [Bicep Registry modules]({{ "/bicep" | relative_url }}) – Official repository for Bicep modules.{% endif %}{% if include.all == "1" or include.data == "1" %}
 - 🌐 [Open data]({{ "/data" | relative_url }}) – Data available for anyone to access, use, and share without restriction.{% endif %}{% if include.all == "1" or include.datatypes == "1" %}
   - 📏 [Pricing units]({{ "/data#-pricing-units" | relative_url }}) – Microsoft pricing units, distinct units, and scaling factors.
-  - 🗺️ [Regions]({{ "/data/#-regions" | relative_url }}) – Microsoft Commerce locations and Azure regions (IDs and names).
-  - 🗺️ [Resource types]({{ "/data/#-resource-types" | relative_url }}) – Microsoft Azure resource type display names, icons, and more.
+  - 🗺️ [Regions]({{ "/data#-regions" | relative_url }}) – Microsoft Commerce locations and Azure regions (IDs and names).
+  - 🗺️ [Resource types]({{ "/data#-resource-types" | relative_url }}) – Microsoft Azure resource type display names, icons, and more.
   - 🎛️ [Services]({{ "/data#-services" | relative_url }}) – Microsoft consumed services, resource types, and FOCUS service categories.{% endif %}


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
<!-- TODO: Summarize the changes with context and motivation -->
Removes the slash after `/data` for the Regions and Resource types links.

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Yes (required for `dev` PRs)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will cover in a future PR (feature branch PRs only)
> - [x] ❎ Not needed (small/internal change)
