### PR TITLE
InstanceFlexibilityRatio should be type Decimal

### DIFF
--- a/src/templates/finops-hub/schemas/reservationdetails_2023-03-01.json
+++ b/src/templates/finops-hub/schemas/reservationdetails_2023-03-01.json
@@ -8,7 +8,7 @@
         "sink": { "name": "InstanceFlexibilityGroup" }
       },
       {
-        "source": { "name": "InstanceFlexibilityRatio", "type": "Ratio" },
+        "source": { "name": "InstanceFlexibilityRatio", "type": "Decimal" },
         "sink": { "name": "InstanceFlexibilityRatio" }
       },
       {


### PR DESCRIPTION
## 🛠️ Description
<!-- TODO: Summarize the changes with context and motivation -->

Data type of "InstanceFlexibilityRatio " is "ratio" rather than "decimal", causing the pipeline to fail when converting to parquet.

## 📷 Screenshots
<!-- TODO: Add screenshots of the new experience or remove section if not applicable -->

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [x] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)
