### PR TITLE
feat: Create materialized view for FocusClean table

### DIFF
--- a/src/templates/finops-hub/modules/adxTableSchema.kql
+++ b/src/templates/finops-hub/modules/adxTableSchema.kql
@@ -95,7 +95,7 @@
   x_SkuTier:string
   )
 
-.create materialized-view FocusClean on table Focus
+.create-or-alter materialized-view FocusClean on table Focus
 {
     Focus
     | extend IngestionTime = ingestion_time()

--- a/src/templates/finops-hub/modules/adxTableSchema.kql
+++ b/src/templates/finops-hub/modules/adxTableSchema.kql
@@ -94,3 +94,11 @@
   x_SkuTerm:string,
   x_SkuTier:string
   )
+
+.create materialized-view FocusClean on table Focus
+{
+    Focus
+    | extend IngestionTime = ingestion_time()
+    | summarize arg_max(IngestionTime , *) by BillingAccountId, ChargePeriodStart, CommitmentDiscountId, Region, ResourceId, SkuPriceId, SubAccountId, x_AccountOwnerId, x_CostCenter, x_InvoiceSectionId, x_SkuDetails, x_SkuMeterId,
+x_SkuOfferId
+}

--- a/src/templates/finops-hub/modules/adxViews.kql
+++ b/src/templates/finops-hub/modules/adxViews.kql
@@ -1,0 +1,9 @@
+// Use this on an existing cluster to create a materialized view for the Focus table based on all the existing data.
+
+.create materialized-view with (backfill=true) FocusClean on table Focus
+{
+    Focus
+    | extend IngestionTime = ingestion_time()
+    | summarize arg_max(IngestionTime , *) by BillingAccountId, ChargePeriodStart, CommitmentDiscountId, Region, ResourceId, SkuPriceId, SubAccountId, x_AccountOwnerId, x_CostCenter, x_InvoiceSectionId, x_SkuDetails, x_SkuMeterId,
+x_SkuOfferId
+}


### PR DESCRIPTION
This commit adds a new materialized view called FocusClean on the table Focus. The view is created in the adxTableSchema.kql file and adxViews.kql file. The purpose of this view is to summarize the data in the Focus table based on various columns such as BillingAccountId, ChargePeriodStart, CommitmentDiscountId, Region, ResourceId, SkuPriceId, SubAccountId, x_AccountOwnerId, x_CostCenter, x_InvoiceSectionId, x_SkuDetails, x_SkuMeterId, and x_SkuOfferId. The view is created with the option to backfill existing data.

