### PR TITLE
[DevOps] PR Builds: Create Initialize-CI script to setup CI

### DIFF
--- a/src/scripts/Initialize-CI.ps1
+++ b/src/scripts/Initialize-CI.ps1
@@ -24,19 +24,15 @@
     .PARAMETER Repository
     Optional. GitHub repo in "owner/repo" format. Default: "microsoft/finops-toolkit".
 
-    .PARAMETER WhatIf
-    Optional. Preview without making changes.
-
     .LINK
     https://github.com/microsoft/finops-toolkit/blob/dev/src/scripts/README.md
 #>
+[CmdletBinding(SupportsShouldProcess)]
 param(
     [Parameter(Mandatory)]
     [string]$SubscriptionId,
 
-    [string]$Repository = "microsoft/finops-toolkit",
-
-    [switch]$WhatIf
+    [string]$Repository = "microsoft/finops-toolkit"
 )
 
 $ErrorActionPreference = "Stop"
@@ -57,18 +53,13 @@ Write-Host ""
 
 Write-Host "Step 1: Creating Azure AD app registration '$appName'..."
 
-$existingApp = Get-AzADApplication -DisplayName $appName -ErrorAction SilentlyContinue | Select-Object -First 1
+$app = Get-AzADApplication -DisplayName $appName -ErrorAction SilentlyContinue | Select-Object -First 1
 
-if ($existingApp)
+if ($app)
 {
-    Write-Host "  App registration already exists (AppId: $($existingApp.AppId))."
-    $app = $existingApp
+    Write-Host "  App registration already exists (AppId: $($app.AppId))."
 }
-elseif ($WhatIf)
-{
-    Write-Host "  [WhatIf] Would create app registration '$appName'."
-}
-else
+elseif ($PSCmdlet.ShouldProcess($appName, 'Create app registration'))
 {
     $app = New-AzADApplication -DisplayName $appName
     Write-Host "  Created app registration (AppId: $($app.AppId))."
@@ -77,21 +68,20 @@ else
 # Service principal
 if ($app)
 {
-    $existingSp = Get-AzADServicePrincipal -ApplicationId $app.AppId -ErrorAction SilentlyContinue
-    if ($existingSp)
+    $sp = Get-AzADServicePrincipal -ApplicationId $app.AppId -ErrorAction SilentlyContinue
+    if ($sp)
     {
         Write-Host "  Service principal already exists."
-        $sp = $existingSp
     }
-    elseif ($WhatIf)
-    {
-        Write-Host "  [WhatIf] Would create service principal."
-    }
-    else
+    elseif ($PSCmdlet.ShouldProcess($appName, 'Create service principal'))
     {
         $sp = New-AzADServicePrincipal -ApplicationId $app.AppId
         Write-Host "  Created service principal (ObjectId: $($sp.Id))."
     }
+}
+else
+{
+    $PSCmdlet.ShouldProcess($appName, 'Create service principal') | Out-Null
 }
 
 #------------------------------------------------------------------------------
@@ -111,11 +101,7 @@ if ($app)
     {
         Write-Host "  Federated credential already exists."
     }
-    elseif ($WhatIf)
-    {
-        Write-Host "  [WhatIf] Would add federated credential (subject: $subject)."
-    }
-    else
+    elseif ($PSCmdlet.ShouldProcess($subject, 'Add federated credential'))
     {
         New-AzADAppFederatedCredential `
             -ApplicationObjectId $app.Id `
@@ -125,6 +111,10 @@ if ($app)
             -Audience @("api://AzureADTokenExchange") | Out-Null
         Write-Host "  Added federated credential (subject: $subject)."
     }
+}
+else
+{
+    $PSCmdlet.ShouldProcess($subject, 'Add federated credential') | Out-Null
 }
 
 #------------------------------------------------------------------------------
@@ -146,15 +136,18 @@ if ($sp)
         {
             Write-Host "  $role already assigned."
         }
