### PR TITLE
[DevOps] PR Builds: Add PR deployment support to Deploy-Hub

### DIFF
--- a/docs-mslearn/toolkit/hubs/configure-scopes.md
+++ b/docs-mslearn/toolkit/hubs/configure-scopes.md
@@ -3,7 +3,7 @@ title: Configure scopes for FinOps hubs
 description: Connect FinOps hubs to billing accounts and subscriptions by configuring Cost Management exports manually or give FinOps hubs access to manage exports for you.
 author: flanakin
 ms.author: micflan
-ms.date: 03/01/2026
+ms.date: 03/04/2026
 ms.topic: how-to
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/hubs/configure-scopes.md
+++ b/docs-mslearn/toolkit/hubs/configure-scopes.md
@@ -3,7 +3,7 @@ title: Configure scopes for FinOps hubs
 description: Connect FinOps hubs to billing accounts and subscriptions by configuring Cost Management exports manually or give FinOps hubs access to manage exports for you.
 author: flanakin
 ms.author: micflan
-ms.date: 02/24/2026
+ms.date: 02/28/2026
 ms.topic: how-to
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/hubs/configure-scopes.md
+++ b/docs-mslearn/toolkit/hubs/configure-scopes.md
@@ -224,8 +224,7 @@ Managed exports use a managed identity (MI) to configure the exports automatical
    - Use the following guides to assign access to each scope you want to monitor:
      - EA enrollments – [Assign enrollment reader role permission](/azure/cost-management-billing/manage/assign-roles-azure-service-principals#assign-enrollment-account-role-permission-to-the-spn).
      - EA departments – [Assign department reader role permission](/azure/cost-management-billing/manage/assign-roles-azure-service-principals#assign-enrollment-account-role-permission-to-the-spn).
-     - Subscriptions and resource groups – [Assign Azure roles using the Azure portal](/azure/role-based-access-control/role-assignments-portal). Assign the following roles to the hub managed identity on each scope:
-       - **Cost Management Contributor** – create and manage exports.
+     - Subscriptions and resource groups – Assign the **Cost Management Contributor** role to the hub managed identity on each scope. [Learn more](/azure/role-based-access-control/role-assignments-portal).
 
    <!--
    ### Enterprise agreement billing accounts and departments

--- a/docs-mslearn/toolkit/hubs/configure-scopes.md
+++ b/docs-mslearn/toolkit/hubs/configure-scopes.md
@@ -226,7 +226,6 @@ Managed exports use a managed identity (MI) to configure the exports automatical
      - EA departments – [Assign department reader role permission](/azure/cost-management-billing/manage/assign-roles-azure-service-principals#assign-enrollment-account-role-permission-to-the-spn).
      - Subscriptions and resource groups – [Assign Azure roles using the Azure portal](/azure/role-based-access-control/role-assignments-portal). Assign the following roles to the hub managed identity on each scope:
        - **Cost Management Contributor** – create and manage exports.
-       - **RBAC Administrator** – required by Cost Management to grant itself access to write export data to the hub storage account.
 
    <!--
    ### Enterprise agreement billing accounts and departments

--- a/docs-mslearn/toolkit/hubs/configure-scopes.md
+++ b/docs-mslearn/toolkit/hubs/configure-scopes.md
@@ -3,7 +3,7 @@ title: Configure scopes for FinOps hubs
 description: Connect FinOps hubs to billing accounts and subscriptions by configuring Cost Management exports manually or give FinOps hubs access to manage exports for you.
 author: flanakin
 ms.author: micflan
-ms.date: 03/05/2026
+ms.date: 03/10/2026
 ms.topic: how-to
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/hubs/configure-scopes.md
+++ b/docs-mslearn/toolkit/hubs/configure-scopes.md
@@ -224,7 +224,9 @@ Managed exports use a managed identity (MI) to configure the exports automatical
    - Use the following guides to assign access to each scope you want to monitor:
      - EA enrollments – [Assign enrollment reader role permission](/azure/cost-management-billing/manage/assign-roles-azure-service-principals#assign-enrollment-account-role-permission-to-the-spn).
      - EA departments – [Assign department reader role permission](/azure/cost-management-billing/manage/assign-roles-azure-service-principals#assign-enrollment-account-role-permission-to-the-spn).
-     - Subscriptions and resource groups – [Assign Azure roles using the Azure portal](/azure/role-based-access-control/role-assignments-portal).
+     - Subscriptions and resource groups – [Assign Azure roles using the Azure portal](/azure/role-based-access-control/role-assignments-portal). Assign the following roles to the hub managed identity on each scope:
+       - **Cost Management Contributor** – create and manage exports.
+       - **RBAC Administrator** – required by Cost Management to grant itself access to write export data to the hub storage account.
 
    <!--
    ### Enterprise agreement billing accounts and departments

--- a/docs-mslearn/toolkit/hubs/configure-scopes.md
+++ b/docs-mslearn/toolkit/hubs/configure-scopes.md
@@ -3,7 +3,7 @@ title: Configure scopes for FinOps hubs
 description: Connect FinOps hubs to billing accounts and subscriptions by configuring Cost Management exports manually or give FinOps hubs access to manage exports for you.
 author: flanakin
 ms.author: micflan
-ms.date: 03/04/2026
+ms.date: 03/05/2026
 ms.topic: how-to
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/hubs/configure-scopes.md
+++ b/docs-mslearn/toolkit/hubs/configure-scopes.md
@@ -3,7 +3,7 @@ title: Configure scopes for FinOps hubs
 description: Connect FinOps hubs to billing accounts and subscriptions by configuring Cost Management exports manually or give FinOps hubs access to manage exports for you.
 author: flanakin
 ms.author: micflan
-ms.date: 02/28/2026
+ms.date: 03/01/2026
 ms.topic: how-to
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/src/scripts/Deploy-Hub.ps1
+++ b/src/scripts/Deploy-Hub.ps1
@@ -76,6 +76,15 @@
     .PARAMETER Location
     Optional. Azure location. Default: westus.
 
+    .PARAMETER PR
+    Use PR naming convention. Sets initials to "pr" so resources are named "pr-{name}".
+
+    .PARAMETER Scope
+    Optional. Azure scope ID for cost data exports (e.g., "/subscriptions/{id}"). When specified with -ManagedExports, enables managed exports and grants the hub identity access. When specified without -ManagedExports, creates exports manually via New-FinOpsCostExport after deployment.
+
+    .PARAMETER ManagedExports
+    Optional. Use managed exports instead of manual exports. Requires -Scope. Grants the hub managed identity the required roles on the scope and passes scopesToMonitor to the template.
+
     .PARAMETER Build
     Optional. Build the template before deploying.
 
@@ -94,6 +103,9 @@ param(
     [string]$Fabric,
     [switch]$StorageOnly,
     [switch]$Remove,
+    [switch]$PR,
+    [string]$Scope,
+    [switch]$ManagedExports,
     [string]$Location,
     [switch]$Build,
     [switch]$WhatIf
@@ -123,7 +135,14 @@ function Get-Initials()
     return $u.Substring(0, [Math]::Min(2, $u.Length))
 }
 
-$initials = Get-Initials
+if ($PR)
+{
+    $initials = "pr"
+}
+else
+{
+    $initials = Get-Initials
+}
 
 # Default name to "adx" when not specified
 if (-not $Name)
@@ -188,6 +207,12 @@ if ($StorageOnly -and $Fabric)
     return
 }
 
+if ($ManagedExports -and -not $Scope)
+{
+    Write-Error "-ManagedExports requires -Scope. Provide an Azure scope ID (e.g., '/subscriptions/{id}')."
+    return
+}
+
 # Build parameters
 $params = @{}
 
@@ -215,6 +240,18 @@ else
 
 Write-Host "  Hub: $($params.hubName)"
 
+# Managed exports via template parameters
+if ($ManagedExports -and $Scope)
+{
+    $params.enableManagedExports = $true
+    $params.scopesToMonitor = @($Scope)
+    Write-Host "  Managed exports: $Scope"
+}
+elseif ($Scope)
+{
+    Write-Host "  Manual exports: $Scope"
+}
+
 # Resource group
 if (-not $ResourceGroup)
 {
@@ -232,3 +269,64 @@ $deployArgs.Build = $Build
 $deployArgs.WhatIf = $WhatIf
 
 & "$PSScriptRoot/Deploy-Toolkit" @deployArgs
+
+#------------------------------------------------------------------------------
+# Post-deployment: configure exports
+#------------------------------------------------------------------------------
+
+if ($Scope -and -not $WhatIf -and $global:ftkDeployment)
+{
+    $outputs = $global:ftkDeployment.Outputs
+
+    if ($ManagedExports)
+    {
+        # Grant hub managed identity the required roles on the scope
+        $managedIdentityId = $outputs["managedIdentityId"].Value
+        if ($managedIdentityId)
+        {
+            Write-Host "Granting hub identity access to $Scope..."
+            $roles = @("Cost Management Contributor", "RBAC Administrator")
+            foreach ($role in $roles)
+            {
+                $existing = Get-AzRoleAssignment -ObjectId $managedIdentityId -RoleDefinitionName $role -Scope $Scope -ErrorAction SilentlyContinue
+                if (-not $existing)
+                {
+                    New-AzRoleAssignment -ObjectId $managedIdentityId -RoleDefinitionName $role -Scope $Scope -ErrorAction SilentlyContinue | Out-Null
+                    Write-Host "  Granted: $role"
+                }
+            }
+        }
+        else
+        {
+            Write-Warning "Could not retrieve managedIdentityId from deployment outputs. Grant access manually."
+        }
+    }
+    else
+    {
+        # Create exports manually via New-FinOpsCostExport
+        $storageAccountId = $outputs["storageAccountId"].Value
+        if ($storageAccountId)
+        {
+            Write-Host "Creating manual exports for $Scope..."
+
+            # Build the FinOps toolkit PowerShell module if not already loaded
+            if (-not (Get-Command New-FinOpsCostExport -ErrorAction SilentlyContinue))
+            {
+                Import-Module "$PSScriptRoot/../powershell/FinOpsToolkit.psm1" -Force
+            }
+
+            New-FinOpsCostExport -Name "ftk-focuscost" `
+                -Scope $Scope `
+                -Dataset "FocusCost" `
+                -StorageAccountId $storageAccountId `
+                -StorageContainer "msexports" `
+                -DoNotOverwrite `
+                -Execute
+            Write-Host "  Created FocusCost export and triggered initial run."
+        }
+        else
+        {
+            Write-Warning "Could not retrieve storageAccountId from deployment outputs. Create exports manually."
+        }
+    }
+}

--- a/src/scripts/Deploy-Hub.ps1
+++ b/src/scripts/Deploy-Hub.ps1
@@ -55,8 +55,11 @@
     .PARAMETER Name
     Optional. First positional parameter. Suffix for the "{initials}-{name}" naming convention used for resource group and ADX cluster. Default: "adx".
 
+    .PARAMETER PR
+    Optional. PR number to include in the hub name for easy identification. Used with -Name to form the default hub name "{pr}{name}{initials}" when -HubName is not specified.
+
     .PARAMETER HubName
-    Optional. Name of the hub instance. Default: "hub".
+    Optional. Name of the hub instance. Default: "hub", or "{pr}{name}{initials}" when -PR or -Name is specified.
 
     .PARAMETER ADX
     Optional. Name of the Azure Data Explorer cluster. Overrides the "{initials}-{name}" convention. Only used when not using -StorageOnly or -Fabric.
@@ -97,6 +100,7 @@
 param(
     [Parameter(Position = 0)]
     [string]$Name,
+    [string]$PR,
     [string]$HubName,
     [string]$ADX,
     [string]$ResourceGroup,
@@ -216,8 +220,14 @@ if ($ManagedExports -and -not $Scope)
 # Build parameters
 $params = @{}
 
-# Hub name
+# Hub name — use "{pr}{name}{initials}" when -PR or -Name is specified, otherwise "hub"
 if ($HubName) { $params.hubName = $HubName }
+elseif ($PR -or $PSBoundParameters.ContainsKey('Name'))
+{
+    $explicitName = if ($PSBoundParameters.ContainsKey('Name')) { $Name } else { $null }
+    $hubParts = @($PR, $explicitName, $initials) | Where-Object { $_ }
+    $params.hubName = (($hubParts -join '') -replace '[^a-zA-Z0-9]', '').ToLower()
+}
 else { $params.hubName = "hub" }
 
 # Analytics backend

--- a/src/scripts/Deploy-Hub.ps1
+++ b/src/scripts/Deploy-Hub.ps1
@@ -77,7 +77,7 @@
     Optional. Azure location. Default: westus.
 
     .PARAMETER PR
-    Optional. Indicates the PR naming convention (e.g., "pr-123") should be used.
+    Optional. PR number for CI deployments. Resources are named "pr-{number}" or "pr-{number}-{name}" when -Name is also specified.
 
     .PARAMETER Scope
     Optional. Azure scope ID for cost data exports (e.g., "/subscriptions/{id}"). When specified with -ManagedExports, enables managed exports and grants the hub identity access. When specified without -ManagedExports, creates exports manually via New-FinOpsCostExport after deployment.
@@ -103,7 +103,7 @@ param(
     [string]$Fabric,
     [switch]$StorageOnly,
     [switch]$Remove,
-    [switch]$PR,
+    [int]$PR,
     [string]$Scope,
     [switch]$ManagedExports,
     [string]$Location,
@@ -137,7 +137,7 @@ function Get-Initials()
 
 if ($PR)
 {
-    $initials = "pr"
+    $initials = "pr-$PR"
 }
 else
 {
@@ -286,7 +286,7 @@ if ($Scope -and -not $WhatIf -and $global:ftkDeployment)
         if ($managedIdentityId)
         {
             Write-Host "Granting hub identity access to $Scope..."
-            $roles = @("Cost Management Contributor", "RBAC Administrator")
+            $roles = @("Cost Management Contributor")
             foreach ($role in $roles)
             {
                 $existing = Get-AzRoleAssignment -ObjectId $managedIdentityId -RoleDefinitionName $role -Scope $Scope -ErrorAction SilentlyContinue

--- a/src/scripts/Deploy-Hub.ps1
+++ b/src/scripts/Deploy-Hub.ps1
@@ -77,7 +77,7 @@
     Optional. Azure location. Default: westus.
 
     .PARAMETER PR
-    Use PR naming convention. Sets initials to "pr" so resources are named "pr-{name}".
+    Optional. Indicates the PR naming convention (e.g., "pr-123") should be used.
 
     .PARAMETER Scope
     Optional. Azure scope ID for cost data exports (e.g., "/subscriptions/{id}"). When specified with -ManagedExports, enables managed exports and grants the hub identity access. When specified without -ManagedExports, creates exports manually via New-FinOpsCostExport after deployment.
@@ -249,6 +249,7 @@ if ($ManagedExports -and $Scope)
 }
 elseif ($Scope)
 {
+    $params.enableManagedExports = $false
     Write-Host "  Manual exports: $Scope"
 }
 
@@ -291,8 +292,15 @@ if ($Scope -and -not $WhatIf -and $global:ftkDeployment)
                 $existing = Get-AzRoleAssignment -ObjectId $managedIdentityId -RoleDefinitionName $role -Scope $Scope -ErrorAction SilentlyContinue
                 if (-not $existing)
                 {
-                    New-AzRoleAssignment -ObjectId $managedIdentityId -RoleDefinitionName $role -Scope $Scope -ErrorAction SilentlyContinue | Out-Null
-                    Write-Host "  Granted: $role"
+                    $result = New-AzRoleAssignment -ObjectId $managedIdentityId -RoleDefinitionName $role -Scope $Scope -ErrorAction SilentlyContinue
+                    if ($result)
+                    {
+                        Write-Host "  Granted: $role"
+                    }
+                    else
+                    {
+                        Write-Warning "Failed to grant $role. You may need to assign it manually."
+                    }
                 }
             }
         }
@@ -309,7 +317,7 @@ if ($Scope -and -not $WhatIf -and $global:ftkDeployment)
         {
             Write-Host "Creating manual exports for $Scope..."
 
-            # Build the FinOps toolkit PowerShell module if not already loaded
+            # Import the FinOps toolkit PowerShell module if not already loaded
             if (-not (Get-Command New-FinOpsCostExport -ErrorAction SilentlyContinue))
             {
                 Import-Module "$PSScriptRoot/../powershell/FinOpsToolkit.psm1" -Force

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -157,7 +157,7 @@ All resources use an `{initials}-{name}` naming convention where initials are pu
 | `‑Fabric`          | Optional. Deploy with Microsoft Fabric. Provide the eventhouse query URI.                                                                                                            |
 | `‑StorageOnly`     | Optional. Deploy a storage-only hub (no Azure Data Explorer or Fabric).                                                                                                              |
 | `‑Remove`          | Optional. Remove test environments. With a name, deletes the target RG. Alone, lists all `{initials}-*`.                                                                             |
-| `‑PR`              | Optional. Use PR naming convention. Sets initials to `pr` so resources are named `pr-{name}`.                                                                                        |
+| `‑PR`              | Optional. PR number for CI deployments. Resources are named `pr-{number}` or `pr-{number}-{name}` when `-Name` is also specified.                                                    |
 | `‑Scope`           | Optional. Azure scope ID for cost data exports (e.g., `/subscriptions/{id}`). With `-ManagedExports`, enables managed exports. Without it, creates exports manually.                 |
 | `‑ManagedExports`  | Optional. Use managed exports instead of manual exports. Requires `-Scope`. Passes `scopesToMonitor` to the template and grants the hub identity required roles.                     |
 | `‑Location`        | Optional. Azure location. Default: `westus`.                                                                                                                                         |
@@ -208,16 +208,16 @@ Examples:
   ./Deploy-Hub -Remove
   ```
 
-- Deploy with PR naming convention (e.g., RG `pr-123`, ADX `pr-123`):
+- Deploy with PR naming convention (e.g., RG `pr-123-adx`, ADX `pr-123-adx`):
 
   ```powershell
-  ./Deploy-Hub -PR 123
+  ./Deploy-Hub -PR 123 -Name adx
   ```
 
 - Deploy with managed exports:
 
   ```powershell
-  ./Deploy-Hub -PR 123 -Scope "/subscriptions/{id}" -ManagedExports -Build
+  ./Deploy-Hub -PR 123 -Name adx -Scope "/subscriptions/{id}" -ManagedExports -Build
   ```
 
 - Deploy storage-only with manual exports:

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -148,18 +148,21 @@ By default, deploys with Azure Data Explorer (dev SKU). Use `-StorageOnly` for s
 
 All resources use an `{initials}-{name}` naming convention where initials are pulled from `git config user.name` and name defaults to `adx`. Pass a name as the first positional parameter to use a custom value (e.g., `216` for Feb 16).
 
-| Parameter        | Description                                                                                                |
-| ---------------- | ---------------------------------------------------------------------------------------------------------- |
-| `‑Name`          | Optional. First positional parameter. Suffix for `{initials}-{name}` convention. Default: `adx`.           |
-| `‑HubName`       | Optional. Name of the hub instance. Default: `hub`.                                                        |
-| `‑ADX`           | Optional. Name of the Azure Data Explorer cluster. Overrides the `{initials}-{name}` convention.           |
-| `‑ResourceGroup` | Optional. Name of the resource group. Overrides the `{initials}-{name}` convention.                        |
-| `‑Fabric`        | Optional. Deploy with Microsoft Fabric. Provide the eventhouse query URI.                                  |
-| `‑StorageOnly`   | Optional. Deploy a storage-only hub (no Azure Data Explorer or Fabric).                                    |
-| `‑Remove`        | Optional. Remove test environments. With a name, deletes the target RG. Alone, lists all `{initials}-*`.   |
-| `‑Location`      | Optional. Azure location. Default: `westus`.                                                               |
-| `‑Build`         | Optional. Build the template before deploying.                                                             |
-| `‑WhatIf`        | Optional. Validate the deployment without making changes.                                                  |
+| Parameter          | Description                                                                                                                                                                          |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `‑Name`            | Optional. First positional parameter. Suffix for `{initials}-{name}` convention. Default: `adx`.                                                                                     |
+| `‑HubName`         | Optional. Name of the hub instance. Default: `hub`.                                                                                                                                  |
+| `‑ADX`             | Optional. Name of the Azure Data Explorer cluster. Overrides the `{initials}-{name}` convention.                                                                                     |
+| `‑ResourceGroup`   | Optional. Name of the resource group. Overrides the `{initials}-{name}` convention.                                                                                                  |
+| `‑Fabric`          | Optional. Deploy with Microsoft Fabric. Provide the eventhouse query URI.                                                                                                            |
+| `‑StorageOnly`     | Optional. Deploy a storage-only hub (no Azure Data Explorer or Fabric).                                                                                                              |
+| `‑Remove`          | Optional. Remove test environments. With a name, deletes the target RG. Alone, lists all `{initials}-*`.                                                                             |
+| `‑PR`              | Optional. Use PR naming convention. Sets initials to `pr` so resources are named `pr-{name}`.                                                                                        |
+| `‑Scope`           | Optional. Azure scope ID for cost data exports (e.g., `/subscriptions/{id}`). With `-ManagedExports`, enables managed exports. Without it, creates exports manually.                 |
+| `‑ManagedExports`  | Optional. Use managed exports instead of manual exports. Requires `-Scope`. Passes `scopesToMonitor` to the template and grants the hub identity required roles.                     |
+| `‑Location`        | Optional. Azure location. Default: `westus`.                                                                                                                                         |
+| `‑Build`           | Optional. Build the template before deploying.                                                                                                                                       |
+| `‑WhatIf`          | Optional. Validate the deployment without making changes.                                                                                                                            |
 
 Examples:
 
@@ -203,6 +206,24 @@ Examples:
 
   ```powershell
   ./Deploy-Hub -Remove
+  ```
+
+- Deploy with PR naming convention (e.g., RG `pr-123`, ADX `pr-123`):
+
+  ```powershell
+  ./Deploy-Hub -PR 123
+  ```
+
+- Deploy with managed exports:
+
+  ```powershell
+  ./Deploy-Hub -PR 123 -Scope "/subscriptions/{id}" -ManagedExports -Build
+  ```
+
+- Deploy storage-only with manual exports:
+
+  ```powershell
+  ./Deploy-Hub -StorageOnly -Scope "/subscriptions/{id}" -Build
   ```
 
 <br>


### PR DESCRIPTION
## 🛠️ Description

Extends Deploy-Hub.ps1 with three new parameters to support CI automation and simplified export configuration:

- **`-PR`** — Sets initials to `pr` for PR-based naming (e.g., `pr-123-adx`)
- **`-Scope`** — Configures cost data exports after deployment (managed or manual)
- **`-ManagedExports`** — Uses template-managed exports and grants the hub identity required RBAC roles on the monitored scope

Post-deployment logic handles two paths:
- **Managed exports**: Grants Cost Management Contributor and RBAC Administrator on the scope, passes `scopesToMonitor` to the template
- **Manual exports**: Creates a FocusCost export via `New-FinOpsCostExport`

Also documents the required RBAC roles for subscription/RG scopes in configure-scopes.md.

This is PR A of a multi-PR effort to add per-PR deployment CI for FinOps hubs.

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [ ] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [x] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [x] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [ ] ❎ Docs not needed (small/internal change)