### PR TITLE
fix(hubs): Fix broken Copilot download link and add protocol handler notes

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -59,6 +59,8 @@ _Released August 2025_
 
 ### [FinOps hubs](hubs/finops-hubs-overview.md) v13
 
+- **Added**
+  - Added GitHub Copilot instructions template for FinOps hubs that can be downloaded and used with VS Code to connect to and query FinOps hub instances using AI ([#1801](https://github.com/microsoft/finops-toolkit/issues/1801)).
 - **Changed**
   - Reorganized Bicep modules into separate apps.
   - Enhanced [Configure scopes documentation](hubs/configure-scopes.md) to explicitly clarify that FinOps hubs support:
@@ -67,6 +69,8 @@ _Released August 2025_
 - **Fixed**
   - Fixed all Bicep compilation errors and warnings with inline suppressions and descriptive comments.
   - Fixed Build-Toolkit.ps1 bicep generate-params command bug.
+  - Fixed broken download link for GitHub Copilot instructions in [Configure AI agents documentation](hubs/configure-ai.md) by adding the finops-hub-copilot template to the build and packaging process.
+  - Added clarifying notes in [Configure AI agents documentation](hubs/configure-ai.md) to explain that vscode:// protocol handler links only work when VS Code is installed locally.
 
 ### [Power BI reports](power-bi/reports.md) v13
 

--- a/docs-mslearn/toolkit/hubs/configure-ai.md
+++ b/docs-mslearn/toolkit/hubs/configure-ai.md
@@ -48,6 +48,9 @@ The simplest way to get started with an AI-powered FinOps hub is with [GitHub Co
    - [Install GitHub Copilot Chat](vscode:extension/GitHub.copilot-chat)
    - [Install Azure MCP server for VS Code](https://insiders.vscode.dev/redirect/mcp/install?name=Azure%20MCP%20Server&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40azure%2Fmcp%40latest%22%2C%22server%22%2C%22start%22%5D%7D)
 
+   > [!TIP]
+   > The first two links use VS Code protocol handlers to open the Extensions view directly to the extension. If clicking doesn't open VS Code, you can manually install the extensions by opening VS Code, clicking the Extensions icon in the Activity Bar, and searching for "GitHub Copilot" and "GitHub Copilot Chat".
+
    <!--
    ### [VS Code Insiders](#tab/vscode-insiders)
 
@@ -78,6 +81,9 @@ If you're using GitHub Copilot, start by opening Chat in Agent mode:
 
 - [Open Agent mode in VS Code](vscode://GitHub.Copilot-Chat/chat?mode=agent&referrer=ftk-finops-hubs-docs-configureai)
 <!-- - [Open Agent mode in VS Code Insiders](vscode-insiders://GitHub.Copilot-Chat/chat?mode=agent&referrer=ftk-finops-hubs-docs-configureai) -->
+
+> [!TIP]
+> These links use VS Code protocol handlers and will only work when VS Code is installed on your device. If clicking the links doesn't open VS Code, you can manually open VS Code, press **Ctrl+Shift+P** (or **Cmd+Shift+P** on Mac), type "Chat: Open Chat", and then select **Agent** mode from the dropdown at the bottom of the chat pane.
 
 The AI instructions for FinOps hubs are preconfigured for FinOps tasks and already know how to find and connect to your FinOps hub instance. To start, ask to connect to your FinOps hub instance:
 

--- a/src/scripts/Package-Toolkit.ps1
+++ b/src/scripts/Package-Toolkit.ps1
@@ -95,7 +95,32 @@ function Copy-TemplateFiles()
         $srcPath = $_
         $templateName = $srcPath.Name
         $versionSubFolder = (Join-Path $srcPath $version)
-        $zip = Join-Path (Get-Item $relDir) "$templateName-v$version.zip"
+
+        # Read build config to check for zipWithoutVersion option
+        $srcConfigPath = "$PSScriptRoot/../templates/$templateName/.build.config"
+        $buildConfig = $null
+        if (Test-Path $srcConfigPath)
+        {
+            try
+            {
+                $buildConfig = Get-Content $srcConfigPath -Raw -ErrorAction Stop | ConvertFrom-Json -Depth 10 -ErrorAction Stop
+            }
+            catch
+            {
+                Write-Verbose "Warning: Failed to parse .build.config for $templateName. Using default settings. Error: $($_.Exception.Message)"
+            }
+        }
+        $zipWithoutVersion = $buildConfig.zipWithoutVersion -eq $true
+
+        # Create ZIP filename with or without version
+        if ($zipWithoutVersion)
+        {
+            $zip = Join-Path (Get-Item $relDir) "$templateName.zip"
+        }
+        else
+        {
+            $zip = Join-Path (Get-Item $relDir) "$templateName-v$version.zip"
+        }
 
         Write-Verbose "Checking for a nested version folder: $versionSubFolder"
         if ((Test-Path -Path $versionSubFolder -PathType Container) -eq $true)

--- a/src/templates/finops-hub-copilot/.build.config
+++ b/src/templates/finops-hub-copilot/.build.config
@@ -1,0 +1,6 @@
+{
+  "ignore": [],
+  "variableExpansion": [],
+  "move": [],
+  "zipWithoutVersion": true
+}


### PR DESCRIPTION
Fixes #1801

## Changes

This PR fixes the broken GitHub Copilot instructions download link and adds clarifying notes about vscode:// protocol handlers.

### What was fixed

1. **Added .build.config for finops-hub-copilot template** - Enables the finops-hub-copilot.zip to be packaged without a version suffix
2. **Updated Package-Toolkit.ps1** - Added support for `zipWithoutVersion` option in .build.config to allow templates to be packaged without version numbers in the filename
3. **Added TIP notes in configure-ai.md** - Added two clarifying notes explaining that vscode:// protocol handler links require VS Code to be installed and providing manual alternatives
4. **Updated changelog** - Added entries for the new feature and fixes in the v13 section

## Testing

- [ ] Verify finops-hub-copilot.zip is generated during packaging
- [ ] Verify vscode:// links work when VS Code is installed
- [ ] Verify TIP notes render correctly in Microsoft Learn

## Related

- Closes #1801
- Supersedes #1842 (closed due to unnecessary JSON regeneration)