### PR TITLE
fix: Deploy-FinOpsHub fails in Cloud Shell/Linux (#665)

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -29,6 +29,11 @@ The following section lists features and enhancements that are currently in deve
 
 - Cost Management export modules for subscriptions and resource groups.
 
+### [PowerShell module](powershell/powershell-commands.md) v14
+
+- **Fixed**
+  - Fixed [Deploy-FinOpsHub](powershell/hubs/Deploy-FinOpsHub.md) failing in Cloud Shell and Linux environments due to missing TEMP environment variable (required by Bicep CLI) and cleanup errors masking the real problem ([#665](https://github.com/microsoft/finops-toolkit/issues/665)).
+
 <br><a name="latest"></a>
 
 ## v13


### PR DESCRIPTION
## 🛠️ Description

Initialize `$toolkitPath` before the try block to ensure cleanup works even if an early failure occurs. The `$toolkitPath` variable was being set inside the try block, but the finally block attempted to use it for cleanup. If an error occurred before `$toolkitPath` was set (e.g., when `$env:temp` is not defined on Linux/Cloud Shell), the cleanup failed with "Cannot bind argument to parameter 'Path' because it is null", masking the real error.

Fixes #665

## 📷 Screenshots

N/A - Code fix only

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [x] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)
