### PR TITLE
[AOE] Fixes link to Power BI report

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -73,6 +73,12 @@ _Released June 2025_
 - **Fixed**
   - Correctly detect the hub version in the [Data ingestion report](power-bi/data-ingestion.md).
 
+### [Optimization engine](optimization-engine/overview.md) v0.12
+
+- **Fixed**
+  - Link to recommendations Power BI report in MS Learn documentation ([#1614](https://github.com/microsoft/finops-toolkit/issues/1730)).
+  - Aka.ms links to point to the latest version of documentation articles in MS Learn.
+
 ### [PowerShell module](powershell/powershell-commands.md) v0.12
 
 - **Changed**

--- a/docs-mslearn/toolkit/optimization-engine/reports.md
+++ b/docs-mslearn/toolkit/optimization-engine/reports.md
@@ -20,7 +20,7 @@ This article explains reporting options available within Azure optimization engi
 
 ## Power BI recommendations report
 
-AOE includes a [Power BI report](reports.md) for visualizing recommendations. To use it, you have first to change the data source connection to the SQL Database you deployed with the AOE. In the Power BI top menu, select **Transform Data** > **Data source settings**.
+AOE includes a [Power BI report](https://aka.ms/AzureOptimizationEngine/powerbi) for visualizing recommendations. To use it, you have first to change the data source connection to the SQL Database you deployed with the AOE. In the Power BI top menu, select **Transform Data** > **Data source settings**.
 
 :::image type="content" source="./media/reports/power-bi-transform-data-menu.png" border="true" alt-text="Screenshot showing navigation to the Data source settings menu item." lightbox="./media/reports/power-bi-transform-data-menu.png":::
 


### PR DESCRIPTION
## 🛠️ Description

During the toolkit docs migration to MS Learn, there were some links that were broken. Most of the changes were simply made in Aka.ms. The only Markdown change was in the link to the Power BI report in the Reports page.

Fixes #1730

## 📋 Checklist

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [X] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [X] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [X] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [X] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [ ] ❎ Docs not needed (small/internal change)
