### PR TITLE
Force common filters and group bys to be lowercase

### DIFF
--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_2.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_2.kql
@@ -1721,8 +1721,8 @@ Recommendations_transform_v1_2()
     //
     | project
         ProviderName,
-        ResourceId,
-        ResourceName,
+        ResourceId = tolower(ResourceId),      // Force lowercase for consistent grouping/filtering
+        ResourceName = tolower(ResourceName),  // Force lowercase for consistent grouping/filtering
         ResourceType,
         SubAccountId = coalesce(SubAccountId, iff(isnotempty(SubscriptionId), strcat('/subscriptions/', SubscriptionId), '')),
         SubAccountName,
@@ -1734,8 +1734,8 @@ Recommendations_transform_v1_2()
         x_RecommendationDate,
         x_RecommendationDescription,
         x_RecommendationDetails,
-        x_RecommendationId,        // TODO: Set for reservation recommendations
-        x_ResourceGroupName,
+        x_RecommendationId = coalesce(x_RecommendationId, tolower(ResourceId)),  // Force lowercase for consistent grouping/filtering
+        x_ResourceGroupName = tolower(x_ResourceGroupName),                      // Force lowercase for consistent grouping/filtering
         x_SourceName,
         x_SourceProvider,
         x_SourceType,

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_2.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_2.kql
@@ -1734,8 +1734,8 @@ Recommendations_transform_v1_2()
         x_RecommendationDate,
         x_RecommendationDescription,
         x_RecommendationDetails,
-        x_RecommendationId = coalesce(x_RecommendationId, tolower(ResourceId)),  // Force lowercase for consistent grouping/filtering
-        x_ResourceGroupName = tolower(x_ResourceGroupName),                      // Force lowercase for consistent grouping/filtering
+        x_RecommendationId = tolower(x_RecommendationId),    // TODO: Set for reservation recommendations; force lowercase for consistent grouping/filtering
+        x_ResourceGroupName = tolower(x_ResourceGroupName),  // Force lowercase for consistent grouping/filtering
         x_SourceName,
         x_SourceProvider,
         x_SourceType,


### PR DESCRIPTION
## 🛠️ Description

Force common filter and group-by columns to lowercase in the IngestionSetup KQL script to ensure consistent casing for joins and comparisons across datasets.

Fixes # N/A

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [x] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)