### PR TITLE
Track hubs deployment options

### DIFF
--- a/docs/deploy/finops-alerts-0.9.json
+++ b/docs/deploy/finops-alerts-0.9.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "16996831884074690489"
+      "templateHash": "12802525131637595090"
     }
   },
   "parameters": {
@@ -97,7 +97,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "14296692176899339374"
+              "templateHash": "10854342800064359748"
             }
           },
           "parameters": {
@@ -3654,7 +3654,7 @@
                         "body": {
                           "To": "@variables('SendAlertTo')",
                           "Subject": "@variables('SetEmailSubject')",
-                          "Body": "<p class=\"editor-paragraph\">@{variables('EmailNotice')}</p><p class=\"editor-paragraph\">@{variables('AppGatewayHTML')}<br>@{variables('IdleDiskHTML')}<br>@{variables('IPAddressHTML')}<br>@{variables('LoadBalancerHTML')}<br>@{variables('DiskSnapshotHTML')}<br>@{variables('StoppedVMHTML')}</p><br><h1 class=\"editor-heading-h1\"><b><strong class=\"editor-text-bold\">📧 </strong></b><b><strong class=\"editor-text-bold\" style=\"font-size: 20px;\">About FinOps alerts</strong></b></h1><p class=\"editor-paragraph\">FinOps alerts keep you informed about cost optimization opportunities within in your cloud environment. They are fully configurable and can be tailored to run on your desired schedule, ensuring that you receive timely notifications on the scenarios most important to your organization. FinOps alerts are part of the FinOps toolkit, an open-source collection of FinOps solutions that help you manage and optimize your cost, usage, and carbon.</p><h1 class=\"editor-heading-h1\"><b><strong class=\"editor-text-bold\" style=\"font-size: 20px;\">Provide feedback</strong></b></h1><p class=\"editor-paragraph\"><a href=\"https://portal.azure.com/#view/HubsExtension/InProductFeedbackBlade/extensionName/FinOpsToolkit/cesQuestion/How%20easy%20or%20hard%20is%20it%20to%20use%20FinOps%20alerts%3F/cvaQuestion/How%20valuable%20are%20FinOps%20alerts%3F/surveyId/FTK0.8/bladeName/Alerts/featureName/Email\" class=\"editor-link\"><u><span class=\"editor-text-underline\">Give feedback</span></u></a><br><a href=\"https://github.com/microsoft/finops-toolkit/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22Tool%3A%20FinOps%20alerts%22%20sort%3Areactions-%2B1-desc\" class=\"editor-link\"><u><span class=\"editor-text-underline\">Vote on or suggest ideas</span></u></a></p><br>"
+                          "Body": "<p class=\"editor-paragraph\">@{variables('EmailNotice')}</p><p class=\"editor-paragraph\">@{variables('AppGatewayHTML')}<br>@{variables('IdleDiskHTML')}<br>@{variables('IPAddressHTML')}<br>@{variables('LoadBalancerHTML')}<br>@{variables('DiskSnapshotHTML')}<br>@{variables('StoppedVMHTML')}</p><br><h1 class=\"editor-heading-h1\"><b><strong class=\"editor-text-bold\">📧 </strong></b><b><strong class=\"editor-text-bold\" style=\"font-size: 20px;\">About FinOps alerts</strong></b></h1><p class=\"editor-paragraph\">FinOps alerts keep you informed about cost optimization opportunities within in your cloud environment. They are fully configurable and can be tailored to run on your desired schedule, ensuring that you receive timely notifications on the scenarios most important to your organization. FinOps alerts are part of the FinOps toolkit, an open-source collection of FinOps solutions that help you manage and optimize your cost, usage, and carbon.</p><h1 class=\"editor-heading-h1\"><b><strong class=\"editor-text-bold\" style=\"font-size: 20px;\">Provide feedback</strong></b></h1><p class=\"editor-paragraph\"><a href=\"https://portal.azure.com/#view/HubsExtension/InProductFeedbackBlade/extensionName/FinOpsToolkit/cesQuestion/How%20easy%20or%20hard%20is%20it%20to%20use%20FinOps%20alerts%3F/cvaQuestion/How%20valuable%20are%20FinOps%20alerts%3F/surveyId/FTK0.9/bladeName/Alerts/featureName/Email\" class=\"editor-link\"><u><span class=\"editor-text-underline\">Give feedback</span></u></a><br><a href=\"https://github.com/microsoft/finops-toolkit/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22Tool%3A%20FinOps%20alerts%22%20sort%3Areactions-%2B1-desc\" class=\"editor-link\"><u><span class=\"editor-text-underline\">Vote on or suggest ideas</span></u></a></p><br>"
                         },
                         "path": "/v2/Mail"
                       }

