### PR TITLE
Fix EffectiveCost is 0 for storage reports

### DIFF
--- a/src/power-bi/storage/Shared.Dataset/definition/tables/CostDetails.tmdl
+++ b/src/power-bi/storage/Shared.Dataset/definition/tables/CostDetails.tmdl
@@ -1399,7 +1399,7 @@ table CostDetails
 				            0.0, each if Text.Contains([x_SourceChanges], "MissingListCost")            then null else [ListCost],            Replacer.ReplaceValue, {"ListCost"}),
 				            0.0, each if Text.Contains([x_SourceChanges], "MissingListUnitPrice")       then null else [ListUnitPrice],       Replacer.ReplaceValue, {"ListUnitPrice"}),
 				            // Fix savings plan purchases
-				            each [EffectiveCost], each if [ChargeCategory] = "Purchase" and ([CommitmentDiscountId] = "" or [CommitmentDiscountId] = null) then [EffectiveCost] else 0.0, Replacer.ReplaceValue, {"EffectiveCost"}),
+				            each [EffectiveCost], each if [ChargeCategory] = "Purchase" and [CommitmentDiscountId] <> "" and [CommitmentDiscountId] <> null then 0.0 else [EffectiveCost], Replacer.ReplaceValue, {"EffectiveCost"}),
 				            // Fix inconsistent Microsoft x_SkuTerm values
 				            "1Year",  12, Replacer.ReplaceValue, {"x_SkuTerm"}),
 				            "3Years", 36, Replacer.ReplaceValue, {"x_SkuTerm"}),


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
The EffectiveCost fix for savings plan purchases was not accounting for usage data and incorrectly set all usage to 0.

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [x] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)
