### PR TITLE
Fix update-mslearn-dates action error + unit test failure 

### DIFF
--- a/.github/workflows/update-mslearn-dates.yml
+++ b/.github/workflows/update-mslearn-dates.yml
@@ -43,7 +43,7 @@ jobs:
             # Check if file has ms.date in frontmatter and update it
             if grep -q "^ms\.date:" "$file"; then
               # Use sed to replace the ms.date line
-              sed -i "s/^ms\.date:.*$/ms.date: $CURRENT_DATE/" "$file"
+              sed -i "s|^ms\.date:.*$|ms.date: $CURRENT_DATE|" "$file"
               echo "  Updated ms.date in $file"
             else
               echo "  No ms.date found in $file, skipping"

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -3,7 +3,7 @@ title: FinOps toolkit changelog
 description: Review the latest features and enhancements in the FinOps toolkit, including updates to FinOps hubs, Power BI reports, and more.
 author: MSBrett
 ms.author: brettwil
-ms.date: 02/11/2026
+ms.date: 02/23/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -8,7 +8,7 @@ ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit
 ms.reviewer: brettwil
-#customer intent: As a FinOps user, I want to understand what changes were made in the latest FinOps toolkit releases.
+#customer intent: As a FinOps practitioner, I want to understand what changes were made in the latest FinOps toolkit releases.
 ---
 
 <!-- cSpell:ignore nextstepaction -->

--- a/src/powershell/Tests/Unit/Action.UpdateMsLearnDates.Tests.ps1
+++ b/src/powershell/Tests/Unit/Action.UpdateMsLearnDates.Tests.ps1
@@ -80,7 +80,7 @@ Describe 'update-mslearn-dates GitHub Action' {
 
         It 'Should use sed to replace ms.date line' {
             $workflowContent | Should -Match 'sed -i'
-            $workflowContent | Should -Match 's/\^ms\\\.date:'
+            $workflowContent | Should -Match 's[/|]\^ms\\\.date:'
         }
 
         It 'Should have step to check for changes before committing' {
@@ -109,7 +109,7 @@ Describe 'update-mslearn-dates GitHub Action' {
     Context 'Sed command validation' {
         It 'Should have correct sed regex to match ms.date at line start' {
             # The sed command should use ^ to anchor to start of line
-            $workflowContent | Should -Match 's/\^ms\\\.date:\.\*\$/ms\.date:'
+            $workflowContent | Should -Match 's[/|]\^ms\\\.date:\.\*\$[/|]ms\.date:'
         }
 
         It 'Should replace entire ms.date line' {
@@ -124,7 +124,7 @@ Describe 'update-mslearn-dates GitHub Action' {
         }
 
         It 'Should only add docs-mslearn files to commit' {
-            $workflowContent | Should -Match 'git add docs-mslearn/'
+            $workflowContent | Should -Match 'git add (-u )?docs-mslearn/'
         }
     }
 }


### PR DESCRIPTION
## 🛠️ Description

The `update-mslearn-dates` GitHub Action fails when processing markdown files because the `sed` command uses `/` as a delimiter, which conflicts with the `MM/DD/YYYY` date format. For example, `sed -i "s/^ms\.date:.*$/ms.date: 02/23/2026/"` breaks because the slashes in the date create extra delimiters.

Changes the sed delimiter from `/` to `|` and updates unit test assertions to match.

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [x] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)