### PR TITLE
[HUBs] Docu - Update manual export configuration parameters

### DIFF
--- a/docs/_reporting/hubs/configure-scopes.md
+++ b/docs/_reporting/hubs/configure-scopes.md
@@ -49,6 +49,8 @@ If you cannot grant permissions for your scope, you can create Cost Management e
    - **Overwrite data** = Off<sup>4</sup>
    - **Storage account** = (Use subscription/resource deployed with your hub)
    - **Container** = `msexports`
+   - **Format** = `CSV`
+   - **Compression Type** = `none`
    - **Directory** = (Specify a unique path for this scope<sup>5</sup>)
      - _**EA billing account:** `billingAccounts/{enrollment-number}`_
      - _**MCA billing profile:** `billingProfiles/{billing-profile-id}`_


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
<!-- TODO: Summarize the changes with context and motivation -->
In the latest UI of Cost Management export dataset function, there are additional configuration parameters. Added the following parameters to the export process, for clarity: 

- Format -> CSV
- Compression Type -> none 
 
Note: The data format of "Parquet" was originally not supported from the Hubs ADF pipelines.  This was to change with [PR No 951](https://github.com/microsoft/finops-toolkit/pull/951) added support for compressed exports from Cost management 

Fixes # <!-- TODO: Add related issues (e.g., Fixes #123, #246, #369) -->

## 📷 Screenshots
<!-- TODO: Add screenshots of the new experience or remove section if not applicable -->
<img width="757" alt="image" src="https://github.com/user-attachments/assets/9bd33659-c093-4d0a-b4e2-87d8e1869c52">

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ x] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [ ] ❎ Docs not needed (small/internal change)
