### PR TITLE
Changed Script name for alignment in instructions

### DIFF
--- a/src/wacoa/README.md
+++ b/src/wacoa/README.md
@@ -106,11 +106,11 @@ This PowerShell script solution automates the generation of cost optimization re
     *   Navigate to the directory where you saved `CostRecommendations.ps1`.
     *   Run the script:
         ```powershell
-        .\CostRecommendations.ps1
+        .\collectCostRecommendations.ps1
         ```
     *   You can also use the `-Verbose` switch for more detailed console output:
         ```powershell
-        .\CostRecommendations.ps1 -Verbose
+        .\collectCostRecommendations.ps1-Verbose
         ```
 
 4.  **Follow the Interactive Prompts:**
@@ -135,7 +135,7 @@ This PowerShell script solution automates the generation of cost optimization re
 ## **Supporting Files**
 
 ### `settings.json` (Auto-generated/Customizable)
-*   **Location:** Same directory as `CostRecommendations.ps1`.
+*   **Location:** Same directory as `collectCostRecommendations.ps1`.
 *   **Purpose:** Stores configuration for script version, repository URLs (for updates and resource downloads), and local paths.
 
 ### `azure-resources/` (Auto-downloaded)


### PR DESCRIPTION
## 🛠️ Description
The instructions for running the scripts don't work as the name used to download it does not match the rest of the steps

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x ] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [ x] ❎ Docs not needed (small/internal change)
