### PR TITLE
Fix ADF triggers not starting after deployment

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -76,6 +76,7 @@ _Released January 2026_
   - Fixed backward compatibility in `Costs_transform_v1_2()` to support Cost Management exports that predate FOCUS 1.2 by adding fallback mappings for `PricingCurrency` and `SkuMeter` columns to their legacy `x_` counterparts.
   - Fixed RemoteHub manifest file not being copied to remote storage by splitting manifest dataset into separate source and sink datasets, allowing RemoteHub to override the sink to point to remote storage.
   - Fixed broken link for GitHub Copilot instructions download in [Configure AI documentation](hubs/configure-ai.md). The packaging process now respects the `unversionedZip` property in `.build.config` to create unversioned ZIP files for finops-hub-copilot, enabling stable download links ([#1803](https://github.com/microsoft/finops-toolkit/issues/1803)).
+  - Fixed ADF triggers not starting after deployment due to `$startTriggers` variable not being set from the `StartAllTriggers` environment variable in the Init-DataFactory.ps1 script.
 
 ### [Optimization engine](optimization-engine/overview.md) v13
 

--- a/src/templates/finops-hub/modules/fx/scripts/Init-DataFactory.ps1
+++ b/src/templates/finops-hub/modules/fx/scripts/Init-DataFactory.ps1
@@ -8,6 +8,9 @@ param(
 # Init outputs
 $DeploymentScriptOutputs = @{}
 
+# Convert environment variable to boolean
+$startTriggers = $env:StartAllTriggers -eq 'true' -or $env:StartAllTriggers -eq 'True'
+
 if (-not $Stop)
 {
     Start-Sleep -Seconds 10
@@ -19,6 +22,7 @@ $triggers = Get-AzDataFactoryV2Trigger `
     -DataFactoryName $env:DataFactoryName
 
 Write-Output "Found $($triggers.Length) trigger(s)"
+Write-Output "StartAllTriggers: $startTriggers"
 
 if ($startTriggers)
 {


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description

The `Init-DataFactory.ps1` script checks `if ($startTriggers)` on line 23 to determine whether to start ADF triggers after deployment. However, the variable `$startTriggers` was never defined in the script.

The Bicep template (`hub-initialize.bicep`) correctly passes an environment variable named `StartAllTriggers` with a value of `'true'` or `'false'`, but the PowerShell script never reads this environment variable, causing triggers to never start.

**Fix:** Added code to convert `$env:StartAllTriggers` to a boolean and assign it to `$startTriggers` before the conditional check.

## 📷 Screenshots

N/A - Infrastructure/deployment script fix

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [x] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)