### PR TITLE
Do not deploy network components when public access is selected.

### DIFF
--- a/docs/_resources/changelog.md
+++ b/docs/_resources/changelog.md
@@ -103,12 +103,15 @@ Legend:
 >
 > 1. Cost Management export modules for subscriptions and resource groups.
 >
+
 🏦 FinOps hubs
 {: .fs-5 .fw-500 .mt-4 mb-0 }
-> 🛠️ Fixed:
+
+> ✏️ Changed:
 >
-> 1. No longer deploys network components when enablePublicAccess is set to true.  When set to false a vNet will be created along with the required private endpoints and DNS zones for Hubs to function in a fully private manner.
->
+> 1. Changed the **enablePublicAccess** parameter to exclude network components.
+>    - When disabled, a VNet will be created along with the required private endpoints and DNS zones to function in a fully private manner.
+
 <br><a name="latest"></a>
 
 ## 🪛 v0.7 Update 1

--- a/docs/_resources/changelog.md
+++ b/docs/_resources/changelog.md
@@ -103,7 +103,12 @@ Legend:
 >
 > 1. Cost Management export modules for subscriptions and resource groups.
 >
-
+🏦 FinOps hubs
+{: .fs-5 .fw-500 .mt-4 mb-0 }
+> 🛠️ Fixed:
+>
+> 1. No longer deploys network components when enablePublicAccess is set to true.  When set to false a vNet will be created along with the required private endpoints and DNS zones for Hubs to function in a fully private manner.
+>
 <br><a name="latest"></a>
 
 ## 🪛 v0.7 Update 1

--- a/src/templates/finops-hub/modules/dataExplorer.bicep
+++ b/src/templates/finops-hub/modules/dataExplorer.bicep
@@ -340,7 +340,7 @@ resource clusterStorageAccess 'Microsoft.Authorization/roleAssignments@2022-04-0
 }
 
 // DNS zone
-resource dataExplorerPrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
+resource dataExplorerPrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = if (!enablePublicAccess) {
   name: dataExplorerPrivateDnsZoneName
   location: 'global'
   tags: union(tags, contains(tagsByResource, 'Microsoft.Network/privateDnsZones') ? tagsByResource['Microsoft.Network/privateDnsZones'] : {})
@@ -348,7 +348,7 @@ resource dataExplorerPrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-0
 }
 
 // Link DNS zone to VNet
-resource dataExplorerPrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = {
+resource dataExplorerPrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = if (!enablePublicAccess) {
   name: '${replace(dataExplorerPrivateDnsZone.name, '.', '-')}-link'
   location: 'global'
   parent: dataExplorerPrivateDnsZone
@@ -362,7 +362,7 @@ resource dataExplorerPrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtu
 }
 
 // Private endpoint
-resource dataExplorerEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
+resource dataExplorerEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = if (!enablePublicAccess) {
   name: '${cluster.name}-ep'
   location: location
   tags: union(tags, contains(tagsByResource, 'Microsoft.Network/privateEndpoints') ? tagsByResource['Microsoft.Network/privateEndpoints'] : {})
@@ -383,7 +383,7 @@ resource dataExplorerEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = 
 }
 
 // DNS records for private endpoint
-resource dataExplorerPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = {
+resource dataExplorerPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = if (!enablePublicAccess) {
   name: 'dataExplorer-endpoint-zone'
   parent: dataExplorerEndpoint
   properties: {

--- a/src/templates/finops-hub/modules/keyVault.bicep
+++ b/src/templates/finops-hub/modules/keyVault.bicep
@@ -40,6 +40,9 @@ param virtualNetworkId string
 @description('Required. Resource ID of the subnet for private endpoints.')
 param privateEndpointSubnetId string
 
+@description('Optional. Enable public access to the data lake.  Default: false.')
+param enablePublicAccess bool
+
 //------------------------------------------------------------------------------
 // Variables
 //------------------------------------------------------------------------------
@@ -83,8 +86,8 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-02-01' = {
     }
     networkAcls: {
       bypass: 'AzureServices'
-      defaultAction: 'Deny'
-  }
+      defaultAction: enablePublicAccess ? 'Allow' : 'Deny'
+    }
   }
 }
 
