### PR TITLE
fixed issue "Remove-FinOpsHub fails when there's only one resource"

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
     "ms-azuretools.vscode-bicep",
     "yzhang.markdown-all-in-one",
     "bierner.markdown-mermaid",
-    "powerquery.vscode-powerquery"
+    "powerquery.vscode-powerquery",
+    "ms-vscode.powershell"
   ]
 }

--- a/src/powershell/Private/Get-HubIdentifier.ps1
+++ b/src/powershell/Private/Get-HubIdentifier.ps1
@@ -12,33 +12,34 @@
 
     Returns the string '123456hyfpqje'.
 #>
-function Get-HubIdentifier
+function Get-HubIdentifier 
 {
-    param
-    (
+    param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string[]]
         $Collection
     )
 
+    $idPattern = '[a-z0-9]{13}'  # Matches exactly 13 alphanumeric characters
     $substrings = @()
-    foreach ($string in $Collection)
-    {
-        for ($startIndex = 0; $startIndex -lt $string.Length; $startIndex++)
-        {
-            for ($endIndex = 1; $endIndex -le ($string.Length - $startIndex); $endIndex++)
-            {
+
+    foreach ($string in $Collection) {
+        # Use regex to find valid 13-character matches
+        $match = [regex]::Matches($string, $idPattern)
+        if ($match.Count -gt 0) {
+            $substrings += $match | ForEach-Object { $_.Value }
+        }
+
+        # Generate all possible substrings
+        for ($startIndex = 0; $startIndex -lt $string.Length; $startIndex++) {
+            for ($endIndex = 1; $endIndex -le ($string.Length - $startIndex); $endIndex++) {
                 $substrings += $string.Substring($startIndex, $endIndex).ToLower()
             }
         }
     }
 
-    $id = $substrings | Group-Object | Where-Object -FilterScript {$_.count -eq $Collection.length -and $_.Name.Length -eq 13} | Select-Object -Expand 'Name'
-    if ($id -notcontains '-' -and $id -notcontains '_')
-    {
-        return $id
-    }
-
-    return $null
+    # Filter out matches that have hyphens or underscores and return the first valid match
+    $validMatches = $substrings | Group-Object | Where-Object { $_.Count -eq $Collection.Length -and $_.Name.Length -eq 13 -and $_.Name -notmatch '[-_]' } | Select-Object -ExpandProperty Name
+    return $validMatches | Select-Object -First 1
 }

--- a/src/powershell/Private/Get-HubIdentifier.ps1
+++ b/src/powershell/Private/Get-HubIdentifier.ps1
@@ -24,16 +24,20 @@ function Get-HubIdentifier
     $idPattern = '[a-z0-9]{13}'  # Matches exactly 13 alphanumeric characters
     $substrings = @()
 
-    foreach ($string in $Collection) {
+    foreach ($string in $Collection)
+    {
         # Use regex to find valid 13-character matches
         $match = [regex]::Matches($string, $idPattern)
-        if ($match.Count -gt 0) {
+        if ($match.Count -gt 0)
+        {
             $substrings += $match | ForEach-Object { $_.Value }
         }
 
         # Generate all possible substrings
-        for ($startIndex = 0; $startIndex -lt $string.Length; $startIndex++) {
-            for ($endIndex = 1; $endIndex -le ($string.Length - $startIndex); $endIndex++) {
+        for ($startIndex = 0; $startIndex -lt $string.Length; $startIndex++)
+        {
+            for ($endIndex = 1; $endIndex -le ($string.Length - $startIndex); $endIndex++)
+            {
                 $substrings += $string.Substring($startIndex, $endIndex).ToLower()
             }
         }

--- a/src/powershell/Public/Remove-FinOpsHub.ps1
+++ b/src/powershell/Public/Remove-FinOpsHub.ps1
@@ -27,7 +27,7 @@
 
     Deletes a FinOps Hub named MyHub and deletes all associated resources except the storage account.
 #>
-. "..\Private\Get-HubIdentifier.ps1"
+
 function Remove-FinOpsHub {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param (

--- a/src/powershell/Public/Remove-FinOpsHub.ps1
+++ b/src/powershell/Public/Remove-FinOpsHub.ps1
@@ -28,7 +28,8 @@
     Deletes a FinOps Hub named MyHub and deletes all associated resources except the storage account.
 #>
 
-function Remove-FinOpsHub {
+function Remove-FinOpsHub
+{
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     param (
         [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
@@ -52,25 +53,34 @@ function Remove-FinOpsHub {
     )
 
     $context = Get-AzContext
-    if (-not $context) {
+    if (-not $context)
+    {
         throw $script:LocalizedData.Common_ContextNotFound
     }
 
-    try {
-        if ($PSCmdlet.ParameterSetName -eq 'Name') {
-            if (-not [string]::IsNullOrEmpty($ResourceGroupName)) {
+    try
+    {
+        if ($PSCmdlet.ParameterSetName -eq 'Name')
+        {
+            if (-not [string]::IsNullOrEmpty($ResourceGroupName))
+            {
                 $hub = Get-FinOpsHub -Name $Name -ResourceGroupName $ResourceGroupName
-            } else {
+            }
+            else
+            {
                 $hub = Get-FinOpsHub -Name $Name
                 $ResourceGroupName = $hub.Resources[0].ResourceGroupName
             }
-        } else {
+        }
+        else
+        {
             $hub = $InputObject
             $Name = $hub.Name
             $ResourceGroupName = $hub.Resources[0].ResourceGroupName
         }
 
-        if (-not $hub) {
+        if (-not $hub)
+        {
             throw $script:LocalizedData.Hub_Remove_NotFound -f $Name
         }
 
@@ -79,23 +89,29 @@ function Remove-FinOpsHub {
         $uniqueId = Get-HubIdentifier -Collection $hub.Resources.Name
         
         $resources = Get-AzResource -ResourceGroupName $ResourceGroupName |
-            Where-Object -FilterScript { $_.Name -like "*$uniqueId*" -and ((-not $KeepStorageAccount) -or $_.ResourceType -ne "Microsoft.Storage/storageAccounts") }
-            Write-Verbose -Message "Filtered Resources: $($resources | ForEach-Object { $_.Name })"
+        Where-Object -FilterScript { $_.Name -like "*$uniqueId*" -and ((-not $KeepStorageAccount) -or $_.ResourceType -ne "Microsoft.Storage/storageAccounts") }
+        Write-Verbose -Message "Filtered Resources: $($resources | ForEach-Object { $_.Name })"
 
-        if ($null -eq $resources) {
+        if ($null -eq $resources)
+        {
             Write-Warning "No resources found to delete."
             return $false
         }
 
         Write-Verbose -Message "Resources to be deleted: $($resources | ForEach-Object { $_.Name })"
 
-        if ($PSCmdlet.ShouldProcess($Name, 'DeleteFinOpsHub')) {
+        if ($PSCmdlet.ShouldProcess($Name, 'DeleteFinOpsHub'))
+        {
             $success = $true
-            foreach ($resource in $resources) {
-                try {
+            foreach ($resource in $resources)
+            {
+                try
+                {
                     Write-Verbose -Message "Deleting resource: $($resource.Name)"
                     Remove-AzResource -ResourceId $resource.ResourceId -Force:$Force -ErrorAction Stop
-                } catch {
+                }
+                catch
+                {
                     Write-Error -Message "Failed to delete resource: $($resource.Name). Error: $_"
                     $success = $false
                 }
@@ -103,11 +119,16 @@ function Remove-FinOpsHub {
 
             return $success
         }
-    } catch {
+    }
+    catch
+    {
         Write-Error -Message "Failed to remove FinOps hub. Error: $_"
-        if ($_.Exception.InnerException) {
+        if ($_.Exception.InnerException)
+        {
             throw "Detailed Error: $($_.Exception.InnerException.Message)"
-        } else {
+        }
+        else
+        {
             throw "Detailed Error: $($_.Exception.Message)"
         }
     }

--- a/src/powershell/Public/Remove-FinOpsHub.ps1
+++ b/src/powershell/Public/Remove-FinOpsHub.ps1
@@ -22,6 +22,9 @@
     .PARAMETER KeepStorageAccount
     Optional. Indicates that the storage account associated with the FinOps Hub should be retained.
 
+    .PARAMETER Force
+    Optional. Deletes specified resources without asking for a confirmation.
+
     .EXAMPLE
     Remove-FinOpsHub -Name MyHub -ResourceGroupName MyRG -KeepStorageAccount
 
@@ -100,6 +103,13 @@ function Remove-FinOpsHub
 
         Write-Verbose -Message "Resources to be deleted: $($resources | ForEach-Object { $_.Name })"
 
+        # Temporarily set $ConfirmPreference to None if -Force is specified
+        if ($Force)
+        {
+            $originalConfirmPreference = $ConfirmPreference
+            $ConfirmPreference = 'None'
+        }
+
         if ($PSCmdlet.ShouldProcess($Name, 'DeleteFinOpsHub'))
         {
             $success = $true
@@ -115,6 +125,12 @@ function Remove-FinOpsHub
                     Write-Error -Message "Failed to delete resource: $($resource.Name). Error: $_"
                     $success = $false
                 }
+            }
+
+            # Restore the original $ConfirmPreference
+            if ($Force)
+            {
+                $ConfirmPreference = $originalConfirmPreference
             }
 
             return $success

--- a/src/powershell/Tests/Integration/Hubs.Tests.ps1
+++ b/src/powershell/Tests/Integration/Hubs.Tests.ps1
@@ -85,23 +85,25 @@ Describe 'Hubs' {
 
         Context 'Deploy and remove' {
             It 'Should deploy and remove a FinOps hubs instance' {
-                Monitor "Deploying..." {
-                    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Scope = 'Function', Target = '*')]
-                    $script:deployResult = Deploy-FinOpsHub `
-                        -Name $ftk_HubName `
-                        -Location $ftk_HubLocation `
-                        -ResourceGroupName $ftk_HubRG
-                    Report -Object ($script:deployResult ?? '(null)')
-                }
+                Monitor "Deploying latest" -Indent '   ' {
+                    Monitor "Deploying..." {
+                        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Scope = 'Function', Target = '*')]
+                        $script:deployResult = Deploy-FinOpsHub `
+                            -Name $ftk_HubName `
+                            -Location $ftk_HubLocation `
+                            -ResourceGroupName $ftk_HubRG
+                        Report -Object ($script:deployResult ?? '(null)')
+                    }
 
-                Monitor 'Getting instance...' {
-                    $script:getResult = Get-FinOpsHub -Name $ftk_HubName -ResourceGroupName $ftk_HubRG
-                    Report -Object ($script:getResult ?? '(null)')
-                }
+                    Monitor 'Getting instance...' {
+                        $script:getResult = Get-FinOpsHub -Name $ftk_HubName -ResourceGroupName $ftk_HubRG
+                        Report -Object ($script:getResult ?? '(null)')
+                    }
 
-                Monitor 'Removing instance...' {
-                    $script:removeaResult = Remove-FinOpsHub -Name $ftk_HubName -ResourceGroupName $ftk_HubRG -Force
-                    Report -Object ($script:removeResult ?? '(null)')
+                    Monitor 'Removing instance...' {
+                        $script:removeaResult = Remove-FinOpsHub -Name $ftk_HubName -ResourceGroupName $ftk_HubRG -Force
+                        Report -Object ($script:removeResult ?? '(null)')
+                    }
                 }
             }
         }

--- a/src/powershell/Tests/Integration/Hubs.Tests.ps1
+++ b/src/powershell/Tests/Integration/Hubs.Tests.ps1
@@ -5,16 +5,18 @@
 
 Describe 'Hubs' {
     BeforeDiscovery {
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
         $requiredRPs = $global:ftk_InitializeTests_Hubs_RequiredRPs
 
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
-        $versions = @('0.0.1', '0.1', '0.1.1') | Sort-Object { [version]$_ }
+        # TODO: Automatically validate the last 3 versions only
+        # TODO: Automatically validate the last 3 versions only
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+        $versions = @('0.1.1', '0.3', '0.4', '0.5') | Sort-Object { [version]$_ }
     }
 
     BeforeAll {
         # Must be duplicated because pre-discovery vars aren't accessible
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
         $requiredRPs = $global:ftk_InitializeTests_Hubs_RequiredRPs
     }
 
@@ -37,16 +39,16 @@ Describe 'Hubs' {
     Context 'Deploy-FinOpsHub' {
         BeforeAll {
             # Arrange
-            [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
             $ftk_ResourceGroup = "ftk-test-integration"
-            [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
-            $name = "ftk-test-DeployHub_$($env:USERNAME)"
-            [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
-            $rg = "ftk-test-integration"
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+            $ftk_HubName = "ftk-test-DeployHub_$($env:USERNAME)"
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+            $ftk_HubRG = "ftk-test-integration"
             # TODO: Confirm lowercase/space requirement and add handling to avoid the limitation
-            [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
-            $location = "eastus" # must be lowercase with no spaces
-            [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+            $ftk_HubLocation = "eastus" # must be lowercase with no spaces
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
             $versions = Get-FinOpsToolkitVersion | Select-Object -ExpandProperty Version -Unique | Sort-Object { $_ }
         }
 
@@ -81,6 +83,29 @@ Describe 'Hubs' {
             }
         }
 
+        Context 'Deploy and remove' {
+            It 'Should deploy and remove a FinOps hubs instance' {
+                Monitor "Deploying..." {
+                    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '', Scope = 'Function', Target = '*')]
+                    $script:deployResult = Deploy-FinOpsHub `
+                        -Name $ftk_HubName `
+                        -Location $ftk_HubLocation `
+                        -ResourceGroupName $ftk_HubRG
+                    Report -Object ($script:deployResult ?? '(null)')
+                }
+
+                Monitor 'Getting instance...' {
+                    $script:getResult = Get-FinOpsHub -Name $ftk_HubName -ResourceGroupName $ftk_HubRG
+                    Report -Object ($script:getResult ?? '(null)')
+                }
+
+                Monitor 'Removing instance...' {
+                    $script:removeaResult = Remove-FinOpsHub -Name $ftk_HubName -ResourceGroupName $ftk_HubRG -Force
+                    Report -Object ($script:removeResult ?? '(null)')
+                }
+            }
+        }
+
         Context 'Deploy and upgrade' -Skip {
             It 'Should deploy FinOps hubs <_>' -ForEach $versions {
                 $ver = $_
@@ -88,18 +113,23 @@ Describe 'Hubs' {
                 # Act
                 Monitor "FinOps hubs $ver" -Indent '   ' {
                     Monitor "Deploying..." {
-                        [Diagnostics.CodeAnalysis.SuppressMessageAttribute ('PSUseDeclaredVarsMoreThanAssignments', Scope = 'Function', Target = '*')]
+                        [Diagnostics.CodeAnalysis.SuppressMessageAttribute ('PSUseDeclaredVarsMoreThanAssignments', '', Scope = 'Function', Target = '*')]
                         $script:deployResult = Deploy-FinOpsHub `
-                            -Name $name `
-                            -Location $location `
-                            -ResourceGroupName $rg `
+                            -Name $ftk_HubName `
+                            -Location $ftk_HubLocation `
+                            -ResourceGroupName $ftk_HubRG `
                             -Version $_
                         Report -Object ($script:deployResult ?? '(null)')
                     }
 
                     Monitor 'Getting instance...' {
-                        $script:getResult = Get-FinOpsHub -Name $name -ResourceGroupName $rg
+                        $script:getResult = Get-FinOpsHub -Name $ftk_HubName -ResourceGroupName $ftk_HubRG
                         Report -Object ($script:getResult ?? '(null)')
+                    }
+
+                    Monitor 'Removing instance...' {
+                        $script:removeResult = Remove-FinOpsHub -Name $ftk_HubName -ResourceGroupName $ftk_HubRG -Force
+                        Report -Object ($script:removeResult ?? '(null)')
                     }
                 }
 
@@ -111,8 +141,8 @@ Describe 'Hubs' {
                 }
 
                 # Assert hub state
-                @($script:getResult).Count | Should -Be 1 -ErrorAction Continue -Because "there should only be one hub with name '$name' in resource group '$rg' (v$ver)"
-                $script:getResult.Location.ToLower() -replace ' ', '' | Should -Be $location -ErrorAction Continue -Because "hub should be in location '$location' (v$ver)"
+                @($script:getResult).Count | Should -Be 1 -ErrorAction Continue -Because "there should only be one hub with name '$ftk_HubName' in resource group '$ftk_HubRG' (v$ver)"
+                $script:getResult.Location.ToLower() -replace ' ', '' | Should -Be $ftk_HubLocation -ErrorAction Continue -Because "hub should be in location '$ftk_HubLocation' (v$ver)"
                 $script:getResult.Version | Should -Be $ver -ErrorAction Continue
                 $script:getResult.Status | Should -Be 'Deployed' -ErrorAction Continue -Because "hub should be in 'Deployed' status (v$ver)"
                 $script:getResult.Status | Should -Not -Be 'Unknown' -ErrorAction Continue -Because "hub should not be in 'Unknown' status (v$ver)"


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
<!-- TODO: Summarize the changes with context and motivation -->

### Get-HubIdentifier.ps1:
I optimized the logic to directly extract a valid 13-character alphanumeric string and improve efficiency. The current method generates substrings unnecessarily (tested it with Verbose Output), slowing down performance and producing irrelevant results.
Regex Matching: Uses a regular expression to directly extract 13-character alphanumeric strings, removing the need for substring generation.
Excludes Special Characters: Filters out matches with hyphens or underscores to ensure a clean identifier.
Efficiency: Processes each string once, significantly improving performance for large collections.

### Remove-FinOpsHub.ps1
This PR simplifies the Remove-FinOpsHub logic by replacing the .Reduce() method with a more sequential foreach loop for deleting resources. It improves error handling, ensuring each resource deletion attempt is properly logged and handled individually. The script now includes clearer verbose messages for filtered resources, deletion attempts, and success statuses. These changes provide better transparency and avoid potential issues caused by parallel deletion, making the script more predictable and easier to debug. 

Fixes # <!-- TODO: Add related issues (e.g., Fixes #123, #246, #369) -->
#554
## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [X] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [X] 👍 Manually deployed + verified
> - [X] 💪 Unit tests
> - [x] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [ ] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [ ] ❎ Docs not needed (small/internal change)