--- a/docs/deploy/finops-alerts-latest.json
+++ b/docs/deploy/finops-alerts-latest.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "16996831884074690489"
+      "templateHash": "12802525131637595090"
     }
   },
   "parameters": {
@@ -97,7 +97,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "14296692176899339374"
+              "templateHash": "10854342800064359748"
             }
           },
           "parameters": {
@@ -3654,7 +3654,7 @@
                         "body": {
                           "To": "@variables('SendAlertTo')",
                           "Subject": "@variables('SetEmailSubject')",
-                          "Body": "<p class=\"editor-paragraph\">@{variables('EmailNotice')}</p><p class=\"editor-paragraph\">@{variables('AppGatewayHTML')}<br>@{variables('IdleDiskHTML')}<br>@{variables('IPAddressHTML')}<br>@{variables('LoadBalancerHTML')}<br>@{variables('DiskSnapshotHTML')}<br>@{variables('StoppedVMHTML')}</p><br><h1 class=\"editor-heading-h1\"><b><strong class=\"editor-text-bold\">📧 </strong></b><b><strong class=\"editor-text-bold\" style=\"font-size: 20px;\">About FinOps alerts</strong></b></h1><p class=\"editor-paragraph\">FinOps alerts keep you informed about cost optimization opportunities within in your cloud environment. They are fully configurable and can be tailored to run on your desired schedule, ensuring that you receive timely notifications on the scenarios most important to your organization. FinOps alerts are part of the FinOps toolkit, an open-source collection of FinOps solutions that help you manage and optimize your cost, usage, and carbon.</p><h1 class=\"editor-heading-h1\"><b><strong class=\"editor-text-bold\" style=\"font-size: 20px;\">Provide feedback</strong></b></h1><p class=\"editor-paragraph\"><a href=\"https://portal.azure.com/#view/HubsExtension/InProductFeedbackBlade/extensionName/FinOpsToolkit/cesQuestion/How%20easy%20or%20hard%20is%20it%20to%20use%20FinOps%20alerts%3F/cvaQuestion/How%20valuable%20are%20FinOps%20alerts%3F/surveyId/FTK0.8/bladeName/Alerts/featureName/Email\" class=\"editor-link\"><u><span class=\"editor-text-underline\">Give feedback</span></u></a><br><a href=\"https://github.com/microsoft/finops-toolkit/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22Tool%3A%20FinOps%20alerts%22%20sort%3Areactions-%2B1-desc\" class=\"editor-link\"><u><span class=\"editor-text-underline\">Vote on or suggest ideas</span></u></a></p><br>"
+                          "Body": "<p class=\"editor-paragraph\">@{variables('EmailNotice')}</p><p class=\"editor-paragraph\">@{variables('AppGatewayHTML')}<br>@{variables('IdleDiskHTML')}<br>@{variables('IPAddressHTML')}<br>@{variables('LoadBalancerHTML')}<br>@{variables('DiskSnapshotHTML')}<br>@{variables('StoppedVMHTML')}</p><br><h1 class=\"editor-heading-h1\"><b><strong class=\"editor-text-bold\">📧 </strong></b><b><strong class=\"editor-text-bold\" style=\"font-size: 20px;\">About FinOps alerts</strong></b></h1><p class=\"editor-paragraph\">FinOps alerts keep you informed about cost optimization opportunities within in your cloud environment. They are fully configurable and can be tailored to run on your desired schedule, ensuring that you receive timely notifications on the scenarios most important to your organization. FinOps alerts are part of the FinOps toolkit, an open-source collection of FinOps solutions that help you manage and optimize your cost, usage, and carbon.</p><h1 class=\"editor-heading-h1\"><b><strong class=\"editor-text-bold\" style=\"font-size: 20px;\">Provide feedback</strong></b></h1><p class=\"editor-paragraph\"><a href=\"https://portal.azure.com/#view/HubsExtension/InProductFeedbackBlade/extensionName/FinOpsToolkit/cesQuestion/How%20easy%20or%20hard%20is%20it%20to%20use%20FinOps%20alerts%3F/cvaQuestion/How%20valuable%20are%20FinOps%20alerts%3F/surveyId/FTK0.9/bladeName/Alerts/featureName/Email\" class=\"editor-link\"><u><span class=\"editor-text-underline\">Give feedback</span></u></a><br><a href=\"https://github.com/microsoft/finops-toolkit/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22Tool%3A%20FinOps%20alerts%22%20sort%3Areactions-%2B1-desc\" class=\"editor-link\"><u><span class=\"editor-text-underline\">Vote on or suggest ideas</span></u></a></p><br>"
                         },
                         "path": "/v2/Mail"
                       }

