### PR TITLE
Update Deploy-FinOpsHub.ps1

### DIFF
--- a/src/powershell/Public/Deploy-FinOpsHub.ps1
+++ b/src/powershell/Public/Deploy-FinOpsHub.ps1
@@ -211,7 +211,7 @@ function Deploy-FinOpsHub
             
             if ($Version -eq 'latest' -or [version]$Version -ge '0.7')
             {
-                $parameterSplat.TemplateParameterObject.Add('enableInfrastructureEncryption', $EnableInfrastructureEncryption)
+                $parameterSplat.TemplateParameterObject.Add('enableInfrastructureEncryption', $EnableInfrastructureEncryption.IsPresent)
                 $parameterSplat.TemplateParameterObject.Add('dataExplorerName', $DataExplorerName)
                 $parameterSplat.TemplateParameterObject.Add('dataExplorerSku', $DataExplorerSku)
                 $parameterSplat.TemplateParameterObject.Add('dataExplorerCapacity', $DataExplorerCapacity)


### PR DESCRIPTION
when expressing a [switch] parameter as a boolean in a hashtable you need to express the .IsPresent property.

enableInfrastructureEncryption was being parsed as an object rather than a boolean causing the error:

Error: Code=InvalidTemplate; Message=Deployment template validation failed: 'The provided value for the template parameter 'enableInfrastructureEncryption' is not valid. Expected a value of type 'Boolean', but received a value of type 'Object'.

<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
<!-- TODO: Summarize the changes with context and motivation -->

Fixes # <!-- TODO: Add related issues (e.g., Fixes #123, #246, #369) -->

## 📷 Screenshots
<!-- TODO: Add screenshots of the new experience or remove section if not applicable -->

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)
