### PR TITLE
Deployment fails with error The element for [steps('advanced').networking.enableManagedExports] could not be found in the createuidefinition

### DIFF
--- a/docs/deploy/finops-hub-12.0.ui.json
+++ b/docs/deploy/finops-hub-12.0.ui.json
@@ -731,7 +731,7 @@
       "fabricQueryUri": "[basics('fabric').fabricQueryUri]",
       "fabricCapacity": "[basics('fabric').fabricCapacity]",
       "enableInfrastructureEncryption": "[steps('advanced').storage.enableInfrastructureEncryption]",
-      "enableManagedExports": "[steps('advanced').networking.enableManagedExports]",
+      "enableManagedExports": "[steps('advanced').managedExports.enableManagedExports]",
       "enablePublicAccess": "[steps('advanced').networking.enablePublicAccess]",
       "virtualNetworkAddressPrefix": "[steps('advanced').networking.virtualNetworkAddressPrefix]",
       "dataExplorerSku": "[steps('pricing').dataExplorer.dataExplorerSku]",

--- a/docs/deploy/finops-hub-latest.ui.json
+++ b/docs/deploy/finops-hub-latest.ui.json
@@ -731,7 +731,7 @@
       "fabricQueryUri": "[basics('fabric').fabricQueryUri]",
       "fabricCapacity": "[basics('fabric').fabricCapacity]",
       "enableInfrastructureEncryption": "[steps('advanced').storage.enableInfrastructureEncryption]",
-      "enableManagedExports": "[steps('advanced').networking.enableManagedExports]",
+      "enableManagedExports": "[steps('advanced').managedExports.enableManagedExports]",
       "enablePublicAccess": "[steps('advanced').networking.enablePublicAccess]",
       "virtualNetworkAddressPrefix": "[steps('advanced').networking.virtualNetworkAddressPrefix]",
       "dataExplorerSku": "[steps('pricing').dataExplorer.dataExplorerSku]",

--- a/src/templates/finops-hub/createUiDefinition.json
+++ b/src/templates/finops-hub/createUiDefinition.json
@@ -731,7 +731,7 @@
       "fabricQueryUri": "[basics('fabric').fabricQueryUri]",
       "fabricCapacity": "[basics('fabric').fabricCapacity]",
       "enableInfrastructureEncryption": "[steps('advanced').storage.enableInfrastructureEncryption]",
-      "enableManagedExports": "[steps('advanced').networking.enableManagedExports]",
+      "enableManagedExports": "[steps('advanced').managedExports.enableManagedExports]",
       "enablePublicAccess": "[steps('advanced').networking.enablePublicAccess]",
       "virtualNetworkAddressPrefix": "[steps('advanced').networking.virtualNetworkAddressPrefix]",
       "dataExplorerSku": "[steps('pricing').dataExplorer.dataExplorerSku]",


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description
Deployment fails with error The element for [steps('advanced').networking.enableManagedExports] could not be found in the createuidefinition

Fixes #1770

## 📷 Screenshots
<img width="831" height="74" alt="image" src="https://github.com/user-attachments/assets/f062a49d-b2fc-45d0-8455-6d660df85cf4" />


## 📋 Checklist
<!-- TODO: Check [x] all answers that apply in each section -->

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)
