### PR TITLE
Set the commitment discount service to Compute for savings plans

### DIFF
--- a/src/power-bi/kql/RateOptimization.SemanticModel/definition/tables/CommitmentDiscountCosts.tmdl
+++ b/src/power-bi/kql/RateOptimization.SemanticModel/definition/tables/CommitmentDiscountCosts.tmdl
@@ -434,6 +434,14 @@ table CommitmentDiscountCosts
 
 		annotation SummarizationSetBy = Automatic
 
+	column ProviderName
+		dataType: string
+		lineageTag: 0abfa1f2-8fad-480d-91af-3af2dc7b9804
+		summarizeBy: none
+		sourceColumn: ProviderName
+
+		annotation SummarizationSetBy = Automatic
+
 	partition CommitmentDiscountCosts = m
 		mode: import
 		queryGroup: 'Data Explorer'
@@ -555,12 +563,17 @@ table CommitmentDiscountCosts
 				        PricingCategory,
 				        PricingQuantity,
 				        PricingUnit,
+				        ProviderName,
 				        RegionName,
 				        SubAccountId,
 				        SubAccountName,
 				        x_CommitmentDiscountKey,
-				        x_CommitmentDiscountServiceCategory = iff(isempty(x_CommitmentDiscountServiceCategory), 'Other', x_CommitmentDiscountServiceCategory),
-				        x_CommitmentDiscountServiceName,
+				        x_CommitmentDiscountServiceCategory = case(
+				            ProviderName == 'Microsoft' and CommitmentDiscountCategory == 'Spend', 'Compute',
+				            isempty(x_CommitmentDiscountServiceCategory), 'Other',
+				            x_CommitmentDiscountServiceCategory
+				        ),
+				        x_CommitmentDiscountServiceName = iff(ProviderName == 'Microsoft' and CommitmentDiscountCategory == 'Spend', 'Compute', x_CommitmentDiscountServiceName),
 				        x_CommitmentDiscountUtilizationAmount,
 				        x_CommitmentDiscountUtilizationPotential,
 				        x_ChargePeriodMonth,


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
Set the commitment discount service to Compute for savings plans

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)