@@ -109,14 +112,14 @@ resource keyVault_secret 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = if (!e
   }
 }
 
-resource keyVaultPrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
+resource keyVaultPrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = if (!enablePublicAccess) {
   name: keyVaultPrivateDnsZoneName
   location: 'global'
   tags: union(tags, contains(tagsByResource, 'Microsoft.KeyVault/privateDnsZones') ? tagsByResource['Microsoft.KeyVault/privateDnsZones'] : {})
   properties: {}
 }
 
-resource keyVaultPrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = {
+resource keyVaultPrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = if (!enablePublicAccess) {
   name: '${replace(keyVaultPrivateDnsZone.name, '.', '-')}-link'
   location: 'global'
   parent: keyVaultPrivateDnsZone
@@ -129,7 +132,7 @@ resource keyVaultPrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNe
   }
 }
 
-resource keyVaultEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
+resource keyVaultEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = if (!enablePublicAccess) {
   name: '${keyVault.name}-ep'
   location: location
   tags: union(tags, contains(tagsByResource, 'Microsoft.Network/privateEndpoints') ? tagsByResource['Microsoft.Network/privateEndpoints'] : {})
@@ -149,7 +152,7 @@ resource keyVaultEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
   }
 }
 
-resource keyVaultPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = {
+resource keyVaultPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = if (!enablePublicAccess) {
   name: 'keyvault-endpoint-zone'
   parent: keyVaultEndpoint
   properties: {

--- a/src/templates/finops-hub/modules/storage.bicep
+++ b/src/templates/finops-hub/modules/storage.bicep
@@ -120,7 +120,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   })
 }
 
-resource scriptStorageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' =  {
+resource scriptStorageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' =  if (!enablePublicAccess){
   name: scriptStorageAccountName
   location: location
   sku: {
@@ -148,35 +148,35 @@ resource scriptStorageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' =  
   }
 }
 
-resource blobPrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
+resource blobPrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = if (!enablePublicAccess) {
   name: 'privatelink.blob.${environment().suffixes.storage}'
   location: 'global'
   tags: union(tags, contains(tagsByResource, 'Microsoft.Storage/privateDnsZones') ? tagsByResource['Microsoft.Storage/privateDnsZones'] : {})
   properties: {}
 }
 
-resource dfsPrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
+resource dfsPrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = if (!enablePublicAccess) {
   name: 'privatelink.dfs.${environment().suffixes.storage}'
   location: 'global'
   tags: union(tags, contains(tagsByResource, 'Microsoft.Storage/privateDnsZones') ? tagsByResource['Microsoft.Storage/privateDnsZones'] : {})
   properties: {}
 }
 
-resource queuePrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
+resource queuePrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = if (!enablePublicAccess) {
   name: 'privatelink.queue.${environment().suffixes.storage}'
   location: 'global'
   tags: union(tags, contains(tagsByResource, 'Microsoft.Storage/privateDnsZones') ? tagsByResource['Microsoft.Storage/privateDnsZones'] : {})
   properties: {}
 }
 
