### PR TITLE
Fix/init datafactory provisioning retry

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -33,6 +33,15 @@ The following section lists features and enhancements that are currently in deve
 
 <br><a name="latest"></a>
 
+## v14
+
+### [FinOps hubs](hubs/finops-hubs-overview.md) v14
+
+- **Fixed**
+  - Fixed Init-DataFactory deployment script failing when an Event Grid subscription is already provisioning by checking subscription status before attempting subscribe/unsubscribe and polling separately for completion ([#1996](https://github.com/microsoft/finops-toolkit/issues/1996)).
+
+<br>
+
 ## v13 Update 1
 
 _Released February 11, 2026_

--- a/src/templates/finops-hub/modules/fx/scripts/Init-DataFactory.ps1
+++ b/src/templates/finops-hub/modules/fx/scripts/Init-DataFactory.ps1
@@ -78,38 +78,43 @@ function Set-BlobTriggerSubscription([string]$TriggerName, [switch]$Subscribe)
     $action = if ($Subscribe) { 'Subscribing' } else { 'Unsubscribing' }
 
     Write-Log "$action $TriggerName to events..."
-    try
-    {
-        Invoke-WithRetry -Name "$action $TriggerName" -Delay 5 -Action {
-            if ($Subscribe)
-            {
-                Add-AzDataFactoryV2TriggerSubscription `
-                    -ResourceGroupName $DataFactoryResourceGroup `
-                    -DataFactoryName $DataFactoryName `
-                    -Name $TriggerName | Out-Null
-            }
-            else
-            {
-                Remove-AzDataFactoryV2TriggerSubscription `
-                    -ResourceGroupName $DataFactoryResourceGroup `
-                    -DataFactoryName $DataFactoryName `
-                    -Name $TriggerName | Out-Null
-            }
-        }
-    }
-    catch
-    {
-        $currentStatus = (Get-AzDataFactoryV2TriggerSubscriptionStatus `
+
+    # Check current status before attempting subscribe/unsubscribe
+    $currentStatus = (Get-AzDataFactoryV2TriggerSubscriptionStatus `
             -ResourceGroupName $DataFactoryResourceGroup `
             -DataFactoryName $DataFactoryName `
             -Name $TriggerName).Status
-        if ($currentStatus -ne 'Provisioning' -and $currentStatus -ne 'Deprovisioning')
-        {
-            throw
-        }
-        Write-Log "$TriggerName subscription is already $currentStatus, waiting for completion..."
+
+    if ($currentStatus -eq $targetStatus)
+    {
+        Write-Log "$TriggerName subscription is already $targetStatus, skipping."
+        return
     }
 
+    if ($currentStatus -eq 'Provisioning' -or $currentStatus -eq 'Deprovisioning')
+    {
+        Write-Log "$TriggerName subscription is $currentStatus, waiting for completion..."
+    }
+    else
+    {
+        # Only call subscribe/unsubscribe when not already in a transitional state
+        if ($Subscribe)
+        {
+            Add-AzDataFactoryV2TriggerSubscription `
+                -ResourceGroupName $DataFactoryResourceGroup `
+                -DataFactoryName $DataFactoryName `
+                -Name $TriggerName | Out-Null
+        }
+        else
+        {
+            Remove-AzDataFactoryV2TriggerSubscription `
+                -ResourceGroupName $DataFactoryResourceGroup `
+                -DataFactoryName $DataFactoryName `
+                -Name $TriggerName | Out-Null
+        }
+    }
+
+    # Poll until provisioning completes
     Invoke-WithRetry -Name "$action status $TriggerName" -Delay 5 -Action {
         $status = Get-AzDataFactoryV2TriggerSubscriptionStatus `
             -ResourceGroupName $DataFactoryResourceGroup `


### PR DESCRIPTION
## 🛠️ Description

Improves the fix from #1997 for Event Grid subscription handling in `Init-DataFactory.ps1`.

The original PR (#1997) correctly identified the problem (subscribe + status poll in the same retry loop), but wrapped the subscribe call in `Invoke-WithRetry` with an outer `try/catch` — meaning up to ~17 minutes of wasted retries before the "already provisioning" fallback kicks in.

This PR takes a check-first approach instead:

1. **Pre-check** the current subscription status before calling subscribe/unsubscribe
2. **Early return** if already at the target status (`Enabled`/`Disabled`)
3. **Skip the call** if already in a transitional state (`Provisioning`/`Deprovisioning`) and go straight to polling
4. **Poll separately** for completion using `Invoke-WithRetry`

Also adds the missing changelog entry under v14.

Fixes #1996
Supersedes #1997

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [x] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)