### PR TITLE
Upgraded SQL Server name availability check API version

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -60,6 +60,11 @@ _Released June 2, 2025_
     - Telemetry is not personally identifiable and only used to improve the template.
     - Disable telemetry by setting the **enableDefaultTelemetry** parameter to **false**.
 
+### [Optimization engine](optimization-engine/overview.md) v0.11
+
+- **Changed**
+  - Upgraded Azure Resource Manager SQL Server name availability API version, used by the engine deployment script, due to upcoming deprecation of 2014-04-01 version.
+
 ### [Open data](open-data.md) v0.11
 
 **[Pricing units](open-data.md#pricing-units)**

--- a/src/optimization-engine/Deploy-AzureOptimizationEngine.ps1
+++ b/src/optimization-engine/Deploy-AzureOptimizationEngine.ps1
@@ -562,7 +562,7 @@ $sql = Get-AzSqlServer -ResourceGroupName $resourceGroupName -Name $sqlServerNam
 if ($null -eq $sql -and -not($sqlServerName -like "*.database.*") -and -not($IgnoreNamingAvailabilityErrors))
 {
 
-    $SqlServerNameAvailabilityUriPath = "/subscriptions/$subscriptionId/providers/Microsoft.Sql/checkNameAvailability?api-version=2014-04-01"
+    $SqlServerNameAvailabilityUriPath = "/subscriptions/$subscriptionId/providers/Microsoft.Sql/checkNameAvailability?api-version=2021-11-01"
     $body = "{`"name`": `"$sqlServerName`", `"type`": `"Microsoft.Sql/servers`"}"
     # TODO: Switch to custom Invoke-Rest command to leverage telemetry tracking
     $sqlNameResult = (Invoke-AzRestMethod -Path $SqlServerNameAvailabilityUriPath -Method POST -Payload $body).Content | ConvertFrom-Json


### PR DESCRIPTION
## 🛠️ Description

Upgraded SQL Server name availability check API version, due to upcoming deprecation of the version that was being used so far. See deprecation announcement [here](https://learn.microsoft.com/en-us/rest/api/sql/retirement).

## 📋 Checklist

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [X] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [X] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [X] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [X] ❎ Docs not needed (small/internal change)
