### PR TITLE
Add -AsTag parameter to Get-Version

### DIFF
--- a/src/scripts/Get-Version.ps1
+++ b/src/scripts/Get-Version.ps1
@@ -13,15 +13,26 @@
     2. Strip control characters
     3. Remove patch version when 0 (keep major.minor and label)
 
+    .PARAMETER AsTag
+    Optional. Returns the version as a git tag (e.g., "v13" instead of "13.0"). Default = false.
+
     .PARAMETER AsDotNetVersion
-    Optional. Indicates that the returned version should be in the format "x.x.x.x". Otherwise, semantic versioning is used. Deafult = false.
+    Optional. Indicates that the returned version should be in the format "x.x.x.x". Otherwise, semantic versioning is used. Default = false.
 
     .EXAMPLE
     ./Get-Version
 
     Gets the current version number.
+
+    .EXAMPLE
+    ./Get-Version -AsTag
+
+    Gets the version as a git tag (e.g., "v13" instead of "13.0").
 #>
 param(
+    [switch]
+    $AsTag,
+
     [switch]
     $AsDotNetVersion
 )
@@ -31,6 +42,11 @@ $ver = (Get-Content (Join-Path $PSScriptRoot ../../package.json) | ConvertFrom-J
     -replace '^(\d+\.\d+)(\.0)(-[a-z]+)?$', '$1$3' `
     -replace '^(\d+\.\d+)(\.0)?(-[a-z]+)?(\.\d+)?$', '$1$3$4' `
     -replace '(-[a-z]+)\.0$', '$1'
+
+if ($AsTag)
+{
+    return 'v' + ($ver -replace '\.0$', '')
+}
 
 if ($AsDotNetVersion -and $ver.Contains('-'))
 {

--- a/src/scripts/Package-Toolkit.ps1
+++ b/src/scripts/Package-Toolkit.ps1
@@ -115,7 +115,7 @@ function Copy-TemplateFiles()
         $zip = if ($unversionedZip) {
             Join-Path (Get-Item $relDir) "$templateName.zip"
         } else {
-            Join-Path (Get-Item $relDir) "$templateName-$version.zip"
+            Join-Path (Get-Item $relDir) "$templateName-$tag.zip"
         }
 
         Write-Verbose "Checking for a nested version folder: $versionSubFolder"
@@ -200,7 +200,8 @@ function Copy-OpenDataFolders()
     }
 }
 
-$version = & "$PSScriptRoot/Get-Version" -AsTag
+$version = & "$PSScriptRoot/Get-Version"
+$tag = & "$PSScriptRoot/Get-Version" -AsTag
 
 if ($CopyFiles -or $Build -or $Preview -or -not ($OpenPBI -or $ZipPBI))
 {

--- a/src/scripts/Package-Toolkit.ps1
+++ b/src/scripts/Package-Toolkit.ps1
@@ -83,7 +83,7 @@ if ($Template -ne "*" -and -not (Test-Path $relDir))
 
 function Copy-TemplateFiles()
 {
-    Write-Host "Packaging $(if ($Template) { "$Template v$version template" } else { "v$version templates" })..."
+    Write-Host "Packaging $(if ($Template) { "$Template $version template" } else { "$version templates" })..."
 
     Write-Verbose "Removing existing ZIP files..."
     Remove-Item "$relDir/*.zip" -Force
@@ -115,7 +115,7 @@ function Copy-TemplateFiles()
         $zip = if ($unversionedZip) {
             Join-Path (Get-Item $relDir) "$templateName.zip"
         } else {
-            Join-Path (Get-Item $relDir) "$templateName-v$version.zip"
+            Join-Path (Get-Item $relDir) "$templateName-$version.zip"
         }
 
         Write-Verbose "Checking for a nested version folder: $versionSubFolder"
@@ -200,7 +200,7 @@ function Copy-OpenDataFolders()
     }
 }
 
-$version = & "$PSScriptRoot/Get-Version"
+$version = & "$PSScriptRoot/Get-Version" -AsTag
 
 if ($CopyFiles -or $Build -or $Preview -or -not ($OpenPBI -or $ZipPBI))
 {

--- a/src/scripts/Package-Toolkit.ps1
+++ b/src/scripts/Package-Toolkit.ps1
@@ -83,7 +83,7 @@ if ($Template -ne "*" -and -not (Test-Path $relDir))
 
 function Copy-TemplateFiles()
 {
-    Write-Host "Packaging $(if ($Template) { "$Template $version template" } else { "$version templates" })..."
+    Write-Host "Packaging $(if ($Template -ne "*") { "$Template $version template" } else { "$version templates" })..."
 
     Write-Verbose "Removing existing ZIP files..."
     Remove-Item "$relDir/*.zip" -Force

--- a/src/scripts/Update-Version.ps1
+++ b/src/scripts/Update-Version.ps1
@@ -102,7 +102,7 @@ if ($update -or $Version)
 {
     # Update version files: ftkver.txt (major.minor) and ftktag.txt (git tag, e.g., "v13")
     $repoRoot = (Resolve-Path "$PSScriptRoot/../..").Path
-    $tag = 'v' + ($ver -replace '\.0$', '')
+    $tag = & "$PSScriptRoot/Get-Version" -AsTag
     foreach ($entry in @{ 'ftkver.txt' = $ver; 'ftktag.txt' = $tag }.GetEnumerator())
     {
         Write-Verbose "Updating $($entry.Key) files..."


### PR DESCRIPTION
## 🛠️ Description

Added `-AsTag` switch to `Get-Version.ps1` that returns the full git tag (e.g., `v13` instead of `13.0`). Updated `Package-Toolkit.ps1` to use it so zip filenames match release expectations (`finops-hub-v13.zip` instead of `finops-hub-v13.0.zip`). Updated `Update-Version.ps1` to use it for writing `ftktag.txt` instead of inline regex.

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)