### PR TITLE
Msbrett/issue1614

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -50,6 +50,7 @@ _Released June 2, 2025_
 - **Fixed**
   - Address new data quality issues with data ingested into Data Explorer:
     - Fix BillingPeriodStart and BillingPeriodEnd to always be at the start of the month.
+    - Change data types for ChargePeriodStart and ChargePeriodEnd from 'datetimezone' to 'date' in Power BI KQL reports to resolve invalid calculations in running total measures.
 
 ### [FinOps alerts](alerts/finops-alerts-overview.md) v0.11
 

--- a/docs/power-bi.md
+++ b/docs/power-bi.md
@@ -197,3 +197,19 @@ Create a new or update an existing FinOps hub instance.
 <a class="btn mb-4 mb-md-0 mr-4" target="_blank" href="https://portal.azure.com/#view/HubsExtension/InProductFeedbackBlade/extensionName/FinOpsToolkit/cesQuestion/How%20easy%20or%20hard%20is%20it%20to%20use%20FinOps%20toolkit%20Power%20BI%20reports%3F/cvaQuestion/How%20valuable%20are%20FinOps%20toolkit%20Power%20BI%20reports%3F/surveyId/FTK{% include ftkver.txt %}/bladeName/PowerBI/featureName/Marketing.Docs">💜 Give feedback</a>
 
 <br>
+
+## Data Model Update: ChargePeriodStart Column for KQL based reports
+
+- **Column:** `ChargePeriodStart`
+- **Old Data Type:** `datetimezone`
+- **New Data Type:** `date`
+- **Reason for Change:**
+  - To ensure correct grouping and aggregation by day in Power BI and downstream analytics tools.
+  - This change eliminates issues with multiple rows per day caused by time and timezone components.
+
+**Note:**
+
+- All queries, visuals, and documentation should now treat `ChargePeriodStart` as a `date` type.
+- If you previously used DAX or Power Query workarounds to normalize this column, you can now use it directly for daily grouping.
+
+<br>

--- a/src/power-bi/kql/Shared.Dataset/definition/tables/Costs.tmdl
+++ b/src/power-bi/kql/Shared.Dataset/definition/tables/Costs.tmdl
@@ -251,18 +251,20 @@ table Costs
 
 	column ChargePeriodEnd
 		dataType: dateTime
-		formatString: General Date
-		sourceProviderType: datetimeoffset
+		formatString: Long Date
+		sourceProviderType: date
 		lineageTag: 0d353195-2c13-4b43-ab97-8f691c508997
 		summarizeBy: none
 		sourceColumn: ChargePeriodEnd
 
 		annotation SummarizationSetBy = Automatic
 
+		annotation UnderlyingDateTimeDataType = Date
+
 	column ChargePeriodStart
 		dataType: dateTime
-		formatString: Mmm d, yyyy
-		sourceProviderType: datetimeoffset
+		formatString: Long Date
+		sourceProviderType: date
 		lineageTag: 015b4c1a-f072-4c68-8f1b-d5e10c54b97e
 		summarizeBy: none
 		sourceColumn: ChargePeriodStart
@@ -270,6 +272,8 @@ table Costs
 		annotation SummarizationSetBy = Automatic
 
 		annotation PBI_FormatHint = {"isCustom":true}
+
+		annotation UnderlyingDateTimeDataType = Date
 
 	column CommitmentDiscountCategory
 		dataType: string
@@ -1838,9 +1842,10 @@ table Costs
 				    ", [MaxRows=null, MaxSize=null, NoTruncate=null, AdditionalSetStatements=null]),
 				
 				    // Sort columns alphabetically
-				    Output = Table.ReorderColumns(Source, List.Sort(Table.ColumnNames(Source)))
+				    Output = Table.ReorderColumns(Source, List.Sort(Table.ColumnNames(Source))),
+				    #"Changed Type" = Table.TransformColumnTypes(Output,{{"ChargePeriodEnd", type date}, {"ChargePeriodStart", type date}})
 				in
-				    Output
+				    #"Changed Type"
 
 	annotation PBI_NavigationStepName = Navigation
 


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
Change the data type for ChargePeriodStart and ChargePeriodEnd to date (was datetimezone) to prevent issues with the runningtotal measures when more than one billing profile is present.  This issue seems to be related to some costs landing in with dates that don't align to the hour.

Fixes #1614

## 📷 Screenshots


## 📋 Checklist


### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [x] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [x] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [ ] ❎ Docs not needed (small/internal change)
