### PR TITLE
[AOE] Fix issues with tag duplicates (case sensitive) after tag inheritance

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -28,6 +28,11 @@ The following section lists features and enhancements that are currently in deve
 
 - Cost Management export modules for subscriptions and resource groups.
 
+### Optimization engine
+
+- **Fixed**
+  - Fixed issue with breaking storage account recommendations when resource tags are duplicated after tag inheritance  ([#1430](https://github.com/microsoft/finops-toolkit/issues/1430)).
+
 <br><a name="latest"></a>
 
 ## v0.9

--- a/src/optimization-engine/runbooks/recommendations/Recommend-StorageAccountOptimizationsToBlobStorage.ps1
+++ b/src/optimization-engine/runbooks/recommendations/Recommend-StorageAccountOptimizationsToBlobStorage.ps1
@@ -187,7 +187,7 @@ let StorageAccountsWithLastTags = $consumptionTableName
 | where todatetime(Date_s) between (lastday_stime..etime)
 | where MeterCategory_s == 'Storage' and ConsumedService_s == 'Microsoft.Storage' and MeterName_s endswith 'Data Stored' and ChargeType_s == 'Usage'
 | extend ResourceId = tolower(ResourceId)
-| distinct ResourceId, Tags_s;
+| summarize arg_max(todatetime(Date_s), Tags_s) by ResourceId;
 $consumptionTableName
 | where todatetime(Date_s) between (stime..etime)
 | where MeterCategory_s == 'Storage' and ConsumedService_s == 'Microsoft.Storage' and MeterName_s endswith 'Data Stored' and ChargeType_s == 'Usage'
@@ -204,6 +204,8 @@ $consumptionTableName
     | where ContainerType_s =~ 'microsoft.resources/subscriptions' 
     | project SubscriptionId=SubscriptionGuid_g, SubscriptionName = ContainerName_s 
 ) on SubscriptionId
+| extend Tags_s = iif(Tags_s !startswith "{", strcat('{', Tags_s, '}'), Tags_s)
+| extend Tags_s = parse_json(tolower(Tags_s))
 "@
 
 try


### PR DESCRIPTION
## 🛠️ Description

The `Recommend-StorageAccountOptimizationsToBlobStorage` runbook breaks when tag inheritance is enabled and billed resources inherit tags from resource groups and/or subscriptions that (case sensitive) duplicate resource tags.

Problem is solved by removing tag duplicates in the Log Analytics query, before parsing tags in PowerShell.

Fixes #1430 

## 📋 Checklist

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [X] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [X] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [X] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [X] ❎ Docs not needed (small/internal change)
