### PR TITLE
Move delay to nested pipeline to avoid blocking when ingesting into ADX.

### DIFF
--- a/src/templates/finops-hub/modules/dataFactory.bicep
+++ b/src/templates/finops-hub/modules/dataFactory.bicep
@@ -3895,7 +3895,6 @@ resource pipeline_ToDataExplorer 'Microsoft.DataFactory/factories/pipelines@2018
   name: '${safeIngestionContainerName}_ETL_dataExplorer'
   parent: dataFactory
   properties: {
-    concurrency: 8 // Sane default for so we don't pay for compute execution time on ingestion jobs queued up in ADX.
     activities: [
       { // Wait
         name: 'Wait'

--- a/src/templates/finops-hub/modules/dataFactory.bicep
+++ b/src/templates/finops-hub/modules/dataFactory.bicep
@@ -3895,6 +3895,7 @@ resource pipeline_ToDataExplorer 'Microsoft.DataFactory/factories/pipelines@2018
   name: '${safeIngestionContainerName}_ETL_dataExplorer'
   parent: dataFactory
   properties: {
+    concurrency: 8 // Sane default for so we don't pay for compute execution time on ingestion jobs queued up in ADX.
     activities: [
       { // Wait
         name: 'Wait'

--- a/src/templates/finops-hub/modules/dataFactory.bicep
+++ b/src/templates/finops-hub/modules/dataFactory.bicep
@@ -3797,16 +3797,6 @@ resource pipeline_ExecuteIngestionETL 'Microsoft.DataFactory/factories/pipelines
   parent: dataFactory
   properties: {
     activities: [
-      { // Wait
-        name: 'Wait'
-        description: 'Files may not be available immediately after being created.'
-        type: 'Wait'
-        dependsOn: []
-        userProperties: []
-        typeProperties: {
-          waitTimeInSeconds: 60
-        }
-      }
       { // Set Container Folder Path
         name: 'Set Container Folder Path'
         type: 'SetVariable'
@@ -3829,12 +3819,6 @@ resource pipeline_ExecuteIngestionETL 'Microsoft.DataFactory/factories/pipelines
         description: 'Run the ADX ETL pipeline.'
         type: 'ExecutePipeline'
         dependsOn: [
-          {
-            activity: 'Wait'
-            dependencyConditions: [
-              'Succeeded'
-            ]
-          }
           {
             activity: 'Set Container Folder Path'
             dependencyConditions: [
@@ -3912,10 +3896,27 @@ resource pipeline_ToDataExplorer 'Microsoft.DataFactory/factories/pipelines@2018
   parent: dataFactory
   properties: {
     activities: [
+      { // Wait
+        name: 'Wait'
+        description: 'Files may not be available immediately after being created.'
+        type: 'Wait'
+        dependsOn: []
+        userProperties: []
+        typeProperties: {
+          waitTimeInSeconds: 60
+        }
+      }
       { // Read Column Names
         name: 'Read Column Names'
         type: 'Lookup'
-        dependsOn: []
+        dependsOn: [
+          {
+            activity: 'Wait'
+            dependencyConditions: [
+              'Succeeded'
+            ]
+          }
+        ]
         policy: {
           timeout: '0.12:00:00'
           retry: 0
@@ -4011,7 +4012,14 @@ resource pipeline_ToDataExplorer 'Microsoft.DataFactory/factories/pipelines@2018
         name: 'Read Hub Config'
         description: 'Read the hub config to determine how long data should be retained.'
         type: 'Lookup'
-        dependsOn: []
+        dependsOn: [
+          {
+            activity: 'Wait'
+            dependencyConditions: [
+              'Succeeded'
+            ]
+          }
+        ]
         policy: {
           timeout: '0.12:00:00'
           retry: 0


### PR DESCRIPTION
## 🛠️ Description
Moves the wait activity to the nested pipeline to avoid blocking on the calling pipeline.
The calling pipeline should exit as quickly as possible to avoid hitting the hard limit of 100 concurrent triggered pipelines.

## 📷 Screenshots
<!-- TODO: Add screenshots of the new experience or remove section if not applicable -->

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [X] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [X] 👍 Manually deployed + verified
> - [X] 💪 Unit tests
> - [X] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [ ] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [X] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [X] ❎ Docs not needed (small/internal change)