-        elseif ($WhatIf)
-        {
-            Write-Host "  [WhatIf] Would grant $role."
-        }
-        else
+        elseif ($PSCmdlet.ShouldProcess("$role on $subscriptionScope", 'Grant role'))
         {
             New-AzRoleAssignment -ObjectId $sp.Id -RoleDefinitionName $role -Scope $subscriptionScope | Out-Null
             Write-Host "  Granted $role."
         }
+    }
+}
+else
+{
+    foreach ($role in $roles)
+    {
+        $PSCmdlet.ShouldProcess("$role on $subscriptionScope", 'Grant role') | Out-Null
     }
 }
 
@@ -176,12 +169,7 @@ if (-not (Get-Command gh -ErrorAction SilentlyContinue))
     return
 }
 
-if ($WhatIf)
-{
-    Write-Host "  [WhatIf] Would create environment '$environmentName' in $Repository."
-    Write-Host "  [WhatIf] Would add secrets: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID, CI_SCOPE."
-}
-else
+if ($PSCmdlet.ShouldProcess("$environmentName in $Repository", 'Create GitHub environment'))
 {
     # Create environment
     gh api "repos/$Repository/environments/$environmentName" -X PUT --silent 2>$null

--- a/src/scripts/Initialize-CI.ps1
+++ b/src/scripts/Initialize-CI.ps1
@@ -37,7 +37,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$appName = "FinOps toolkit CI"
+$appName = "FinOps toolkit CI ($Repository)"
 $environmentName = "ftk-pr"
 
 $scope = "/subscriptions/$SubscriptionId"
@@ -172,7 +172,8 @@ if (-not (Get-Command gh -ErrorAction SilentlyContinue))
 if ($PSCmdlet.ShouldProcess("$environmentName in $Repository", 'Create GitHub environment'))
 {
     # Create environment
-    gh api "repos/$Repository/environments/$environmentName" -X PUT --silent 2>$null
+    gh api "repos/$Repository/environments/$environmentName" -X PUT --silent
+    if ($LASTEXITCODE -ne 0) { throw "Failed to create GitHub environment '$environmentName'." }
     Write-Host "  Created environment '$environmentName'."
 
     # Get tenant ID from current context
@@ -189,6 +190,7 @@ if ($PSCmdlet.ShouldProcess("$environmentName in $Repository", 'Create GitHub en
     foreach ($name in $secrets.Keys)
     {
         $secrets[$name] | gh secret set $name --repo $Repository --env $environmentName
+        if ($LASTEXITCODE -ne 0) { throw "Failed to set secret '$name'." }
         Write-Host "  Set secret: $name"
     }
 }

--- a/src/scripts/Initialize-CI.ps1
+++ b/src/scripts/Initialize-CI.ps1
@@ -53,7 +53,9 @@ Write-Host ""
 
 Write-Host "Step 1: Creating Azure AD app registration '$appName'..."
 
-$app = Get-AzADApplication -DisplayName $appName -ErrorAction SilentlyContinue | Select-Object -First 1
+$app = Get-AzADApplication -DisplayName $appName -ErrorAction SilentlyContinue `
+| Where-Object { $_.DisplayName -eq $appName } `
+| Select-Object -First 1
 
 if ($app)
 {
@@ -124,21 +126,20 @@ else
 Write-Host ""
 Write-Host "Step 3: Granting RBAC on subscription $SubscriptionId..."
 
-$subscriptionScope = "/subscriptions/$SubscriptionId"
 $roles = @("Contributor", "User Access Administrator")
 
 if ($sp)
 {
     foreach ($role in $roles)
     {
-        $existing = Get-AzRoleAssignment -ObjectId $sp.Id -RoleDefinitionName $role -Scope $subscriptionScope -ErrorAction SilentlyContinue
+        $existing = Get-AzRoleAssignment -ObjectId $sp.Id -RoleDefinitionName $role -Scope $scope -ErrorAction SilentlyContinue
         if ($existing)
         {
             Write-Host "  $role already assigned."
         }
-        elseif ($PSCmdlet.ShouldProcess("$role on $subscriptionScope", 'Grant role'))
+        elseif ($PSCmdlet.ShouldProcess("$role on $scope", 'Grant role'))
         {
-            New-AzRoleAssignment -ObjectId $sp.Id -RoleDefinitionName $role -Scope $subscriptionScope | Out-Null
+            New-AzRoleAssignment -ObjectId $sp.Id -RoleDefinitionName $role -Scope $scope | Out-Null
             Write-Host "  Granted $role."
         }
     }
@@ -147,7 +148,7 @@ else
 {
     foreach ($role in $roles)
     {
-        $PSCmdlet.ShouldProcess("$role on $subscriptionScope", 'Grant role') | Out-Null
+        $PSCmdlet.ShouldProcess("$role on $scope", 'Grant role') | Out-Null
     }
 }
 

--- a/src/scripts/Initialize-CI.ps1
+++ b/src/scripts/Initialize-CI.ps1
@@ -1,0 +1,221 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+    .SYNOPSIS
+    One-time setup for FinOps toolkit CI environments.
+
+    .DESCRIPTION
+    Creates the Azure AD app registration, service principal, federated credential, and GitHub environment needed for per-PR deployment CI. Only needs to be run once per repository.
+
+    .EXAMPLE
+    Initialize-CI -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e"
+
+    Sets up CI with the specified subscription for deployments and cost exports.
+
+    .EXAMPLE
+    Initialize-CI -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -WhatIf
+
+    Previews what would be created without making changes.
+
+    .PARAMETER SubscriptionId
+    Required. Azure subscription ID for PR deployments and cost exports.
+
+    .PARAMETER Repository
+    Optional. GitHub repo in "owner/repo" format. Default: "microsoft/finops-toolkit".
+
+    .PARAMETER WhatIf
+    Optional. Preview without making changes.
+
+    .LINK
+    https://github.com/microsoft/finops-toolkit/blob/dev/src/scripts/README.md
+#>
+param(
+    [Parameter(Mandatory)]
+    [string]$SubscriptionId,
+
+    [string]$Repository = "microsoft/finops-toolkit",
+
+    [switch]$WhatIf
+)
+
+$ErrorActionPreference = "Stop"
+
+$appName = "FinOps toolkit CI"
+$environmentName = "ftk-pr"
+
+$scope = "/subscriptions/$SubscriptionId"
+
+Write-Host "Initializing CI for $Repository..."
+Write-Host "  Subscription: $SubscriptionId"
+Write-Host "  Environment: $environmentName"
+Write-Host ""
+
+#------------------------------------------------------------------------------
+# Step 1: Azure AD app registration + service principal
+#------------------------------------------------------------------------------
+
+Write-Host "Step 1: Creating Azure AD app registration '$appName'..."
+
+$existingApp = Get-AzADApplication -DisplayName $appName -ErrorAction SilentlyContinue | Select-Object -First 1
+
+if ($existingApp)
+{
+    Write-Host "  App registration already exists (AppId: $($existingApp.AppId))."
+    $app = $existingApp
+}
+elseif ($WhatIf)
+{
+    Write-Host "  [WhatIf] Would create app registration '$appName'."
+}
+else
+{
+    $app = New-AzADApplication -DisplayName $appName
+    Write-Host "  Created app registration (AppId: $($app.AppId))."
+}
+
+# Service principal
+if ($app)
+{
+    $existingSp = Get-AzADServicePrincipal -ApplicationId $app.AppId -ErrorAction SilentlyContinue
+    if ($existingSp)
+    {
+        Write-Host "  Service principal already exists."
+        $sp = $existingSp
+    }
+    elseif ($WhatIf)
+    {
+        Write-Host "  [WhatIf] Would create service principal."
+    }
+    else
+    {
+        $sp = New-AzADServicePrincipal -ApplicationId $app.AppId
+        Write-Host "  Created service principal (ObjectId: $($sp.Id))."
+    }
+}
+
+#------------------------------------------------------------------------------
+# Step 2: Federated credential for GitHub Actions OIDC
+#------------------------------------------------------------------------------
+
+Write-Host ""
+Write-Host "Step 2: Adding federated credential for GitHub Actions..."
+
+$credName = "github-$environmentName"
+$subject = "repo:${Repository}:environment:${environmentName}"
+
+if ($app)
+{
+    $existingCred = Get-AzADAppFederatedCredential -ApplicationObjectId $app.Id -ErrorAction SilentlyContinue | Where-Object { $_.Subject -eq $subject }
+    if ($existingCred)
+    {
+        Write-Host "  Federated credential already exists."
+    }
+    elseif ($WhatIf)
+    {
+        Write-Host "  [WhatIf] Would add federated credential (subject: $subject)."
+    }
+    else
+    {
+        New-AzADAppFederatedCredential `
+            -ApplicationObjectId $app.Id `
+            -Name $credName `
+            -Issuer "https://token.actions.githubusercontent.com" `
+            -Subject $subject `
+            -Audience @("api://AzureADTokenExchange") | Out-Null
+        Write-Host "  Added federated credential (subject: $subject)."
+    }
+}
+
+#------------------------------------------------------------------------------
+# Step 3: RBAC on the target subscription
+#------------------------------------------------------------------------------
+
+Write-Host ""
+Write-Host "Step 3: Granting RBAC on subscription $SubscriptionId..."
+
+$subscriptionScope = "/subscriptions/$SubscriptionId"
+$roles = @("Contributor", "User Access Administrator")
+
+if ($sp)
+{
+    foreach ($role in $roles)
+    {
+        $existing = Get-AzRoleAssignment -ObjectId $sp.Id -RoleDefinitionName $role -Scope $subscriptionScope -ErrorAction SilentlyContinue
+        if ($existing)
+        {
+            Write-Host "  $role already assigned."
+        }
+        elseif ($WhatIf)
+        {
+            Write-Host "  [WhatIf] Would grant $role."
+        }
+        else
+        {
+            New-AzRoleAssignment -ObjectId $sp.Id -RoleDefinitionName $role -Scope $subscriptionScope | Out-Null
+            Write-Host "  Granted $role."
+        }
+    }
+}
+
+#------------------------------------------------------------------------------
+# Step 4: GitHub environment + secrets
+#------------------------------------------------------------------------------
+
+Write-Host ""
+Write-Host "Step 4: Creating GitHub environment '$environmentName'..."
+
+# Verify gh CLI is available
+if (-not (Get-Command gh -ErrorAction SilentlyContinue))
+{
+    Write-Warning "GitHub CLI (gh) not found. Install it from https://cli.github.com/ and run this step manually."
+    Write-Host ""
+    Write-Host "Manual steps:"
+    Write-Host "  1. Create environment '$environmentName' in $Repository settings"
+    Write-Host "  2. Add secrets: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID, CI_SCOPE"
+    return
+}
+
+if ($WhatIf)
+{
+    Write-Host "  [WhatIf] Would create environment '$environmentName' in $Repository."
+    Write-Host "  [WhatIf] Would add secrets: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID, CI_SCOPE."
+}
+else
+{
+    # Create environment
+    gh api "repos/$Repository/environments/$environmentName" -X PUT --silent 2>$null
+    Write-Host "  Created environment '$environmentName'."
+
+    # Get tenant ID from current context
+    $tenantId = (Get-AzContext).Tenant.Id
+
+    # Set secrets
+    $secrets = @{
+        AZURE_CLIENT_ID       = $app.AppId
+        AZURE_TENANT_ID       = $tenantId
+        AZURE_SUBSCRIPTION_ID = $SubscriptionId
+        CI_SCOPE              = $scope
+    }
+
+    foreach ($name in $secrets.Keys)
+    {
+        $secrets[$name] | gh secret set $name --repo $Repository --env $environmentName
+        Write-Host "  Set secret: $name"
+    }
+}
+
+#------------------------------------------------------------------------------
+# Summary
+#------------------------------------------------------------------------------
+
+Write-Host ""
+Write-Host "--- Summary ---"
+if ($app)
+{
+    Write-Host "  App registration: $appName (AppId: $($app.AppId))"
+}
+Write-Host "  GitHub environment: $environmentName"
+Write-Host "  Subscription: $SubscriptionId"
+Write-Host ""
+Write-Host "CI is ready. The ftk-pr-deploy workflow will use the '$environmentName' environment."

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -5,6 +5,7 @@ FinOps toolkit scripts are used for local development, testing, and publishing o
 On this page:
 
 - [🆕 Init-Repo](#-init-repo)
+- [🔧 Initialize-CI](#-initialize-ci)
 - [🌐 Build-OpenData](#-build-opendata)
 - [📦 Build-Toolkit](#-build-toolkit)
 - [🚀 Deploy-Hub](#-deploy-hub)
@@ -61,6 +62,32 @@ Examples:
 
   ```powershell
   ./Init-Repo -All
+  ```
+
+<br>
+
+## 🔧 Initialize-CI
+
+[Initialize-CI.ps1](./Initialize-CI.ps1) is a one-time setup script that creates the Azure AD app registration, service principal, federated credential, and GitHub environment needed for per-PR deployment CI.
+
+| Parameter          | Description                                                                                    |
+| ------------------ | ---------------------------------------------------------------------------------------------- |
+| `‑SubscriptionId`  | Required. Azure subscription ID for PR deployments and cost exports.                           |
+| `‑Repository`      | Optional. GitHub repo in `owner/repo` format. Default: `microsoft/finops-toolkit`.             |
+| `‑WhatIf`          | Optional. Preview without making changes.                                                      |
+
+Examples:
+
+- Set up CI for a subscription:
+
+  ```powershell
+  ./Initialize-CI -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e"
+  ```
+
+- Preview what would be created:
+
+  ```powershell
+  ./Initialize-CI -SubscriptionId "aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e" -WhatIf
   ```
 
 <br>

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -70,6 +70,11 @@ Examples:
 
 [Initialize-CI.ps1](./Initialize-CI.ps1) is a one-time setup script that creates the Azure AD app registration, service principal, federated credential, and GitHub environment needed for per-PR deployment CI.
 
+Prerequisites:
+
+- Logged into Azure (`Connect-AzAccount`) with permissions to create app registrations and grant subscription-level RBAC (Contributor + User Access Administrator).
+- Logged into GitHub CLI (`gh auth login`) with permissions to create environments and secrets in the target repository.
+
 | Parameter          | Description                                                                                    |
 | ------------------ | ---------------------------------------------------------------------------------------------- |
 | `‑SubscriptionId`  | Required. Azure subscription ID for PR deployments and cost exports.                           |


### PR DESCRIPTION
## 🛠️ Description

Adds `src/scripts/Initialize-CI.ps1`, a one-time setup script for per-PR deployment CI. It creates:

1. **Azure AD app registration** ("FinOps toolkit CI") with a federated credential for GitHub Actions OIDC
2. **Service principal** with Contributor + User Access Administrator on the target subscription
3. **GitHub environment** (`ftk-pr`) with secrets: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `CI_SCOPE`

The script is idempotent — safe to re-run if any step was partially completed.

This is PR C of a multi-PR effort to add per-PR deployment CI for FinOps hubs.

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [ ] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [x] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [ ] ❎ Docs not needed (small/internal change)