-resource tablePrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = {
+resource tablePrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = if (!enablePublicAccess) {
   name: 'privatelink.table.${environment().suffixes.storage}'
   location: 'global'
   tags: union(tags, contains(tagsByResource, 'Microsoft.Storage/privateDnsZones') ? tagsByResource['Microsoft.Storage/privateDnsZones'] : {})
   properties: {}
 }
 
-resource blobPrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = {
+resource blobPrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = if (!enablePublicAccess) {
   parent: blobPrivateDnsZone
   name: '${replace(blobPrivateDnsZone.name, '.', '-')}-link'
   location: 'global'
@@ -189,7 +189,7 @@ resource blobPrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetwor
   }
 }
 
-resource dfsPrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = {
+resource dfsPrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = if (!enablePublicAccess) {
   parent: dfsPrivateDnsZone
   name: '${replace(dfsPrivateDnsZone.name, '.', '-')}-link'
   location: 'global'
@@ -202,7 +202,7 @@ resource dfsPrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetwork
   }
 }
 
-resource queuePrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = {
+resource queuePrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = if (!enablePublicAccess) {
   parent: queuePrivateDnsZone
   name: '${replace(queuePrivateDnsZone.name, '.', '-')}-link'
   location: 'global'
@@ -215,7 +215,7 @@ resource queuePrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetwo
   }
 }
 
-resource tablePrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = {
+resource tablePrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = if (!enablePublicAccess) {
   parent: tablePrivateDnsZone
   name: '${replace(tablePrivateDnsZone.name, '.', '-')}-link'
   location: 'global'
@@ -228,7 +228,7 @@ resource tablePrivateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetwo
   }
 }
 
-resource blobEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
+resource blobEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = if (!enablePublicAccess) {
   name: '${storageAccount.name}-blob-ep'
   location: location
   tags: union(tags, contains(tagsByResource, 'Microsoft.Network/privateEndpoints') ? tagsByResource['Microsoft.Network/privateEndpoints'] : {})
@@ -248,7 +248,7 @@ resource blobEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
   }
 }
 
-resource scriptEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
+resource scriptEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = if (!enablePublicAccess) {
   name: '${scriptStorageAccount.name}-blob-ep'
   location: location
   tags: union(tags, contains(tagsByResource, 'Microsoft.Network/privateEndpoints') ? tagsByResource['Microsoft.Network/privateEndpoints'] : {})
@@ -268,7 +268,7 @@ resource scriptEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
   }
 }
 
-resource dfsEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
+resource dfsEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = if (!enablePublicAccess) {
   name: '${storageAccount.name}-dfs-ep'
   location: location
   tags: union(tags, contains(tagsByResource, 'Microsoft.Network/privateEndpoints') ? tagsByResource['Microsoft.Network/privateEndpoints'] : {})
@@ -288,7 +288,7 @@ resource dfsEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = {
   }
 }
 
-resource blobPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = {
+resource blobPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = if (!enablePublicAccess) {
   name: 'storage-endpoint-zone'
   parent: blobEndpoint
   properties: {
@@ -303,7 +303,7 @@ resource blobPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZ
   }
 }
 
-resource dfsPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = {
+resource dfsPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = if (!enablePublicAccess) {
   name: 'dfs-endpoint-zone'
   parent: dfsEndpoint
   properties: {
@@ -318,7 +318,7 @@ resource dfsPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZo
   }
 }
 
-resource scriptPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = {
+resource scriptPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01' = if (!enablePublicAccess) {
   name: 'blob-endpoint-zone'
   parent: scriptEndpoint
   properties: {
@@ -411,7 +411,19 @@ resource uploadSettings 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
     scriptEndpoint
     scriptPrivateDnsZoneGroup
   ]
-  properties: {
+  properties: union(enablePublicAccess ? {} : {
+    storageAccountSettings: {
+      storageAccountName: scriptStorageAccount.name
+    }
+    containerSettings: {
+      containerGroupName: '${scriptStorageAccount.name}cg'
+      subnetIds: [
+        {
+          id: scriptSubnetId
+        }
+      ]
+    }
+  }, {
     azPowerShellVersion: '9.0'
     retentionInterval: 'PT1H'
     environmentVariables: [
@@ -453,19 +465,7 @@ resource uploadSettings 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
       }
     ]
     scriptContent: loadTextContent('./scripts/Copy-FileToAzureBlob.ps1')
-    storageAccountSettings: {
-      storageAccountName: scriptStorageAccount.name
-      //storageAccountKey: storageAccount.listKeys().keys[0].value
-    }
-    containerSettings: {
-      containerGroupName: '${scriptStorageAccount.name}cg'
-      subnetIds: [
-        {
-          id: scriptSubnetId
-        }
-      ]
-    }
-  }
+  })
 }
 
 //==============================================================================


### PR DESCRIPTION
## 🛠️ Description
When enablePublicAccess = true, the network components should not be deployed - private endpoints, private DNS zones, and the VNet itself.

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [X] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [X] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [ ] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [x] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)
