### PR TITLE
[AOE] Changed default SQL database backup redundancy to LRS

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -86,6 +86,8 @@ _Released January 2026_
 
 ### [Optimization engine](optimization-engine/overview.md) v13
 
+- **Changed**
+  - Changed default SQL database backup redundancy to LRS, for improved cost efficiency and compatibility with deployments in non-paired Azure regions.
 - **Fixed**
   - Reservations-related workbooks fixed by replacing Instance Size Flexibility ratios CSV vanity URL with actual one to work around Log Analytics externaldata limitation ([#1810](https://github.com/microsoft/finops-toolkit/issues/1810)).
   - Underutilized disks recommendations were not being generated when customer environment has Premium SSD V2 disks ([#1831](https://github.com/microsoft/finops-toolkit/issues/1831)).

--- a/src/optimization-engine/azuredeploy-nested.bicep
+++ b/src/optimization-engine/azuredeploy-nested.bicep
@@ -1761,7 +1761,7 @@ resource sqlDatabase 'Microsoft.Sql/servers/databases@2022-05-01-preview' = {
     zoneRedundant: false
     readScale: 'Disabled'
     autoPauseDelay: 60
-    requestedBackupStorageRedundancy: 'Geo'
+    requestedBackupStorageRedundancy: 'Local'
   }
 }
 


### PR DESCRIPTION
## 🛠️ Description

Changed default Azure Optimization Engine SQL database backup redundancy to LRS, for improved cost efficiency and compatibility with deployments in non-paired Azure regions.

## 📋 Checklist

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [X] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [X] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [X] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)
