### PR TITLE
Fix finops-workbooks Bicep validation - correct .build.config paths

### DIFF
--- a/src/templates/finops-workbooks/.build.config
+++ b/src/templates/finops-workbooks/.build.config
@@ -6,7 +6,7 @@
   "variableExpansion": [],
   "move": [
     {
-      "path": "../governance-workbook",
+      "path": "../../release/governance-workbook",
       "destination": "workbooks/governance",
       "ignore": [
         "azuredeploy*.json",
@@ -17,7 +17,7 @@
       ]
     },
     {
-      "path": "../optimization-workbook",
+      "path": "../../release/optimization-workbook",
       "destination": "workbooks/optimization",
       "ignore": [
         "azuredeploy*.json",


### PR DESCRIPTION
## 🐛 Problem
Bicep compiler validation fails on `src/templates/finops-workbooks/main.bicep` because the `.build.config` was looking for workbook modules in the wrong location.

## 🔍 Root Cause
The `.build.config` paths were set to `../governance-workbook` and `../optimization-workbook`, but the Build-Toolkit.ps1 script generates these templates to the `release/` directory, not `src/templates/`.

## ✅ Solution
Updated `.build.config` to point to correct location:
- `../governance-workbook` → `../../release/governance-workbook`
- `../optimization-workbook` → `../../release/optimization-workbook`

## ✔️ Validation
- ✅ Build succeeded: `pwsh ./src/scripts/Build-Toolkit.ps1 finops-workbooks`
- ✅ Bicep validation passed: `bicep build release/finops-workbooks/main.bicep`
- ✅ Azure deployment what-if succeeded for ftk-workbooks resource group
- ✅ Workbook modules correctly copied to `release/finops-workbooks/workbooks/`

## 📋 Changes
- `src/templates/finops-workbooks/.build.config`: Updated 2 path references

Fixes #1862