### PR TITLE
Auto Update Open Data Workflow

### DIFF
--- a/.github/workflows/opendata-ci.yml
+++ b/.github/workflows/opendata-ci.yml
@@ -1,0 +1,42 @@
+name: Open Data CI
+on:
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - 'src/open-data/**/*.csv'
+      - 'src/open-data/**/*.json'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env: 
+      CI_COMMIT_MESSAGE: Open Data CI Commit
+      CI_COMMIT_AUTHOR: ${{ github.event.repository.name }} CI
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+        token: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}
+    - name: Set environment variable "commit-message"
+      run: echo "commit-message=$(git log -1 --pretty=format:'%s')" >> $GITHUB_ENV
+    - name: Set environment variable "commit-author"
+      run: echo "commit-author=$(git log -1 --pretty=format:'%an')" >> $GITHUB_ENV
+    - name: Set environment variable "is-auto-commit"
+      if: env.commit-message == env.CI_COMMIT_MESSAGE && env.commit-author == env.CI_COMMIT_AUTHOR
+      run: echo "is-auto-commit=true" >> $GITHUB_ENV
+    - name: Build Open Data
+      if: env.is-auto-commit == false
+      shell: pwsh
+      run: |
+        src/scripts/Build-OpenData.ps1 -PowerShell
+        if (git status --porcelain)
+        {
+          git config --global user.name "${{ env.CI_COMMIT_AUTHOR }}"
+          git config --global user.email "finopstoolkit@users.noreply.github.com"
+          git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
+          git push
+        }
+    - name: Test Open Data
+      shell: pwsh
+      run: |
+        src/scripts/Build-OpenData.ps1 -Test

--- a/.github/workflows/opendata-ci.yml
+++ b/.github/workflows/opendata-ci.yml
@@ -10,13 +10,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env: 
-      CI_COMMIT_MESSAGE: Update open data
+      CI_COMMIT_MESSAGE: Generate PowerShell commands for open data
       CI_COMMIT_AUTHOR: Open Data CI
     steps:
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.ref }}
-        token: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}
+        token: ${{ secrets.GIT_CICD_ACCESS_TOKEN }}
     - name: Set environment variable "commit-message"
       run: echo "commit-message=$(git log -1 --pretty=format:'%s')" >> $GITHUB_ENV
     - name: Set environment variable "commit-author"

--- a/.github/workflows/opendata-ci.yml
+++ b/.github/workflows/opendata-ci.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env: 
-      CI_COMMIT_MESSAGE: Open Data CI Commit
-      CI_COMMIT_AUTHOR: ${{ github.event.repository.name }} CI
+      CI_COMMIT_MESSAGE: Update open data
+      CI_COMMIT_AUTHOR: Open Data CI
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
Add workflow to trigger on updates to .csv's or .json files in the open data directory. The workflow will run Build-OpenData and commit the changes to the current branch if applicable. Then will run the opendata tests. The workflow will require a fine grained PAT for the ability to push commits.

Fixes #915, #916

## 📷 Screenshots
This workflow requires a PAT with the below permissions:
![image](https://github.com/user-attachments/assets/4b96dcdb-0449-4e95-8e8f-e3ba3a858dca)

Below image of workflow filtering correctly on paths. Initial pr only contained a .txt file in the opendata folder which did not trigger the CI.
![image](https://github.com/user-attachments/assets/8557f6cf-abdc-4582-bf00-55f23b8b046f)

Initial commit for PR: https://github.com/aromano2/finops-toolkit/pull/16/commits/2d441d3b87945e125992e57892d46963412293c0

Second commit to update a csv: https://github.com/aromano2/finops-toolkit/pull/16/commits/698868fda85bd40751edbfb0122997d816b550e6

Auto commit from workflow: https://github.com/aromano2/finops-toolkit/pull/16/commits/c07844717cad6cbc632f3064213f9ed18eede2fc

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [ ] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [ ] ❎ Docs not needed (small/internal change)
