### PR TITLE
chore: update doc paths in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,6 +39,8 @@ Fixes # <!-- TODO: Add related issues (e.g., Fixes #123, #246, #369) -->
 ### 📖 Did you update documentation?
 
 > - [ ] ✅ Public docs in `docs` (required for `dev`)
+> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
+> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
 > - [ ] ✅ Internal dev docs in `src` (required for `dev`)
 > - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
 > - [ ] ❎ Docs not needed (small/internal change)


### PR DESCRIPTION
Make it clearer in the PR template what doc directories are available