### PR TITLE
Fix how labels are applied in Update-Version

### DIFF
--- a/src/scripts/Update-Version.ps1
+++ b/src/scripts/Update-Version.ps1
@@ -56,7 +56,7 @@ param
     [AllowNull()]
     [ValidateSet($null, '', 'dev', 'alpha', 'rc', 'preview')]
     [string]
-    $Label = 'dev',
+    $Label,
 
     [string]
     $Version
@@ -74,20 +74,21 @@ elseif ($Version)
     Write-Verbose "Updating to version $update."
 }
 
-# Determine label
-$newLabel = if (-not $Label) { "dev" } else { $Label.ToLower() -replace '[^a-z]', '' }
-if ($update -eq "prerelease")
-{
-    Write-Verbose "Using label '$newLabel'."
-}
-
 # Only update version if requested
 if ($update -or $Version)
 {
     # Update version in NPM
     Write-Verbose "Updating NPM version..."
-    $null = npm --no-git-tag-version --preid $newLabel version $update
-}
+    $null = npm --no-git-tag-version version $update
+    
+    # Update label, if needed
+    if ($Label)
+    {
+        $newLabel = $Label.ToLower() -replace '[^a-z]', ''
+        Write-Verbose "Using label '$newLabel'."
+        $null = npm --no-git-tag-version --preid $newLabel version preminor
+    }
+}    
 
 $ver = & "$PSScriptRoot/Get-Version"
 


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
Fixes an issue where the "-dev" label isn't getting applied when calling Update-Version.

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)
