### PR TITLE
Update Key Vault to Support Delete Protection

### DIFF
--- a/src/templates/finops-hub/modules/keyVault.bicep
+++ b/src/templates/finops-hub/modules/keyVault.bicep
@@ -77,6 +77,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-02-01' = {
     enableSoftDelete: true
     softDeleteRetentionInDays: 90
     enableRbacAuthorization: false
+    enablePurgeProtection: true
     createMode: 'default'
     tenantId: subscription().tenantId
     accessPolicies: formattedAccessPolicies


### PR DESCRIPTION
To be compliant with Enterprise scale policy implementation adding enabling purge protection as true to the keyvault being deployed.  Mentioned in the issue here https://github.com/microsoft/finops-toolkit/issues/1067

<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
<!-- TODO: Summarize the changes with context and motivation -->
Property specifying whether protection against purge is enabled for this vault. Setting this property to true activates protection against purge for this vault and its content - only the Key Vault service may initiate a hard, irrecoverable deletion. 

Fixes # <!-- TODO: Add related issues (e.g., Fixes #123, #246, #369) -->

## 📷 Screenshots
<!-- TODO: Add screenshots of the new experience or remove section if not applicable -->

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)
