### PR TITLE
Fix RemoteHub manifest dataset handling and improve naming clarity

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -74,7 +74,7 @@ _Released January 2026_
   - Fixed datatype mismatch in InitializeHub pipeline by changing `x_PricingBlockSize` from `decimal` to `real` to match PricingUnits table schema.
   - Fixed ADF pipeline dependency logic in config_RunBackfillJob, config_StartExportProcess, and config_ConfigureExports pipelines to properly handle both array and non-array scope configurations by adding 'Failed' condition to 'Save/Set Scopes' activity dependencies.
   - Fixed backward compatibility in `Costs_transform_v1_2()` to support Cost Management exports that predate FOCUS 1.2 by adding fallback mappings for `PricingCurrency` and `SkuMeter` columns to their legacy `x_` counterparts.
-  - Fixed RemoteHub manifest file not being copied to remote storage by splitting manifest dataset into separate source and sink datasets, allowing RemoteHub to override the sink to point to remote storage.
+  - Fixed RemoteHub manifest file not being copied to remote storage. The ingestion_manifest dataset is now consistently handled like other ingestion datasets (ingestion, ingestion_files) - created by the Core module and overridden by the RemoteHub module when configured, ensuring manifests are written to the correct storage location. Also renamed manifest_source to msexports_manifest and manifest_sink to ingestion_manifest for clarity.
   - Fixed broken link for GitHub Copilot instructions download in [Configure AI documentation](hubs/configure-ai.md). The packaging process now respects the `unversionedZip` property in `.build.config` to create unversioned ZIP files for finops-hub-copilot, enabling stable download links ([#1803](https://github.com/microsoft/finops-toolkit/issues/1803)).
 
 ### [Optimization engine](optimization-engine/overview.md) v13

--- a/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep
@@ -118,8 +118,12 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
     name: '${INGESTION}_files'
   }
 
-  resource dataset_manifest_source 'datasets' = {
-    name: 'manifest_source'
+  resource dataset_ingestion_manifest 'datasets' existing = {
+    name: 'ingestion_manifest'
+  }
+
+  resource dataset_msexports_manifest 'datasets' = {
+    name: 'msexports_manifest'
     properties: {
       parameters: {
         fileName: {
@@ -129,40 +133,6 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
         folderPath: {
           type: 'String'
           defaultValue: MSEXPORTS
-        }
-      }
-      type: 'Json'
-      typeProperties: {
-        location: {
-          type: 'AzureBlobFSLocation'
-          fileName: {
-            value: '@{dataset().fileName}'
-            type: 'Expression'
-          }
-          folderPath: {
-            value: '@{dataset().folderPath}'
-            type: 'Expression'
-          }
-        }
-      }
-      linkedServiceName: {
-        referenceName: app.storage
-        type: 'LinkedServiceReference'
-      }
-    }
-  }
-
-  resource dataset_manifest_sink 'datasets' = {
-    name: 'manifest_sink'
-    properties: {
-      parameters: {
-        fileName: {
-          type: 'String'
-          defaultValue: 'manifest.json'
-        }
-        folderPath: {
-          type: 'String'
-          defaultValue: INGESTION
         }
       }
       type: 'Json'
@@ -322,7 +292,7 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
               }
             }
             dataset: {
-              referenceName: dataFactory::dataset_manifest_source.name
+              referenceName: dataFactory::dataset_msexports_manifest.name
               type: 'DatasetReference'
               parameters: {
                 fileName: {
@@ -1020,7 +990,7 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
           }
           inputs: [
             {
-              referenceName: dataFactory::dataset_manifest_source.name
+              referenceName: dataFactory::dataset_msexports_manifest.name
               type: 'DatasetReference'
               parameters: {
                 fileName: 'manifest.json'
@@ -1033,7 +1003,7 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
           ]
           outputs: [
             {
-              referenceName: dataFactory::dataset_manifest_sink.name
+              referenceName: dataFactory::dataset_ingestion_manifest.name
               type: 'DatasetReference'
               parameters: {
                 fileName: 'manifest.json'

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Core/app.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Core/app.bicep
@@ -236,6 +236,42 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
       }
     }
   }
+
+  resource dataset_ingestion_manifest 'datasets' = {
+    name: 'ingestion_manifest'
+    properties: {
+      annotations: []
+      parameters: {
+        fileName: {
+          type: 'String'
+          defaultValue: 'manifest.json'
+        }
+        folderPath: {
+          type: 'String'
+          defaultValue: INGESTION
+        }
+      }
+      type: 'Json'
+      typeProperties: {
+        location: {
+          type: 'AzureBlobFSLocation'
+          fileName: {
+            value: '@{dataset().fileName}'
+            type: 'Expression'
+          }
+          folderPath: {
+            value: '@{dataset().folderPath}'
+            type: 'Expression'
+          }
+        }
+      }
+      linkedServiceName: {
+        parameters: {}
+        referenceName: app.storage
+        type: 'LinkedServiceReference'
+      }
+    }
+  }
 }
 
 //==============================================================================

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/RemoteHub/app.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/RemoteHub/app.bicep
@@ -152,9 +152,9 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
     }
   }
 
-  // Replace the manifest_sink dataset to write manifests to remote hub
-  resource dataset_manifest_sink 'datasets' = {
-    name: 'manifest_sink'
+  // Replace the ingestion_manifest dataset to write manifests to remote hub
+  resource dataset_ingestion_manifest 'datasets' = {
+    name: 'ingestion_manifest'
     properties: {
       annotations: []
       parameters: {


### PR DESCRIPTION
## 🛠️ Description

Fixes the RemoteHub manifest dataset handling to ensure manifests are correctly written to remote storage when a RemoteHub is configured.

**Problem:**
The `manifest_sink` dataset was defined in both the Exports module and the RemoteHub module. The Exports module definition was overwriting the RemoteHub configuration, causing manifests to be written to local storage instead of remote storage.

**Solution:**
- Moved `ingestion_manifest` dataset creation from Exports to Core module for consistency with other ingestion datasets (`dataset_ingestion`, `dataset_ingestion_files`)
- Renamed `manifest_source` → `msexports_manifest` to clearly indicate it points to the msexports container
- Renamed `manifest_sink` → `ingestion_manifest` to clearly indicate it points to the ingestion container
- RemoteHub now properly overrides `ingestion_manifest` to point to remote storage
- Follows the established pattern where Core creates base datasets and RemoteHub overrides them when configured

**Impact:**
- RemoteHub configurations will now correctly write manifests to remote storage
- Dataset names are more intuitive and avoid confusion with ADF source/sink terminology
- No breaking changes for deployments without RemoteHub

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [ ] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [x] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [ ] ❎ Docs not needed (small/internal change)