### PR TITLE
Fix Split-AzureResourceId tests

### DIFF
--- a/src/powershell/Tests/Unit/Split-AzureResourceId.Tests.ps1
+++ b/src/powershell/Tests/Unit/Split-AzureResourceId.Tests.ps1
@@ -15,10 +15,10 @@ Describe 'Split-AzureResourceId' {
     It 'Should parse tenant' {
         $id = "/tenants/$subId"
         $result = Split-AzureResourceId -Id $id
-        $result.SubscriptionId | Should -Be $null
-        $result.SubscriptionResourceId | Should -Be $null
-        $result.ResourceGroupId | Should -Be $null
-        $result.ResourceGroupName | Should -Be $null
+        $result.SubscriptionId | Should -BeNullOrEmpty -Because "tenants have no subscription ID"
+        $result.SubscriptionResourceId | Should -BeNullOrEmpty -Because "tenants have no subscription resource ID"
+        $result.ResourceGroupId | Should -BeNullOrEmpty -Because "tenants have no resource group ID"
+        $result.ResourceGroupName | Should -BeNullOrEmpty -Because "tenants have no resource group name"
         $result.Provider | Should -Be 'Microsoft.Resources'
         $result.Name | Should -Be $subId
         $result.Type | Should -Be "Microsoft.Resources/tenants"
@@ -28,10 +28,10 @@ Describe 'Split-AzureResourceId' {
     It 'Should parse tenant resource' {
         $id = "/providers/$rp/$type1/$name1"
         $result = Split-AzureResourceId -Id $id
-        $result.SubscriptionId | Should -Be $null
-        $result.SubscriptionResourceId | Should -Be $null
-        $result.ResourceGroupId | Should -Be $null
-        $result.ResourceGroupName | Should -Be $null
+        $result.SubscriptionId | Should -BeNullOrEmpty -Because "tenant resources have no subscription ID"
+        $result.SubscriptionResourceId | Should -BeNullOrEmpty -Because "tenant resources have no subscription resource ID"
+        $result.ResourceGroupId | Should -BeNullOrEmpty -Because "tenant resources have no resource group ID"
+        $result.ResourceGroupName | Should -BeNullOrEmpty -Because "tenant resources have no resource group name"
         $result.Provider | Should -Be $rp
         $result.Name | Should -Be $name1
         $result.Type | Should -Be "$rp/$type1"
@@ -41,10 +41,10 @@ Describe 'Split-AzureResourceId' {
     It 'Should parse tenant nested resource' {
         $id = "/providers/$rp/$type1/$name1/$type2/$name2"
         $result = Split-AzureResourceId -Id $id
-        $result.SubscriptionId | Should -Be $null
-        $result.SubscriptionResourceId | Should -Be $null
-        $result.ResourceGroupId | Should -Be $null
-        $result.ResourceGroupName | Should -Be $null
+        $result.SubscriptionId | Should -BeNullOrEmpty -Because "nested tenant resources have no subscription ID"
+        $result.SubscriptionResourceId | Should -BeNullOrEmpty -Because "nested tenant resources have no subscription resource ID"
+        $result.ResourceGroupId | Should -BeNullOrEmpty -Because "nested tenant resources have no resource group ID"
+        $result.ResourceGroupName | Should -BeNullOrEmpty -Because "nested tenant resources have no resource group name"
         $result.Provider | Should -Be $rp
         $result.Name | Should -Be "$name1/$name2"
         $result.Type | Should -Be "$rp/$type1/$type2"
@@ -56,21 +56,21 @@ Describe 'Split-AzureResourceId' {
         $result = Split-AzureResourceId -Id $id
         $result.SubscriptionId | Should -Be $subId
         $result.SubscriptionResourceId | Should -Be "/subscriptions/$subId"
-        $result.ResourceGroupId | Should -Be $null
-        $result.ResourceGroupName | Should -Be $null
+        $result.ResourceGroupId | Should -BeNullOrEmpty -Because "subscriptions have no resource group ID"
+        $result.ResourceGroupName | Should -BeNullOrEmpty -Because "subscriptions have no resource group name"
         $result.Provider | Should -Be 'Microsoft.Resources'
         $result.Name | Should -Be $subId
         $result.Type | Should -Be "Microsoft.Resources/subscriptions"
         $result.ResourceId | Should -Be $id
     }
-
+    
     It 'Should parse subscription resource' {
         $id = "/subscriptions/$subId/providers/$rp/$type1/$name1"
         $result = Split-AzureResourceId -Id $id
         $result.SubscriptionId | Should -Be $subId
         $result.SubscriptionResourceId | Should -Be "/subscriptions/$subId"
-        $result.ResourceGroupId | Should -Be $null
-        $result.ResourceGroupName | Should -Be $null
+        $result.ResourceGroupId | Should -BeNullOrEmpty -Because "subscription resources have no resource group ID"
+        $result.ResourceGroupName | Should -BeNullOrEmpty -Because "subscription resources have no resource group name"
         $result.Provider | Should -Be $rp
         $result.Name | Should -Be $name1
         $result.Type | Should -Be "$rp/$type1"
@@ -126,32 +126,32 @@ Describe 'Split-AzureResourceId' {
         $result.Provider | Should -Be $rp
         $result.Name | Should -Be "$name1/$name2"
         $result.Type | Should -Be "$rp/$type1/$type2"
-        $result.ResourceId | Should -Be ($id.Split('/')[0..($id.Split('/').Count - 2)] -Join '/')
+        $result.ResourceId | Should -Be ($id.Split('/')[0..($id.Split('/').Count - 2)] -join '/')
     }
 
     It 'Should handle empty resource ID' {
         $id = ""
         $result = Split-AzureResourceId -Id $id
-        $result.SubscriptionId | Should -Be $null
-        $result.SubscriptionResourceId | Should -Be $null
-        $result.ResourceGroupId | Should -Be $null
-        $result.ResourceGroupName | Should -Be $null
-        $result.Provider | Should -Be $null
-        $result.Name | Should -Be $null
-        $result.Type | Should -Be $null
-        $result.ResourceId | Should -Be $null
+        $result.SubscriptionId | Should -BeNullOrEmpty
+        $result.SubscriptionResourceId | Should -BeNullOrEmpty
+        $result.ResourceGroupId | Should -BeNullOrEmpty
+        $result.ResourceGroupName | Should -BeNullOrEmpty
+        $result.Provider | Should -BeNullOrEmpty
+        $result.Name | Should -BeNullOrEmpty
+        $result.Type | Should -BeNullOrEmpty
+        $result.ResourceId | Should -BeNullOrEmpty
     }
 
     It 'Should handle null resource ID' {
         $id = $null
         $result = Split-AzureResourceId -Id $id
-        $result.SubscriptionId | Should -Be $null
-        $result.SubscriptionResourceId | Should -Be $null
-        $result.ResourceGroupId | Should -Be $null
-        $result.ResourceGroupName | Should -Be $null
-        $result.Provider | Should -Be $null
-        $result.Name | Should -Be $null
-        $result.Type | Should -Be $null
-        $result.ResourceId | Should -Be $null
+        $result.SubscriptionId | Should -BeNullOrEmpty
+        $result.SubscriptionResourceId | Should -BeNullOrEmpty
+        $result.ResourceGroupId | Should -BeNullOrEmpty
+        $result.ResourceGroupName | Should -BeNullOrEmpty
+        $result.Provider | Should -BeNullOrEmpty
+        $result.Name | Should -BeNullOrEmpty
+        $result.Type | Should -BeNullOrEmpty
+        $result.ResourceId | Should -BeNullOrEmpty
     }
 }


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
Fix an error in the Split-AzureResourceId tests that was failing for an empty string (rather than a null)

## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [x] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)
