### PR TITLE
Add contributors guideline

### DIFF
--- a/.github/ISSUE_TEMPLATE/propose-tool.md
+++ b/.github/ISSUE_TEMPLATE/propose-tool.md
@@ -1,0 +1,31 @@
+---
+name: "\U+1F4CB Propose new tool"
+about: Suggest a new tool to be included in the Toolkit
+title: ''
+labels: "Needs: Triage \U0001F50D, Type: Feature \U0001F48E"
+assignees: ''
+---
+
+## New Tool Submission
+
+### Tool Name:
+[Insert Tool Name]
+
+### Description:
+[Provide a brief description of the tool and its intended purpose.]
+
+### Use Case:
+[Explain the use case or scenarios where this tool would be beneficial for FinOps practitioners.]
+
+### Functionality:
+[Outline the key features and functionalities of the tool.]
+
+### Implementation:
+[Provide guidance or instructions on how to implement and utilize the tool.]
+
+### Additional Information:
+[Include any additional information, links, or resources related to the tool.]
+
+### Contributor Information:
+- **Name**: [Your Name]
+- **Contact Email**: [Your Email Address]

--- a/docs/_resources/contributors.md
+++ b/docs/_resources/contributors.md
@@ -52,9 +52,6 @@ If you're eager to contribute but unsure where to begin, a great starting point 
 
 If this is the first time you are working on the FinOps toolkit repository, make sure to review our [Get started wiki](https://github.com/microsoft/finops-toolkit/wiki#-get-started).
 
-
-Once you are assigned to the bug, GitHub will automatically assign the tag "Community Contributor" to inform the team responsible for that tool of your contribution. 
-
 <br>
 
 ## 🛠️ Suggesting and owning a new feature, fixing an existing bug, or suggesting a change for an existing tool

--- a/docs/_resources/contributors.md
+++ b/docs/_resources/contributors.md
@@ -32,7 +32,7 @@ Welcome to the FinOps toolkit! As an open-source initiative, our success hinges 
 There are several ways you can contribute to the FinOps toolkit:
 
 1. 🐛 **Working on existing bugs:** You can assist by identifying and addressing existing bugs listed in our repository. 
-2. 🛠️ **Suggesting and owning a new feature, fixing an existing bug, or suggesting a change for an existing tool:** This involves proposing new features, fixing bugs, or suggesting changes for existing tools. 
+2. 🛠️  **Providing suggestions for new features or improvements:** If you're not comfortable with coding, you can still contribute by suggesting new features or improvements for our tools.
 3. 💡 **Proposing a new tool:** If you've developed a FinOps-related tool and want it to be part of the FinOps toolkit, you can submit a proposal for consideration.
 4. 👀 **Reviewing pull requests:** Code reviews are a critical aspect of maintaining code quality and ensuring the reliability and functionality of the project. By reviewing existing pull requests (PRs) suggested by community members, you can contribute significantly to the project's success without necessarily creating new code.
 5. 💬 **Answering questions:** Being actively involved in answering questions and providing assistance to community members is an invaluable contribution to the project.

--- a/docs/_resources/contributors.md
+++ b/docs/_resources/contributors.md
@@ -87,15 +87,15 @@ The FinOps toolkit governance committee will review your proposal and reach out 
 
 Check the list of [open pull requests](https://github.com/microsoft/finops-toolkit/pulls) and provide constructive feedback on code changes proposed by community members. Ensure that the code adheres to our [coding guidelines](https://github.com/microsoft/finops-toolkit/wiki/Coding-guidelines), is well-documented, and follows best practices.
 
+Offer suggestions for improving the quality of the code, such as optimizing performance, enhancing readability, and addressing potential edge cases or bugs.
+
+Test the functionality of the code changes proposed in the PR to ensure they work as intended. This involves running tests, verifying edge cases, and checking for any unintended side effects.
+
 When possible, try to suggest code changes using **Add a suggestion** to streamline the review process.
 
 ![Screenshot of the 'Add a suggestion' command in pull request reviews](https://user-images.githubusercontent.com/399533/179936119-88c10c44-f181-4fa3-83b8-91376c8e4c58.png)
 
 <br>
-
-- **Improve Quality:** Offer suggestions for improving the quality of the code, such as optimizing performance, enhancing readability, and addressing potential edge cases or bugs.
-
-- **Validate Functionality:** Test the functionality of the code changes proposed in the PR to ensure they work as intended. This involves running tests, verifying edge cases, and checking for any unintended side effects.
 
 ## 💬 Answering questions
 

--- a/docs/_resources/contributors.md
+++ b/docs/_resources/contributors.md
@@ -19,6 +19,9 @@ The FinOps Toolkit project welcomes contributions from the community.
   - [Working on existing bugs](#1-working-on-existing-bugs)
   - [Suggesting and owning a new feature, fixing a bug, or suggesting a change for an existing Tool](#2-suggesting-and-owning-a-new-feature-fixing-a-bug-or-suggesting-a-change-for-an-existing-tool)
   - [Submitting a proposal for a new tool](#3-submitting-a-proposal-for-a-new-tool)
+  - [Code review](#4-code-review)
+  - [Answering questions](#5-answering-questions)
+  - [Documentation update](#6-documentation-update)
 
 </details>
 
@@ -33,6 +36,9 @@ There are three primary ways you can contribute to the success of the project:
 1. 🐛 **Working on existing bugs:** You can assist by identifying and addressing existing bugs listed in our repository. 
 2. 🛠️ **Suggesting and owning a new feature, fixing an existing bug, or suggesting a change for an existing tool:** This involves proposing new features, fixing bugs, or suggesting changes for existing tools. 
 3. 💡 **Submitting a proposal for a new tool:** If you've developed a FinOps-related tool and want it to be part of the FinOps Toolkit, you can submit a proposal for consideration.
+4. 👀 **Code review:** Code review is a critical aspect of maintaining code quality and ensuring the reliability and functionality of the project. By reviewing existing pull requests (PRs) suggested by community members, you can contribute significantly to the project's success without necessarily creating new code.
+5. 💬 **Answering questions:** Being actively involved in answering questions and providing assistance to community members is an invaluable contribution to the project.
+6. 📚 **Documentation update:** Documentation serves as a crucial resource for users, developers, and contributors alike. Keeping documentation accurate, comprehensive, and up-to-date is essential for the success of the toolkit.
 
 We appreciate your interest in contributing to the FinOps Toolkit project!
 
@@ -43,11 +49,9 @@ If you're eager to contribute but unsure where to begin, a great starting point 
 1. Look through the list of existing bugs in the [Issues tab](https://github.com/finopsfoundation/FinOpsToolkit/issues).
 2. Assign yourself to the bug you want to work on.
 
-Once you are assigned to the bug, GitHub will automatically assign the tag "Community Contributor" to inform the team responsible for that tool of your contribution. Remember not to start coding until you receive approval from the governance team. 
+If this is the first time you are working on the FinOps Toolkit repository, make sure to review our [Get Started Wiki.](https://github.com/microsoft/finops-toolkit/wiki#-test-and-verify)
 
-<!---
-Assuming we have a list of "approved" developers we could have a Github policy to auto-assign a tag if a bug is assigned to anyone else, right? 
--->
+Once you are assigned to the bug, GitHub will automatically assign the tag "Community Contributor" to inform the team responsible for that tool of your contribution. 
 
 ### 🛠️ 2. Suggesting and owning a new feature, fixing an existing bug, or suggesting a change for an existing tool
 
@@ -62,22 +66,59 @@ To do that, follow these steps:
 3. Check the box "Willing to fix" at the bottom of the page.
 4. Submit your issue.
 
-Your issue will be reviewed by the FinOps Toolkit governance team, who will reach out to you to discuss further and give you the green light to start developing. Do not start coding before receiving approval from the governance team.
-
-**Note:** Do not start coding before receiving approval from the governance team.
+Your issue will be reviewed by the FinOps Toolkit governance team, who will reach out to you to discuss further and give you the green light to start developing. 
 
 ### 3. 💡 Submitting a proposal for a new tool
 
 If you have developed a FinOps-related tool and want it to be part of the FinOps Toolkit, follow these steps:
 
-1. Send an email to [finpostoolkitgovcommittee@microsoft.com](mailto:finpostoolkitgovcommittee@microsoft.com) with your proposal.
+1. Send an email to [ftk-leads@microsoft.com](mailto:ftk-leads@microsoft.com) with your proposal.
 2. Include as much information as possible about your tool and how it can benefit the FinOps community.
 
-<!---
-TODO: Create DL and add Governance committee members - BTW we can call the DL anyway we like, don't need to use the name that I added here
--->
+The FinOps toolkit governance committee will review your proposal and reach out to you for further discussion.
 
-The Toolkit governance committee will review your proposal and reach out to you for further discussion.
 
-Feel free to reach out if you have any questions or need assistance with your contribution.
+### 4. 👀 **Code review**
+
+- **Review Pull Requests:** Regularly check the list of open PRs on the repository and provide constructive feedback on code changes proposed by community members. Ensure that the code adheres to our [coding guidelines](https://github.com/microsoft/finops-toolkit/wiki/Coding-guidelines.md), is well-documented, and follows best practices.
+
+When possible, try to suggest code changes using **Add a suggestion** to streamline the review process.
+
+![Screenshot of the 'Add a suggestion' command in pull request reviews](https://user-images.githubusercontent.com/399533/179936119-88c10c44-f181-4fa3-83b8-91376c8e4c58.png)
+
+<br>
+
+- **Improve Quality:** Offer suggestions for improving the quality of the code, such as optimizing performance, enhancing readability, and addressing potential edge cases or bugs.
+
+- **Validate Functionality:** Test the functionality of the code changes proposed in the PR to ensure they work as intended. This involves running tests, verifying edge cases, and checking for any unintended side effects.
+
+### 5. 💬 Answering Questions
+
+Being actively involved in answering questions and providing assistance to community members is an invaluable contribution to the project.
+
+- **Share Knowledge:** Utilize your expertise and experience to provide helpful and informative responses to questions raised by community members. Offer clear explanations, examples, and references to support your answers.
+
+- **Help Resolve Issues:** Assist community members in troubleshooting technical issues, or resolving configuration problems they encounter while using the toolkit.
+
+### 6. 📚 Documentation Update:
+
+- **Identify Areas for Improvement:** Review the existing documentation to identify any outdated information, inaccuracies, or gaps that need to be addressed.
+
+- **Improve Clarity and Consistency:** Clarify ambiguous sections, reorganize content for better structure, and ensure consistency in terminology, formatting, and style throughout the documentation.
+
+- **Update Content:** Update outdated information, add new content to cover recent features or changes, and remove obsolete sections that are no longer relevant.
+
+<br>
+
+# 🙏 Thank you! <!-- markdownlint-disable-line single-h1 -->
+
+Your contributions to open source, large or small, make projects like this possible. Thank you for taking the time to contribute.
+
+<br>
+
+_<sub>
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+</sub>_
 

--- a/docs/_resources/contributors.md
+++ b/docs/_resources/contributors.md
@@ -1,13 +1,14 @@
 ---
 layout: default
 parent: Resources
-title: How to Contribute
+title: How to contribute
 nav_order: 10
 description: 'Contribute with the FinOps toolkit'
 permalink: /resources/contributors
 ---
 
-<span class="fs-9 d-block mb-4">FinOps Toolkit Contributors Guideline</span>
+<span class="fs-9 d-block mb-4">Contribution guide</span>
+
 The FinOps Toolkit project welcomes contributions from the community.
 {: .fs-6 .fw-300 }
 
@@ -15,60 +16,65 @@ The FinOps Toolkit project welcomes contributions from the community.
    <summary class="fs-2 text-uppercase">On this page</summary>
 
 
-- [📝 How to Contribute](#-finops-toolkit-contribution-guide)
-  - [Working on existing bugs](#1-working-on-existing-bugs)
-  - [Suggesting and owning a new feature, fixing a bug, or suggesting a change for an existing Tool](#2-suggesting-and-owning-a-new-feature-fixing-a-bug-or-suggesting-a-change-for-an-existing-tool)
-  - [Submitting a proposal for a new tool](#3-submitting-a-proposal-for-a-new-tool)
-  - [Code review](#4-code-review)
-  - [Answering questions](#5-answering-questions)
-  - [Documentation update](#6-documentation-update)
+- [Working on existing bugs](#-working-on-existing-bugs)
+- [Suggesting and owning a new feature, fixing a bug, or suggesting a change for an existing Tool](#-suggesting-and-owning-a-new-feature-fixing-a-bug-or-suggesting-a-change-for-an-existing-tool)
+- [Proposing a new tool](#-proposing-a-new-tool)
+- [Reviewing pull requests](#-reviewing-pull-requests)
+- [Answering questions](#-answering-questions)
+- [Updating documentation](#-updating-documentation)
 
 </details>
 
 ---
 
-## 📝 FinOps Toolkit Contribution Guide
+Welcome to the FinOps toolkit! As an open-source initiative, our success hinges on the collective effort of the community. Your contributions play a vital role in enhancing and expanding the toolkit's capabilities, making it more valuable and effective.
 
-Welcome to the FinOps Toolkit project! As an open-source initiative, our success hinges on the collective effort of the community. Your contributions play a vital role in enhancing and expanding the toolkit's capabilities, making it more valuable and effective.
-
-There are three primary ways you can contribute to the success of the project:
+There are several ways you can contribute to the FinOps toolkit:
 
 1. 🐛 **Working on existing bugs:** You can assist by identifying and addressing existing bugs listed in our repository. 
 2. 🛠️ **Suggesting and owning a new feature, fixing an existing bug, or suggesting a change for an existing tool:** This involves proposing new features, fixing bugs, or suggesting changes for existing tools. 
-3. 💡 **Submitting a proposal for a new tool:** If you've developed a FinOps-related tool and want it to be part of the FinOps Toolkit, you can submit a proposal for consideration.
-4. 👀 **Code review:** Code review is a critical aspect of maintaining code quality and ensuring the reliability and functionality of the project. By reviewing existing pull requests (PRs) suggested by community members, you can contribute significantly to the project's success without necessarily creating new code.
+3. 💡 **Proposing a new tool:** If you've developed a FinOps-related tool and want it to be part of the FinOps toolkit, you can submit a proposal for consideration.
+4. 👀 **Reviewing pull requests:** Code reviews are a critical aspect of maintaining code quality and ensuring the reliability and functionality of the project. By reviewing existing pull requests (PRs) suggested by community members, you can contribute significantly to the project's success without necessarily creating new code.
 5. 💬 **Answering questions:** Being actively involved in answering questions and providing assistance to community members is an invaluable contribution to the project.
-6. 📚 **Documentation update:** Documentation serves as a crucial resource for users, developers, and contributors alike. Keeping documentation accurate, comprehensive, and up-to-date is essential for the success of the toolkit.
+6. 📚 **Updating documentation:** Documentation serves as a crucial resource for users, developers, and contributors alike. Keeping documentation accurate, comprehensive, and up to date is essential for the success of the toolkit.
+
 
 We appreciate your interest in contributing to the FinOps Toolkit project!
 
-### 🐛 1. Working on existing bugs
+<br>
+
+## 🐛 Working on existing bugs
 
 If you're eager to contribute but unsure where to begin, a great starting point is to review the list of existing feedback and identify issues that align with your skills and interests. 
 
-1. Look through the list of existing bugs in the [Issues tab](https://github.com/finopsfoundation/FinOpsToolkit/issues).
+1. Look through the list of [existing issues](https://github.com/microsoft/finops-toolkit/issues).
 2. Assign yourself to the bug you want to work on.
 
-If this is the first time you are working on the FinOps Toolkit repository, make sure to review our [Get Started Wiki.](https://github.com/microsoft/finops-toolkit/wiki#-test-and-verify)
+If this is the first time you are working on the FinOps toolkit repository, make sure to review our [Get started wiki](https://github.com/microsoft/finops-toolkit/wiki#-get-started).
+
 
 Once you are assigned to the bug, GitHub will automatically assign the tag "Community Contributor" to inform the team responsible for that tool of your contribution. 
 
-### 🛠️ 2. Suggesting and owning a new feature, fixing an existing bug, or suggesting a change for an existing tool
+<br>
 
-#### Submitting a New Issue and Willing to Fix
+## 🛠️ Suggesting and owning a new feature, fixing an existing bug, or suggesting a change for an existing tool
+
+### Submitting a new issue
 
 If you have a new feature suggestion, identified a bug, or have ideas for improving existing tools, we encourage you to submit an issue. Your feedback helps us ensure that the toolkit meets the needs of its users. And if you're willing to take it a step further and contribute to implementing your suggestions, we welcome your contributions with open arms! 
 
 To do that, follow these steps: 
 
-1. Go to the [Issues tab](https://github.com/finopsfoundation/FinOpsToolkit/issues) and click on "New issue".
+1. Go to the [issues list](https://github.com/finopsfoundation/FinOpsToolkit/issues) and click on "New issue".
 2. Choose the option that best describes your contribution (bug fix, change request, or feature request).
 3. Check the box "Willing to fix" at the bottom of the page.
 4. Submit your issue.
 
 Your issue will be reviewed by the FinOps Toolkit governance team, who will reach out to you to discuss further and give you the green light to start developing. 
 
-### 3. 💡 Submitting a proposal for a new tool
+<br>
+
+## 💡 Proposing a new tool
 
 If you have developed a FinOps-related tool and want it to be part of the FinOps Toolkit, follow these steps:
 
@@ -78,9 +84,11 @@ If you have developed a FinOps-related tool and want it to be part of the FinOps
 The FinOps toolkit governance committee will review your proposal and reach out to you for further discussion.
 
 
-### 4. 👀 **Code review**
+<br>
 
-- **Review Pull Requests:** Regularly check the list of open PRs on the repository and provide constructive feedback on code changes proposed by community members. Ensure that the code adheres to our [coding guidelines](https://github.com/microsoft/finops-toolkit/wiki/Coding-guidelines.md), is well-documented, and follows best practices.
+## 👀 **Reviewing pull requests**
+
+Check the list of [open pull requests](https://github.com/microsoft/finops-toolkit/pulls) and provide constructive feedback on code changes proposed by community members. Ensure that the code adheres to our [coding guidelines](https://github.com/microsoft/finops-toolkit/wiki/Coding-guidelines), is well-documented, and follows best practices.
 
 When possible, try to suggest code changes using **Add a suggestion** to streamline the review process.
 
@@ -92,21 +100,20 @@ When possible, try to suggest code changes using **Add a suggestion** to streaml
 
 - **Validate Functionality:** Test the functionality of the code changes proposed in the PR to ensure they work as intended. This involves running tests, verifying edge cases, and checking for any unintended side effects.
 
-### 5. 💬 Answering Questions
+## 💬 Answering questions
 
 Being actively involved in answering questions and providing assistance to community members is an invaluable contribution to the project.
 
-- **Share Knowledge:** Utilize your expertise and experience to provide helpful and informative responses to questions raised by community members. Offer clear explanations, examples, and references to support your answers.
+- **Share knowledge:** Utilize your expertise and experience to provide helpful and informative responses to questions raised by community members. Offer clear explanations, examples, and references to support your answers.
+- **Help resolve issues:** Assist community members in troubleshooting technical issues, or resolving configuration problems they encounter while using the toolkit.
 
-- **Help Resolve Issues:** Assist community members in troubleshooting technical issues, or resolving configuration problems they encounter while using the toolkit.
+<br>
 
-### 6. 📚 Documentation Update:
+## 📚 Updating documentation
 
-- **Identify Areas for Improvement:** Review the existing documentation to identify any outdated information, inaccuracies, or gaps that need to be addressed.
-
-- **Improve Clarity and Consistency:** Clarify ambiguous sections, reorganize content for better structure, and ensure consistency in terminology, formatting, and style throughout the documentation.
-
-- **Update Content:** Update outdated information, add new content to cover recent features or changes, and remove obsolete sections that are no longer relevant.
+- **Identify areas for improvement:** Review the existing documentation to identify any outdated information, inaccuracies, or gaps that need to be addressed.
+- **Improve clarity and consistency:** Clarify ambiguous sections, reorganize content for better structure, and ensure consistency in terminology, formatting, and style throughout the documentation.
+- **Update content:** Update outdated information, add new content to cover recent features or changes, and remove obsolete sections that are no longer relevant.
 
 <br>
 

--- a/docs/_resources/contributors.md
+++ b/docs/_resources/contributors.md
@@ -67,13 +67,12 @@ To do that, follow these steps:
 3. Check the box "Willing to fix" at the bottom of the page.
 4. Submit your issue.
 
-Your issue will be reviewed by the FinOps Toolkit governance team, who will reach out to you to discuss further and give you the green light to start developing. 
 
 <br>
 
 ## 💡 Proposing a new tool
 
-If you have developed a FinOps-related tool and want it to be part of the FinOps toolkit, send the details to [ftk-leads@microsoft.com](mailto:ftk-leads@microsoft.com?subject=[FTK]+New+tool+for+the+FinOps+toolkit). Please include as much information as possible about your tool and how it can benefit the FinOps community.
+If you have developed a FinOps-related tool and want it to be part of the FinOps toolkit, go to the issues list, click on "New issue" and select the "Propose a new tool" option. Please include as much information as possible about your tool and how it can benefit the FinOps community.
 
 The FinOps toolkit governing board will review your proposal and reach out to you for further discussion.
 

--- a/docs/_resources/contributors.md
+++ b/docs/_resources/contributors.md
@@ -1,0 +1,83 @@
+---
+layout: default
+parent: Resources
+title: How to Contribute
+nav_order: 10
+description: 'Contribute with the FinOps toolkit'
+permalink: /resources/contributors
+---
+
+<span class="fs-9 d-block mb-4">FinOps Toolkit Contributors Guideline</span>
+The FinOps Toolkit project welcomes contributions from the community.
+{: .fs-6 .fw-300 }
+
+<details open markdown="1">
+   <summary class="fs-2 text-uppercase">On this page</summary>
+
+
+- [📝 How to Contribute](#-finops-toolkit-contribution-guide)
+  - [Working on existing bugs](#1-working-on-existing-bugs)
+  - [Suggesting and owning a new feature, fixing a bug, or suggesting a change for an existing Tool](#2-suggesting-and-owning-a-new-feature-fixing-a-bug-or-suggesting-a-change-for-an-existing-tool)
+  - [Submitting a proposal for a new tool](#3-submitting-a-proposal-for-a-new-tool)
+
+</details>
+
+---
+
+## 📝 FinOps Toolkit Contribution Guide
+
+Welcome to the FinOps Toolkit project! As an open-source initiative, our success hinges on the collective effort of the community. Your contributions play a vital role in enhancing and expanding the toolkit's capabilities, making it more valuable and effective.
+
+There are three primary ways you can contribute to the success of the project:
+
+1. 🐛 **Working on existing bugs:** You can assist by identifying and addressing existing bugs listed in our repository. 
+2. 🛠️ **Suggesting and owning a new feature, fixing an existing bug, or suggesting a change for an existing tool:** This involves proposing new features, fixing bugs, or suggesting changes for existing tools. 
+3. 💡 **Submitting a proposal for a new tool:** If you've developed a FinOps-related tool and want it to be part of the FinOps Toolkit, you can submit a proposal for consideration.
+
+We appreciate your interest in contributing to the FinOps Toolkit project!
+
+### 🐛 1. Working on existing bugs
+
+If you're eager to contribute but unsure where to begin, a great starting point is to review the list of existing feedback and identify issues that align with your skills and interests. 
+
+1. Look through the list of existing bugs in the [Issues tab](https://github.com/finopsfoundation/FinOpsToolkit/issues).
+2. Assign yourself to the bug you want to work on.
+
+Once you are assigned to the bug, GitHub will automatically assign the tag "Community Contributor" to inform the team responsible for that tool of your contribution. Remember not to start coding until you receive approval from the governance team. 
+
+<!---
+Assuming we have a list of "approved" developers we could have a Github policy to auto-assign a tag if a bug is assigned to anyone else, right? 
+-->
+
+### 🛠️ 2. Suggesting and owning a new feature, fixing an existing bug, or suggesting a change for an existing tool
+
+#### Submitting a New Issue and Willing to Fix
+
+If you have a new feature suggestion, identified a bug, or have ideas for improving existing tools, we encourage you to submit an issue. Your feedback helps us ensure that the toolkit meets the needs of its users. And if you're willing to take it a step further and contribute to implementing your suggestions, we welcome your contributions with open arms! 
+
+To do that, follow these steps: 
+
+1. Go to the [Issues tab](https://github.com/finopsfoundation/FinOpsToolkit/issues) and click on "New issue".
+2. Choose the option that best describes your contribution (bug fix, change request, or feature request).
+3. Check the box "Willing to fix" at the bottom of the page.
+4. Submit your issue.
+
+Your issue will be reviewed by the FinOps Toolkit governance team, who will reach out to you to discuss further and give you the green light to start developing. Do not start coding before receiving approval from the governance team.
+
+**Note:** Do not start coding before receiving approval from the governance team.
+
+### 3. 💡 Submitting a proposal for a new tool
+
+If you have developed a FinOps-related tool and want it to be part of the FinOps Toolkit, follow these steps:
+
+1. Send an email to [finpostoolkitgovcommittee@microsoft.com](mailto:finpostoolkitgovcommittee@microsoft.com) with your proposal.
+2. Include as much information as possible about your tool and how it can benefit the FinOps community.
+
+<!---
+TODO: Create DL and add Governance committee members - BTW we can call the DL anyway we like, don't need to use the name that I added here
+-->
+
+The Toolkit governance committee will review your proposal and reach out to you for further discussion.
+
+Feel free to reach out if you have any questions or need assistance with your contribution.
+

--- a/docs/_resources/contributors.md
+++ b/docs/_resources/contributors.md
@@ -73,13 +73,9 @@ Your issue will be reviewed by the FinOps Toolkit governance team, who will reac
 
 ## 💡 Proposing a new tool
 
-If you have developed a FinOps-related tool and want it to be part of the FinOps Toolkit, follow these steps:
+If you have developed a FinOps-related tool and want it to be part of the FinOps toolkit, send the details to [ftk-leads@microsoft.com](mailto:ftk-leads@microsoft.com?subject=[FTK]+New+tool+for+the+FinOps+toolkit). Please include as much information as possible about your tool and how it can benefit the FinOps community.
 
-1. Send an email to [ftk-leads@microsoft.com](mailto:ftk-leads@microsoft.com) with your proposal.
-2. Include as much information as possible about your tool and how it can benefit the FinOps community.
-
-The FinOps toolkit governance committee will review your proposal and reach out to you for further discussion.
-
+The FinOps toolkit governing board will review your proposal and reach out to you for further discussion.
 
 <br>
 


### PR DESCRIPTION
This PR introduces the contributors guideline for the FinOps Toolkit for community members accessing the Toolkit from the webpage rather than the GitHub repository. The goal is to provide a simplified version of how individuals can contribute to the project, encouraging newcomers to get started easily. The guideline invites community members to participate, even if it will require further support, such as guidance on GitHub branches are organized.