### PR TITLE
[DevOps] PR Builds: Add deployment checkboxes to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,15 @@ Fixes # <!-- TODO: Add related issues (e.g., Fixes #123, #246, #369) -->
 > - [ ] 💪 Unit tests
 > - [ ] 🙌 Integration tests
 
+### 📦 Deploy to test?
+
+> - [ ] Hubs with ADX (managed)
+> - [ ] Hubs with Fabric (manual) — URI: <!-- paste eventhouse query URI -->
+> - [ ] Hubs (manual)
+> - [ ] Hubs (no data)
+> - [ ] Workbooks
+> - [ ] Alerts
+
 ### 🙋‍♀️ Do any of the following that apply?
 
 > - [ ] 🚨 This is a breaking change.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,8 +27,8 @@ Fixes # <!-- TODO: Add related issues (e.g., Fixes #123, #246, #369) -->
 
 ### 📦 Deploy to test?
 
-> - [ ] Hubs with ADX (managed)
-> - [ ] Hubs with Fabric (manual) — URI: <!-- paste eventhouse query URI -->
+> - [ ] Hubs + ADX (managed)
+> - [ ] Hubs + Fabric (manual) — URI: <!-- paste eventhouse query URI -->
 > - [ ] Hubs (manual)
 > - [ ] Hubs (no data)
 > - [ ] Workbooks


### PR DESCRIPTION
## 🛠️ Description

Adds a "Deploy to test?" section to the PR template with checkboxes for CI-driven deployments:

- **Hubs with ADX (managed)** — ADX + managed exports, data available in ~24hrs
- **Hubs with Fabric (manual)** — Fabric eventhouse + manual exports
- **Hubs (manual)** — Storage-only + manual exports
- **Hubs (no data)** — Storage-only, no exports (fastest)
- **Workbooks** — Workbook template
- **Alerts** — Alerts template

These checkboxes will be parsed by the upcoming `ftk-pr-deploy` workflow to determine which deployments to run per PR.

This is PR B of a multi-PR effort to add per-PR deployment CI for FinOps hubs.

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)