### PR TITLE
Fix: Reset-AutomationSchedules incorrectly checking if provided time is at least one hour in the future

### DIFF
--- a/src/optimization-engine/Reset-AutomationSchedules.ps1
+++ b/src/optimization-engine/Reset-AutomationSchedules.ps1
@@ -79,16 +79,21 @@ if (-not($newBaseTimeStr)) {
     $newBaseTimeStr = $baseTimeStr
 }
 else {
+    $minAllowedTime = [DateTimeOffset]::UtcNow.AddHours(-1)
+    $newBaseTime = $null
+
     try {
-        $newBaseTimeStr += "Z"
-        $newBaseTime = [DateTime]::Parse($newBaseTimeStr)
+        $newBaseTime = [DateTimeOffset]::Parse($newBaseTimeStr + "Z")
     }
     catch {
         throw "$newBaseTimeStr is an invalid base time. Use the following format: YYYY-MM-dd HH:mm:ss. For example: 1977-09-08 06:14:15"
     }
-    if ($newBaseTime -lt (Get-Date).ToUniversalTime().AddHours(-1)) {
-        throw "$newBaseTimeStr is an invalid base time. It can't be sooner than $((Get-Date).ToUniversalTime().AddHours(-1).ToString('u'))"
+
+    if ($newBaseTime -lt $minAllowedTime) {
+        throw "$($newBaseTime.ToString('u')) is an invalid base time. It can't be sooner than $($minAllowedTime.ToString('u'))"
     }
+    
+    $newBaseTimeStr = $newBaseTime.ToString("yyyy-MM-dd HH:mm:ss") + "Z"
 }
 
 $baseTimeUtc = [DateTime]::Parse($newBaseTimeStr).ToUniversalTime()

--- a/src/optimization-engine/Reset-AutomationSchedules.ps1
+++ b/src/optimization-engine/Reset-AutomationSchedules.ps1
@@ -79,7 +79,7 @@ if (-not($newBaseTimeStr)) {
     $newBaseTimeStr = $baseTimeStr
 }
 else {
-    $minAllowedTime = [DateTimeOffset]::UtcNow.AddHours(-1)
+    $minAllowedTime = [DateTimeOffset]::UtcNow.AddHours(1)
     $newBaseTime = $null
 
     try {
@@ -90,7 +90,7 @@ else {
     }
 
     if ($newBaseTime -lt $minAllowedTime) {
-        throw "$($newBaseTime.ToString('u')) is an invalid base time. It can't be sooner than $($minAllowedTime.ToString('u'))"
+        throw "$($newBaseTime.ToString('u')) is an invalid base time. It must be at least 1 hour in the future (after $($minAllowedTime.ToString('u')))"
     }
     
     $newBaseTimeStr = $newBaseTime.ToString("yyyy-MM-dd HH:mm:ss") + "Z"


### PR DESCRIPTION
## 🛠️ Description
This fixes an issue in the validation of the provided time in Reset-AutomationSchedules.ps1. The current implementation was checking UTC - 1 hour against the local time of the parsed time string instead of UTC. The current implementation was also checking if sooner than an hour ago instead of sooner than an hour in the future.

Output of the original script from when I encountered the bug:

Please, enter a new base time for the *weekly* schedules in UTC (YYYY-MM-dd HH:mm:ss). If you want to keep the current one, just press ENTER: 2025-10-02 06:00:00
Exception: C:\Working\finops-toolkit\src\optimization-engine\Reset-AutomationSchedules.ps1:90
Line |
  90 |          throw "$newBaseTimeStr is an invalid base time. It can't be s …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | 2025-10-02 06:00:00Z is an invalid base time. It can't be sooner than 2025-10-02 02:56:01Z

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)
