### PR TITLE
Fix BCP318 warnings in finops-workbooks conditional outputs

### DIFF
--- a/src/templates/finops-workbooks/main.bicep
+++ b/src/templates/finops-workbooks/main.bicep
@@ -104,13 +104,13 @@ module governance 'workbooks/governance/main.bicep' = if (includeGovernance) {
 //==============================================================================
 
 @sys.description('Optimization workbook resource ID.')
-output optimizationId string = optimization.outputs.workbookId
+output optimizationId string = includeOptimization ? optimization!.outputs.workbookId : ''
 
 @sys.description('Optimization workbook Azure portal link.')
-output optimizationUrl string = optimization.outputs.workbookUrl
+output optimizationUrl string = includeOptimization ? optimization!.outputs.workbookUrl : ''
 
 @sys.description('Governance workbook resource ID.')
-output governanceId string = governance.outputs.workbookId
+output governanceId string = includeGovernance ? governance!.outputs.workbookId : ''
 
 @sys.description('Governance workbook Azure portal link.')
-output governanceUrl string = governance.outputs.workbookUrl
+output governanceUrl string = includeGovernance ? governance!.outputs.workbookUrl : ''


### PR DESCRIPTION
## Summary
Fixes BCP318 warnings that occur when conditional workbook modules are disabled via parameters.

## Changes
- Added null-forgiving operator (!) to conditional module outputs
- Used ternary expressions to return empty strings when modules are not deployed
- Prevents deployment failures when `includeOptimization` or `includeGovernance` set to false

## Testing
✅ Tested 3 deployment scenarios in Azure:
- Both workbooks enabled - all outputs have values
- Only optimization enabled - governance outputs return empty strings
- Only governance enabled - optimization outputs return empty strings

Fixes #1864