--- a/docs/deploy/finops-hub-0.9.json
+++ b/docs/deploy/finops-hub-0.9.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "5439938411281903410"
+      "templateHash": "6665130305505342036"
     }
   },
   "parameters": {
@@ -280,7 +280,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "2523028206602190451"
+              "templateHash": "9032999427449681343"
             }
           },
           "parameters": {
@@ -498,14 +498,14 @@
             "dataFactorySuffix": "[format('-{0}', variables('uniqueSuffix'))]",
             "dataFactoryName": "[replace(format('{0}{1}', take(variables('dataFactoryPrefix'), sub(63, length(variables('dataFactorySuffix')))), variables('dataFactorySuffix')), '--', '-')]",
             "deployDataExplorer": "[not(empty(parameters('dataExplorerName')))]",
-            "telemetryId": "00f120b5-2007-6120-0000-40b000000000"
+            "telemetryId": "[join(createArray('00f120b5-2007-6120-0000-40b000000000_', if(or(empty(parameters('remoteHubStorageUri')), empty(parameters('remoteHubStorageKey'))), '', 'R'), substring(split(parameters('storageSku'), '_')[1], 0, 1), if(empty(parameters('dataExplorerName')), '', format('X{0}', substring(parameters('dataExplorerSku'), 0, 1))), if(empty(parameters('dataExplorerName')), '', replace(replace(replace(replace(replace(replace(replace(replace(split(split(parameters('dataExplorerSku'), 'Standard_')[1], '_')[0], 'C', ''), 'D', ''), 'E', ''), 'L', ''), 'a', ''), 'd', ''), 'i', ''), 's', '')), if(or(empty(parameters('dataExplorerName')), equals(parameters('dataExplorerCapacity'), 1)), '', format('x{0}', parameters('dataExplorerCapacity'))), if(parameters('enablePublicAccess'), '', 'P')), '')]"
           },
           "resources": [
             {
               "condition": "[parameters('enableDefaultTelemetry')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
-              "name": "[format('pid-{0}-{1}', variables('telemetryId'), uniqueString(deployment().name, parameters('location')))]",
+              "name": "[format('pid-{0}_{1}', variables('telemetryId'), uniqueString(deployment().name, parameters('location')))]",
               "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -2155,7 +2155,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.33.93.31351",
-                      "templateHash": "18243166431907778116"
+                      "templateHash": "12998070848171971309"
                     }
                   },
                   "functions": [
@@ -2377,7 +2377,7 @@
                     }
                   },
                   "variables": {
-                    "$fxv#0": "# Copyright (c) Microsoft Corporation.\r\n# Licensed under the MIT License.\r\n\r\n# Init outputs\r\n$DeploymentScriptOutputs = @{}\r\n\r\n#\r\n$adfParams = @{\r\n    ResourceGroupName = $env:DataFactoryResourceGroup\r\n    DataFactoryName   = $env:DataFactoryName\r\n}\r\n\r\n# Delete old triggers\r\n$triggers = Get-AzDataFactoryV2Trigger @adfParams -ErrorAction SilentlyContinue `\r\n| Where-Object { $_.Name -match '^msexports(_(setup|daily|monthly|extract|FileAdded))?$' }\r\n$DeploymentScriptOutputs[\"stopTriggers\"] = $triggers | Stop-AzDataFactoryV2Trigger -Force -ErrorAction SilentlyContinue\r\n$DeploymentScriptOutputs[\"deleteTriggers\"] = $triggers | Remove-AzDataFactoryV2Trigger -Force -ErrorAction SilentlyContinue\r\n\r\n# Delete old pipelines\r\n$DeploymentScriptOutputs[\"pipelines\"] = Get-AzDataFactoryV2Pipeline @adfParams -ErrorAction SilentlyContinue `\r\n| Where-Object { $_.Name -match '^(msexports_(backfill|extract|fill|get|run|setup|transform)|config_(BackfillData|ExportData|RunBackfill|RunExports))$' } `\r\n| Remove-AzDataFactoryV2Pipeline -Force -ErrorAction SilentlyContinue\r\n",
+                    "$fxv#0": "# Copyright (c) Microsoft Corporation.\r\n# Licensed under the MIT License.\r\n\r\n# Init outputs\r\n$DeploymentScriptOutputs = @{}\r\n\r\n# \r\n$adfParams = @{\r\n    ResourceGroupName = $env:DataFactoryResourceGroup\r\n    DataFactoryName   = $env:DataFactoryName\r\n}\r\n\r\n# Delete old triggers\r\n$triggers = Get-AzDataFactoryV2Trigger @adfParams -ErrorAction SilentlyContinue `\r\n| Where-Object { $_.Name -match '^msexports(_(setup|daily|monthly|extract|FileAdded))?$' }\r\n$DeploymentScriptOutputs[\"stopTriggers\"] = $triggers | Stop-AzDataFactoryV2Trigger -Force -ErrorAction SilentlyContinue\r\n$DeploymentScriptOutputs[\"deleteTriggers\"] = $triggers | Remove-AzDataFactoryV2Trigger -Force -ErrorAction SilentlyContinue\r\n\r\n# Delete old pipelines\r\n$DeploymentScriptOutputs[\"pipelines\"] = Get-AzDataFactoryV2Pipeline @adfParams -ErrorAction SilentlyContinue `\r\n| Where-Object { $_.Name -match '^(msexports_(backfill|extract|fill|get|run|setup|transform)|config_(BackfillData|ExportData|RunBackfill|RunExports))$' } `\r\n| Remove-AzDataFactoryV2Pipeline -Force -ErrorAction SilentlyContinue\r\n",
                     "$fxv#1": "# Copyright (c) Microsoft Corporation.\r\n# Licensed under the MIT License.\r\n\r\nParam(\r\n    [switch] $Stop\r\n)\r\n\r\n# Init outputs\r\n$DeploymentScriptOutputs = @{}\r\n\r\nif (-not $Stop)\r\n{\r\n    Start-Sleep -Seconds 10\r\n}\r\n\r\n# Loop thru triggers\r\n$env:Triggers.Split('|') `\r\n| ForEach-Object {\r\n    $trigger = $_\r\n    if ($Stop)\r\n    {\r\n        Write-Output \"Stopping trigger $trigger...\"\r\n        $triggerOutput = Stop-AzDataFactoryV2Trigger `\r\n            -ResourceGroupName $env:DataFactoryResourceGroup `\r\n            -DataFactoryName $env:DataFactoryName `\r\n            -Name $trigger `\r\n            -Force `\r\n            -ErrorAction SilentlyContinue # Ignore errors, since the trigger may not exist\r\n    }\r\n    else\r\n    {\r\n        Write-Output \"Starting trigger $trigger...\"\r\n        $triggerOutput = Start-AzDataFactoryV2Trigger `\r\n            -ResourceGroupName $env:DataFactoryResourceGroup `\r\n            -DataFactoryName $env:DataFactoryName `\r\n            -Name $trigger `\r\n            -Force\r\n    }\r\n    if ($triggerOutput)\r\n    {\r\n        Write-Output \"done...\"\r\n    }\r\n    else\r\n    {\r\n        Write-Output \"failed...\"\r\n    }\r\n    $DeploymentScriptOutputs[$trigger] = $triggerOutput\r\n}\r\n\r\nif ($Stop)\r\n{\r\n    Start-Sleep -Seconds 10\r\n}\r\n\r\nif (-not [string]::IsNullOrWhiteSpace($env:Pipelines))\r\n{\r\n    $env:Pipelines.Split('|') `\r\n    | ForEach-Object {\r\n        Write-Output \"Running the init pipeline...\"\r\n        Invoke-AzDataFactoryV2Pipeline `\r\n            -ResourceGroupName $env:DataFactoryResourceGroup `\r\n            -DataFactoryName $env:DataFactoryName `\r\n            -PipelineName $_\r\n    }\r\n}\r\n",
                     "$fxv#2": "# Copyright (c) Microsoft Corporation.\r\n# Licensed under the MIT License.\r\n\r\nParam(\r\n    [switch] $Stop\r\n)\r\n\r\n# Init outputs\r\n$DeploymentScriptOutputs = @{}\r\n\r\nif (-not $Stop)\r\n{\r\n    Start-Sleep -Seconds 10\r\n}\r\n\r\n# Loop thru triggers\r\n$env:Triggers.Split('|') `\r\n| ForEach-Object {\r\n    $trigger = $_\r\n    if ($Stop)\r\n    {\r\n        Write-Output \"Stopping trigger $trigger...\"\r\n        $triggerOutput = Stop-AzDataFactoryV2Trigger `\r\n            -ResourceGroupName $env:DataFactoryResourceGroup `\r\n            -DataFactoryName $env:DataFactoryName `\r\n            -Name $trigger `\r\n            -Force `\r\n            -ErrorAction SilentlyContinue # Ignore errors, since the trigger may not exist\r\n    }\r\n    else\r\n    {\r\n        Write-Output \"Starting trigger $trigger...\"\r\n        $triggerOutput = Start-AzDataFactoryV2Trigger `\r\n            -ResourceGroupName $env:DataFactoryResourceGroup `\r\n            -DataFactoryName $env:DataFactoryName `\r\n            -Name $trigger `\r\n            -Force\r\n    }\r\n    if ($triggerOutput)\r\n    {\r\n        Write-Output \"done...\"\r\n    }\r\n    else\r\n    {\r\n        Write-Output \"failed...\"\r\n    }\r\n    $DeploymentScriptOutputs[$trigger] = $triggerOutput\r\n}\r\n\r\nif ($Stop)\r\n{\r\n    Start-Sleep -Seconds 10\r\n}\r\n\r\nif (-not [string]::IsNullOrWhiteSpace($env:Pipelines))\r\n{\r\n    $env:Pipelines.Split('|') `\r\n    | ForEach-Object {\r\n        Write-Output \"Running the init pipeline...\"\r\n        Invoke-AzDataFactoryV2Pipeline `\r\n            -ResourceGroupName $env:DataFactoryResourceGroup `\r\n            -DataFactoryName $env:DataFactoryName `\r\n            -PipelineName $_\r\n    }\r\n}\r\n",
                     "focusSchemaVersion": "1.0",

--- a/docs/deploy/finops-hub-latest.json
+++ b/docs/deploy/finops-hub-latest.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.33.93.31351",
-      "templateHash": "5439938411281903410"
+      "templateHash": "6665130305505342036"
     }
   },
   "parameters": {
@@ -280,7 +280,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.33.93.31351",
-              "templateHash": "2523028206602190451"
+              "templateHash": "9032999427449681343"
             }
           },
           "parameters": {
@@ -498,14 +498,14 @@
             "dataFactorySuffix": "[format('-{0}', variables('uniqueSuffix'))]",
             "dataFactoryName": "[replace(format('{0}{1}', take(variables('dataFactoryPrefix'), sub(63, length(variables('dataFactorySuffix')))), variables('dataFactorySuffix')), '--', '-')]",
             "deployDataExplorer": "[not(empty(parameters('dataExplorerName')))]",
-            "telemetryId": "00f120b5-2007-6120-0000-40b000000000"
+            "telemetryId": "[join(createArray('00f120b5-2007-6120-0000-40b000000000_', if(or(empty(parameters('remoteHubStorageUri')), empty(parameters('remoteHubStorageKey'))), '', 'R'), substring(split(parameters('storageSku'), '_')[1], 0, 1), if(empty(parameters('dataExplorerName')), '', format('X{0}', substring(parameters('dataExplorerSku'), 0, 1))), if(empty(parameters('dataExplorerName')), '', replace(replace(replace(replace(replace(replace(replace(replace(split(split(parameters('dataExplorerSku'), 'Standard_')[1], '_')[0], 'C', ''), 'D', ''), 'E', ''), 'L', ''), 'a', ''), 'd', ''), 'i', ''), 's', '')), if(or(empty(parameters('dataExplorerName')), equals(parameters('dataExplorerCapacity'), 1)), '', format('x{0}', parameters('dataExplorerCapacity'))), if(parameters('enablePublicAccess'), '', 'P')), '')]"
           },
           "resources": [
             {
               "condition": "[parameters('enableDefaultTelemetry')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
-              "name": "[format('pid-{0}-{1}', variables('telemetryId'), uniqueString(deployment().name, parameters('location')))]",
+              "name": "[format('pid-{0}_{1}', variables('telemetryId'), uniqueString(deployment().name, parameters('location')))]",
               "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -2155,7 +2155,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.33.93.31351",
-                      "templateHash": "18243166431907778116"
+                      "templateHash": "12998070848171971309"
                     }
                   },
                   "functions": [
@@ -2377,7 +2377,7 @@
                     }
                   },
                   "variables": {
-                    "$fxv#0": "# Copyright (c) Microsoft Corporation.\r\n# Licensed under the MIT License.\r\n\r\n# Init outputs\r\n$DeploymentScriptOutputs = @{}\r\n\r\n#\r\n$adfParams = @{\r\n    ResourceGroupName = $env:DataFactoryResourceGroup\r\n    DataFactoryName   = $env:DataFactoryName\r\n}\r\n\r\n# Delete old triggers\r\n$triggers = Get-AzDataFactoryV2Trigger @adfParams -ErrorAction SilentlyContinue `\r\n| Where-Object { $_.Name -match '^msexports(_(setup|daily|monthly|extract|FileAdded))?$' }\r\n$DeploymentScriptOutputs[\"stopTriggers\"] = $triggers | Stop-AzDataFactoryV2Trigger -Force -ErrorAction SilentlyContinue\r\n$DeploymentScriptOutputs[\"deleteTriggers\"] = $triggers | Remove-AzDataFactoryV2Trigger -Force -ErrorAction SilentlyContinue\r\n\r\n# Delete old pipelines\r\n$DeploymentScriptOutputs[\"pipelines\"] = Get-AzDataFactoryV2Pipeline @adfParams -ErrorAction SilentlyContinue `\r\n| Where-Object { $_.Name -match '^(msexports_(backfill|extract|fill|get|run|setup|transform)|config_(BackfillData|ExportData|RunBackfill|RunExports))$' } `\r\n| Remove-AzDataFactoryV2Pipeline -Force -ErrorAction SilentlyContinue\r\n",
+                    "$fxv#0": "# Copyright (c) Microsoft Corporation.\r\n# Licensed under the MIT License.\r\n\r\n# Init outputs\r\n$DeploymentScriptOutputs = @{}\r\n\r\n# \r\n$adfParams = @{\r\n    ResourceGroupName = $env:DataFactoryResourceGroup\r\n    DataFactoryName   = $env:DataFactoryName\r\n}\r\n\r\n# Delete old triggers\r\n$triggers = Get-AzDataFactoryV2Trigger @adfParams -ErrorAction SilentlyContinue `\r\n| Where-Object { $_.Name -match '^msexports(_(setup|daily|monthly|extract|FileAdded))?$' }\r\n$DeploymentScriptOutputs[\"stopTriggers\"] = $triggers | Stop-AzDataFactoryV2Trigger -Force -ErrorAction SilentlyContinue\r\n$DeploymentScriptOutputs[\"deleteTriggers\"] = $triggers | Remove-AzDataFactoryV2Trigger -Force -ErrorAction SilentlyContinue\r\n\r\n# Delete old pipelines\r\n$DeploymentScriptOutputs[\"pipelines\"] = Get-AzDataFactoryV2Pipeline @adfParams -ErrorAction SilentlyContinue `\r\n| Where-Object { $_.Name -match '^(msexports_(backfill|extract|fill|get|run|setup|transform)|config_(BackfillData|ExportData|RunBackfill|RunExports))$' } `\r\n| Remove-AzDataFactoryV2Pipeline -Force -ErrorAction SilentlyContinue\r\n",
                     "$fxv#1": "# Copyright (c) Microsoft Corporation.\r\n# Licensed under the MIT License.\r\n\r\nParam(\r\n    [switch] $Stop\r\n)\r\n\r\n# Init outputs\r\n$DeploymentScriptOutputs = @{}\r\n\r\nif (-not $Stop)\r\n{\r\n    Start-Sleep -Seconds 10\r\n}\r\n\r\n# Loop thru triggers\r\n$env:Triggers.Split('|') `\r\n| ForEach-Object {\r\n    $trigger = $_\r\n    if ($Stop)\r\n    {\r\n        Write-Output \"Stopping trigger $trigger...\"\r\n        $triggerOutput = Stop-AzDataFactoryV2Trigger `\r\n            -ResourceGroupName $env:DataFactoryResourceGroup `\r\n            -DataFactoryName $env:DataFactoryName `\r\n            -Name $trigger `\r\n            -Force `\r\n            -ErrorAction SilentlyContinue # Ignore errors, since the trigger may not exist\r\n    }\r\n    else\r\n    {\r\n        Write-Output \"Starting trigger $trigger...\"\r\n        $triggerOutput = Start-AzDataFactoryV2Trigger `\r\n            -ResourceGroupName $env:DataFactoryResourceGroup `\r\n            -DataFactoryName $env:DataFactoryName `\r\n            -Name $trigger `\r\n            -Force\r\n    }\r\n    if ($triggerOutput)\r\n    {\r\n        Write-Output \"done...\"\r\n    }\r\n    else\r\n    {\r\n        Write-Output \"failed...\"\r\n    }\r\n    $DeploymentScriptOutputs[$trigger] = $triggerOutput\r\n}\r\n\r\nif ($Stop)\r\n{\r\n    Start-Sleep -Seconds 10\r\n}\r\n\r\nif (-not [string]::IsNullOrWhiteSpace($env:Pipelines))\r\n{\r\n    $env:Pipelines.Split('|') `\r\n    | ForEach-Object {\r\n        Write-Output \"Running the init pipeline...\"\r\n        Invoke-AzDataFactoryV2Pipeline `\r\n            -ResourceGroupName $env:DataFactoryResourceGroup `\r\n            -DataFactoryName $env:DataFactoryName `\r\n            -PipelineName $_\r\n    }\r\n}\r\n",
                     "$fxv#2": "# Copyright (c) Microsoft Corporation.\r\n# Licensed under the MIT License.\r\n\r\nParam(\r\n    [switch] $Stop\r\n)\r\n\r\n# Init outputs\r\n$DeploymentScriptOutputs = @{}\r\n\r\nif (-not $Stop)\r\n{\r\n    Start-Sleep -Seconds 10\r\n}\r\n\r\n# Loop thru triggers\r\n$env:Triggers.Split('|') `\r\n| ForEach-Object {\r\n    $trigger = $_\r\n    if ($Stop)\r\n    {\r\n        Write-Output \"Stopping trigger $trigger...\"\r\n        $triggerOutput = Stop-AzDataFactoryV2Trigger `\r\n            -ResourceGroupName $env:DataFactoryResourceGroup `\r\n            -DataFactoryName $env:DataFactoryName `\r\n            -Name $trigger `\r\n            -Force `\r\n            -ErrorAction SilentlyContinue # Ignore errors, since the trigger may not exist\r\n    }\r\n    else\r\n    {\r\n        Write-Output \"Starting trigger $trigger...\"\r\n        $triggerOutput = Start-AzDataFactoryV2Trigger `\r\n            -ResourceGroupName $env:DataFactoryResourceGroup `\r\n            -DataFactoryName $env:DataFactoryName `\r\n            -Name $trigger `\r\n            -Force\r\n    }\r\n    if ($triggerOutput)\r\n    {\r\n        Write-Output \"done...\"\r\n    }\r\n    else\r\n    {\r\n        Write-Output \"failed...\"\r\n    }\r\n    $DeploymentScriptOutputs[$trigger] = $triggerOutput\r\n}\r\n\r\nif ($Stop)\r\n{\r\n    Start-Sleep -Seconds 10\r\n}\r\n\r\nif (-not [string]::IsNullOrWhiteSpace($env:Pipelines))\r\n{\r\n    $env:Pipelines.Split('|') `\r\n    | ForEach-Object {\r\n        Write-Output \"Running the init pipeline...\"\r\n        Invoke-AzDataFactoryV2Pipeline `\r\n            -ResourceGroupName $env:DataFactoryResourceGroup `\r\n            -DataFactoryName $env:DataFactoryName `\r\n            -PipelineName $_\r\n    }\r\n}\r\n",
                     "focusSchemaVersion": "1.0",

--- a/src/scripts/Package-Toolkit.ps1
+++ b/src/scripts/Package-Toolkit.ps1
@@ -84,7 +84,7 @@ function Copy-TemplateFiles()
     Remove-Item "$relDir/*.zip" -Force
 
     return Get-ChildItem "$relDir/$Template*" -Directory `
-    | Where-Object { $_.Name -ne 'pbit' -and $_.Name -ne 'pbix' } `
+    | Where-Object { @('pbit', 'pbix', 'FinOpsToolkit') -notcontains $_.Name } `
     | ForEach-Object {
         Write-Verbose ("Packaging $_" -replace (Get-Item $relDir).FullName, '.')
         $srcPath = $_


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
Add a few characters to the telemetry ID used for tracking deployments to identify specific deployment options:
- Remote hubs (`R`)
- LRS vs. ZRS storage redundancy (`L` or `Z`)
- Data Explorer enabled (`X`)
- ADX dev or standard SKU (`D` or `S`)
- ADX SKU core count (e.g., `11` in the screenshot for the D11v2 SKU)
- ADX cluster node count (e.g., `x2` for 2-node cluster)
- Private endpoints enabled (`P`)

## 📷 Screenshots
In the screenshot: `LXD11` = LRS storage + ADX dev SKU with "11" cores (actually 2 for this size). Remote hubs and private endpoints are not enabled. There's only 1 node in the ADX cluster (hence no "x#" at the end).
![Screenshot of the list of deployments](https://github.com/user-attachments/assets/01196951-d5e8-4611-9030-fb60272be94b)

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)
