### PR TITLE
Fix: Prices transform cross-row operations broken by per-batch execution

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -47,8 +47,9 @@ The following section lists features and enhancements that are currently in deve
   - Remote Hub configuration (storage URI, storage key, and purge protection) is now displayed in the Basics tab when Remote Hub mode is selected, making the mutual exclusivity clear.
   - Data Explorer SKU and retention settings are now only visible when Azure Data Explorer mode is selected.
 - **Fixed**
-  - Fixed prices transform function producing incorrect results when price sheet data is split across multiple ingestion batches by moving cross-row operations (commitment discount eligibility) from the ingestion-time update policy to the query-time Hub view functions ([#1625](https://github.com/microsoft/finops-toolkit/issues/1625)).
-    - Stopped nulling savings plan price columns (`ContractedUnitPrice`, `ListUnitPrice`) since the raw values from Cost Management (`UnitPrice`, `MarketPrice`) already contain the correct contracted and retail rates for all price types, including savings plans.
+  - Fixed price data ingestion bugs when price sheet data is split across multiple files ([#1625](https://github.com/microsoft/finops-toolkit/issues/1625)).
+    - Commitment discount prices are now consistently set correctly using a full price sheet lookup.
+    - Commitment discount eligibility columns moved to the Prices* Hub functions rather than hard-coded in the `Prices_final_v*` tables.
 
 ### [PowerShell module](powershell/powershell-commands.md) v14
 

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -46,6 +46,9 @@ The following section lists features and enhancements that are currently in deve
   - Improved deployment UI to consolidate hub mode selection into a single radio button group with four mutually exclusive options: None (storage only for Power BI reports), Azure Data Explorer, Microsoft Fabric, or Remote Hub ([#1929](https://github.com/microsoft/finops-toolkit/issues/1929)).
   - Remote Hub configuration (storage URI, storage key, and purge protection) is now displayed in the Basics tab when Remote Hub mode is selected, making the mutual exclusivity clear.
   - Data Explorer SKU and retention settings are now only visible when Azure Data Explorer mode is selected.
+- **Fixed**
+  - Fixed prices transform function producing incorrect results when price sheet data is split across multiple ingestion batches by moving cross-row operations (commitment discount eligibility) from the ingestion-time update policy to the query-time Hub view functions ([#1625](https://github.com/microsoft/finops-toolkit/issues/1625)).
+    - Stopped nulling savings plan price columns (`ContractedUnitPrice`, `ListUnitPrice`) since the raw values from Cost Management (`UnitPrice`, `MarketPrice`) already contain the correct contracted and retail rates for all price types, including savings plans.
 
 ### [PowerShell module](powershell/powershell-commands.md) v14
 

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -3,7 +3,7 @@ title: FinOps toolkit changelog
 description: Review the latest features and enhancements in the FinOps toolkit, including updates to FinOps hubs, Power BI reports, and more.
 author: MSBrett
 ms.author: brettwil
-ms.date: 03/01/2026
+ms.date: 03/02/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/HubSetup_v1_0.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/HubSetup_v1_0.kql
@@ -216,10 +216,22 @@ Costs_v1_0()
 
 
 // Prices_final_v1_0
+// Commitment discount eligibility is computed here instead of in the update policy because ADX
+// update policies execute per-ingestion batch, not across the full table.
+// See https://github.com/microsoft/finops-toolkit/issues/1625
 .create-or-alter function
 with (docstring = 'Gets all prices aligned to FOCUS 1.0.', folder = 'Prices')
 Prices_v1_0()
 {
+    // Commitment discount eligibility -- computed here because the update policy only sees per-batch data
+    let commitmentMeters = database('Ingestion').Prices_final_v1_0
+        | union (database('Ingestion').Prices_final_v1_2)
+        | where x_SkuPriceType in ('ReservedInstance', 'SavingsPlan')
+        | distinct x_SkuMeterId, x_SkuPriceType;
+    let riMeters = commitmentMeters | where x_SkuPriceType == 'ReservedInstance' | project x_SkuMeterId;
+    let spMeters = commitmentMeters | where x_SkuPriceType == 'SavingsPlan' | project x_SkuMeterId;
+    //
+    // Calculate commitment discount eligibility
     database('Ingestion').Prices_final_v1_0
     | union (
         database('Ingestion').Prices_final_v1_2
@@ -238,12 +250,15 @@ Prices_v1_0()
             x_SkuIncludedQuantity                = todecimal(x_SkuIncludedQuantity),
             x_SkuTier                            = todecimal(x_SkuTier),
             x_TotalUnitPriceDiscount             = todecimal(x_TotalUnitPriceDiscount),
-            x_TotalUnitPriceDiscountPercent      = todecimal(x_TotalUnitPriceDiscountPercent) 
+            x_TotalUnitPriceDiscountPercent      = todecimal(x_TotalUnitPriceDiscountPercent)
         // Rename columns
         | project-rename
             x_PricingCurrency = PricingCurrency,
             x_SkuMeterName = SkuMeter
     )
+    | extend x_CommitmentDiscountSpendEligibility = iff(x_SkuMeterId in (riMeters) and x_SkuPriceType == 'Consumption', 'Eligible', 'Not Eligible')
+    | extend x_CommitmentDiscountUsageEligibility = iff(x_SkuMeterId in (spMeters) and x_SkuPriceType == 'Consumption', 'Eligible', 'Not Eligible')
+    //
     | project
         BillingAccountId,
         BillingAccountName,

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/HubSetup_v1_2.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/HubSetup_v1_2.kql
@@ -360,10 +360,22 @@ Costs_v1_2()
 
 
 // Prices_final_v1_2
+// Commitment discount eligibility is computed here instead of in the update policy because ADX
+// update policies execute per-ingestion batch, not across the full table.
+// See https://github.com/microsoft/finops-toolkit/issues/1625
 .create-or-alter function
 with (docstring = 'Gets all prices aligned to FOCUS 1.2.', folder = 'Prices')
 Prices_v1_2()
 {
+    // Commitment discount eligibility -- computed here because the update policy only sees per-batch data
+    let commitmentMeters = database('Ingestion').Prices_final_v1_2
+        | union (database('Ingestion').Prices_final_v1_0)
+        | where x_SkuPriceType in ('ReservedInstance', 'SavingsPlan')
+        | distinct x_SkuMeterId, x_SkuPriceType;
+    let riMeters = commitmentMeters | where x_SkuPriceType == 'ReservedInstance' | project x_SkuMeterId;
+    let spMeters = commitmentMeters | where x_SkuPriceType == 'SavingsPlan' | project x_SkuMeterId;
+    //
+    // Calculate commitment discount eligibility
     database('Ingestion').Prices_final_v1_2
     | union (
         database('Ingestion').Prices_final_v1_0
@@ -381,12 +393,15 @@ Prices_v1_2()
             x_SkuIncludedQuantity                = toreal(x_SkuIncludedQuantity),
             x_SkuTier                            = toreal(x_SkuTier),
             x_TotalUnitPriceDiscount             = toreal(x_TotalUnitPriceDiscount),
-            x_TotalUnitPriceDiscountPercent      = toreal(x_TotalUnitPriceDiscountPercent) 
+            x_TotalUnitPriceDiscountPercent      = toreal(x_TotalUnitPriceDiscountPercent)
         // Rename columns
         | project-rename
             PricingCurrency = x_PricingCurrency,
             SkuMeter = x_SkuMeterName
     )
+    | extend x_CommitmentDiscountSpendEligibility = iff(x_SkuMeterId in (riMeters) and x_SkuPriceType == 'Consumption', 'Eligible', 'Not Eligible')
+    | extend x_CommitmentDiscountUsageEligibility = iff(x_SkuMeterId in (spMeters) and x_SkuPriceType == 'Consumption', 'Eligible', 'Not Eligible')
+    //
     | project
         BillingAccountId,
         BillingAccountName,

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_0.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_0.kql
@@ -78,11 +78,11 @@ Prices_transform_v1_0()
     );
     //
     // NOTE: Commitment discount eligibility requires cross-row lookups and is deferred to the Hub
-    // view (Prices_v1_2) because ADX update policies execute per-ingestion batch, not across the
+    // view (Prices_v1_0) because ADX update policies execute per-ingestion batch, not across the
     // full table. See https://github.com/microsoft/finops-toolkit/issues/1625
     prices
     //
-    // Commitment discount eligibility is computed in the Hub view (Prices_v1_2)
+    // Commitment discount eligibility is computed in the Hub view (Prices_v1_0)
     | extend x_CommitmentDiscountSpendEligibility = ''
     | extend x_CommitmentDiscountUsageEligibility = ''
     //

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_0.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_0.kql
@@ -61,8 +61,8 @@ Prices_transform_v1_0()
             x_SkuRegion = MeterRegion,
             x_SkuServiceFamily = ServiceFamily,
             x_SkuTier = TierMinimumUnits
-        | extend ContractedUnitPrice = iff(x_SkuPriceType != 'SavingsPlan', UnitPrice, todecimal(''))  // UnitPrice for savings plan is not the on-demand unit price
-        | extend ListUnitPrice = iff(x_SkuPriceType != 'SavingsPlan', MarketPrice, todecimal(''))  // MarketPrice for savings plan is not the list price
+        | extend ContractedUnitPrice = UnitPrice   // Negotiated rate for this price type (on-demand, RI, or SP)
+        | extend ListUnitPrice = MarketPrice       // Retail rate for this price type (on-demand, RI, or SP)
         | extend ChargeCategory = case(
             x_SkuPriceType == 'Consumption', 'Usage',
             x_SkuPriceType == 'ReservedInstance', 'Purchase',
@@ -72,32 +72,19 @@ Prices_transform_v1_0()
         | extend SkuPriceIdv2 = strcat(case(x_SkuPriceType == 'Consumption', 'OD', x_SkuPriceType == 'ReservedInstance', 'RI', x_SkuPriceType == 'SavingsPlan', 'SP', 'XX'), substring(ChargeCategory, 0, 1), x_SkuTerm, '_', x_SkuProductId, '_', x_SkuId, '_', x_SkuMeterType, '_', x_SkuTier, x_SkuOfferId)
         | extend x_BillingAccountId = iff(BillingAccountId startswith '/', split(BillingAccountId, '/')[-1], coalesce(BillingAccountId, EnrollmentNumber))
         | extend x_BillingProfileId = iff(BillingProfileId startswith '/', split(BillingProfileId, '/')[-1], coalesce(BillingProfileId, EnrollmentNumber))
-        | extend tmp_SavingsPlanKey = strcat(x_SkuMeterId, x_SkuProductId, x_SkuId, x_SkuTier, x_SkuOfferId)
         //
         // Get latest ingested row based on the unique ID
         | extend x_IngestionTime = ingestion_time()
     );
     //
-    // Meters for reservations and savings plans to identify commitment eligibility
-    let riMeters = prices | where x_SkuPriceType == 'ReservedInstance' | distinct x_SkuMeterId;
-    let spMeters = prices | where x_SkuPriceType == 'SavingsPlan' | distinct x_SkuMeterId;
-    //
-    // Copy list/base/contracted prices from on-demand SKUs
+    // NOTE: Commitment discount eligibility requires cross-row lookups and is deferred to the Hub
+    // view (Prices_v1_2) because ADX update policies execute per-ingestion batch, not across the
+    // full table. See https://github.com/microsoft/finops-toolkit/issues/1625
     prices
-    | where x_SkuPriceType == 'SavingsPlan'
-    // If we use join, specify the shuffle key
-    // TODO: Compare join vs. lookup perf -- | join kind=leftouter hint.strategy=shuffle (prices | where x_SkuPriceType == 'Consumption' | where x_SkuMeterId in (spMeters) | distinct tmp_SavingsPlanKey, ListUnitPrice, ContractedUnitPrice, x_BaseUnitPrice) on tmp_SavingsPlanKey
-    | lookup kind=leftouter (prices | where x_SkuPriceType == 'Consumption' | where x_SkuMeterId in (spMeters) | distinct tmp_SavingsPlanKey, ListUnitPrice, ContractedUnitPrice, x_BaseUnitPrice) on tmp_SavingsPlanKey
-    | extend ListUnitPrice = coalesce(ListUnitPrice, ListUnitPrice1)
-    | extend ContractedUnitPrice = coalesce(ContractedUnitPrice, ContractedUnitPrice1)
-    | extend x_BaseUnitPrice = coalesce(x_BaseUnitPrice, x_BaseUnitPrice1)
-    | project-away ListUnitPrice1, ContractedUnitPrice1, x_BaseUnitPrice1, tmp_SavingsPlanKey
-    | union ((prices | where x_SkuPriceType != 'SavingsPlan'))
     //
-    // Calculate commitment discount elgibility
-    // TODO: Would a join be faster?
-    | extend x_CommitmentDiscountSpendEligibility = iff(x_SkuMeterId in (riMeters) and x_SkuPriceType != 'ReservedInstance', 'Eligible', 'Not Eligible')
-    | extend x_CommitmentDiscountUsageEligibility = iff(x_SkuMeterId in (spMeters), 'Eligible', 'Not Eligible')
+    // Commitment discount eligibility is computed in the Hub view (Prices_v1_2)
+    | extend x_CommitmentDiscountSpendEligibility = ''
+    | extend x_CommitmentDiscountUsageEligibility = ''
     //
     // Add PricingUnit and x_PricingBlockSize
     // TODO: Compare join vs. lookup perf -- | join kind=leftouter (PricingUnits) on x_PricingUnitDescription | project-away x_PricingUnitDescription1

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_0.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_0.kql
@@ -46,6 +46,8 @@ Prices_transform_v1_0()
         | extend x_SkuProductId = coalesce(ProductId, ProductID)
         | extend x_SkuTerm = isoMonths(Term)
         | project-rename
+            ContractedUnitPrice = UnitPrice,
+            ListUnitPrice = MarketPrice,
             x_BaseUnitPrice = BasePrice,
             x_EffectivePeriodEnd = EffectiveEndDate,
             x_EffectivePeriodStart = EffectiveStartDate,
@@ -61,8 +63,6 @@ Prices_transform_v1_0()
             x_SkuRegion = MeterRegion,
             x_SkuServiceFamily = ServiceFamily,
             x_SkuTier = TierMinimumUnits
-        | extend ContractedUnitPrice = UnitPrice   // Negotiated rate for this price type (on-demand, RI, or SP)
-        | extend ListUnitPrice = MarketPrice       // Retail rate for this price type (on-demand, RI, or SP)
         | extend ChargeCategory = case(
             x_SkuPriceType == 'Consumption', 'Usage',
             x_SkuPriceType == 'ReservedInstance', 'Purchase',
@@ -90,7 +90,7 @@ Prices_transform_v1_0()
     // TODO: Compare join vs. lookup perf -- | join kind=leftouter (PricingUnits) on x_PricingUnitDescription | project-away x_PricingUnitDescription1
     | lookup kind=leftouter (PricingUnits | extend x_PricingBlockSize = todecimal(x_PricingBlockSize)) on x_PricingUnitDescription
     //
-    | extend x_EffectiveUnitPrice = iff(x_SkuPriceType == 'SavingsPlan', UnitPrice, todecimal(''))  // Savings plan prices are for the effective price, not the contracted price
+    | extend x_EffectiveUnitPrice = iff(x_SkuPriceType == 'SavingsPlan', ContractedUnitPrice, todecimal(''))  // Savings plan prices are for the effective price, not the contracted price
     | extend x_EffectiveUnitPriceDiscount = ContractedUnitPrice - x_EffectiveUnitPrice
     | extend x_ContractedUnitPriceDiscount = ListUnitPrice - ContractedUnitPrice
     | extend x_TotalUnitPriceDiscount = ListUnitPrice - x_EffectiveUnitPrice

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_2.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_2.kql
@@ -37,6 +37,8 @@ Prices_transform_v1_2()
         | extend x_SkuProductId = coalesce(ProductId, ProductID)
         | extend x_SkuTerm = isoMonths(Term)
         | project-rename
+            ContractedUnitPrice = UnitPrice,
+            ListUnitPrice = MarketPrice,
             SkuMeter = MeterName,
             x_BaseUnitPrice = BasePrice,
             x_EffectivePeriodEnd = EffectiveEndDate,
@@ -52,8 +54,6 @@ Prices_transform_v1_2()
             x_SkuRegion = MeterRegion,
             x_SkuServiceFamily = ServiceFamily,
             x_SkuTier = TierMinimumUnits
-        | extend ContractedUnitPrice = UnitPrice   // Negotiated rate for this price type (on-demand, RI, or SP)
-        | extend ListUnitPrice = MarketPrice       // Retail rate for this price type (on-demand, RI, or SP)
         | extend ChargeCategory = case(
             x_SkuPriceType == 'Consumption', 'Usage',
             x_SkuPriceType == 'ReservedInstance', 'Purchase',
@@ -93,7 +93,7 @@ Prices_transform_v1_2()
     // TODO: Compare join vs. lookup perf -- | join kind=leftouter (PricingUnits) on x_PricingUnitDescription | project-away x_PricingUnitDescription1
     | lookup kind=leftouter (PricingUnits) on x_PricingUnitDescription
     //
-    | extend x_EffectiveUnitPrice = iff(x_SkuPriceType == 'SavingsPlan', UnitPrice, real(null))  // Savings plan prices are for the effective price, not the contracted price
+    | extend x_EffectiveUnitPrice = iff(x_SkuPriceType == 'SavingsPlan', ContractedUnitPrice, real(null))  // Savings plan prices are for the effective price, not the contracted price
     | extend x_EffectiveUnitPriceDiscount = ContractedUnitPrice - x_EffectiveUnitPrice
     | extend x_ContractedUnitPriceDiscount = ListUnitPrice - ContractedUnitPrice
     | extend x_TotalUnitPriceDiscount = ListUnitPrice - x_EffectiveUnitPrice

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_2.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_2.kql
@@ -52,8 +52,8 @@ Prices_transform_v1_2()
             x_SkuRegion = MeterRegion,
             x_SkuServiceFamily = ServiceFamily,
             x_SkuTier = TierMinimumUnits
-        | extend ContractedUnitPrice = iff(x_SkuPriceType != 'SavingsPlan', UnitPrice, real(null))  // UnitPrice for savings plan is not the on-demand unit price
-        | extend ListUnitPrice = iff(x_SkuPriceType != 'SavingsPlan', MarketPrice, real(null))  // MarketPrice for savings plan is not the list price
+        | extend ContractedUnitPrice = UnitPrice   // Negotiated rate for this price type (on-demand, RI, or SP)
+        | extend ListUnitPrice = MarketPrice       // Retail rate for this price type (on-demand, RI, or SP)
         | extend ChargeCategory = case(
             x_SkuPriceType == 'Consumption', 'Usage',
             x_SkuPriceType == 'ReservedInstance', 'Purchase',
@@ -63,27 +63,15 @@ Prices_transform_v1_2()
         | extend SkuPriceIdv2 = strcat(case(x_SkuPriceType == 'Consumption', 'OD', x_SkuPriceType == 'ReservedInstance', 'RI', x_SkuPriceType == 'SavingsPlan', 'SP', 'XX'), substring(ChargeCategory, 0, 1), x_SkuTerm, '_', x_SkuProductId, '_', x_SkuId, '_', x_SkuMeterType, '_', x_SkuTier, x_SkuOfferId)
         | extend x_BillingAccountId = iff(BillingAccountId startswith '/', split(BillingAccountId, '/')[-1], coalesce(BillingAccountId, EnrollmentNumber))
         | extend x_BillingProfileId = iff(BillingProfileId startswith '/', split(BillingProfileId, '/')[-1], coalesce(BillingProfileId, EnrollmentNumber))
-        | extend tmp_SavingsPlanKey = strcat(x_SkuMeterId, x_SkuProductId, x_SkuId, x_SkuTier, x_SkuOfferId)
         //
         // Get latest ingested row based on the unique ID
         | extend x_IngestionTime = ingestion_time()
     );
     //
-    // Meters for reservations and savings plans to identify commitment eligibility
-    let riMeters = prices | where x_SkuPriceType == 'ReservedInstance' | distinct x_SkuMeterId;
-    let spMeters = prices | where x_SkuPriceType == 'SavingsPlan' | distinct x_SkuMeterId;
-    //
-    // Copy list/base/contracted prices from on-demand SKUs
+    // NOTE: Commitment discount eligibility requires cross-row lookups and is deferred to the Hub
+    // view (Prices_v1_2) because ADX update policies execute per-ingestion batch, not across the
+    // full table. See https://github.com/microsoft/finops-toolkit/issues/1625
     prices
-    | where x_SkuPriceType == 'SavingsPlan'
-    // If we use join, specify the shuffle key
-    // TODO: Compare join vs. lookup perf -- | join kind=leftouter hint.strategy=shuffle (prices | where x_SkuPriceType == 'Consumption' | where x_SkuMeterId in (spMeters) | distinct tmp_SavingsPlanKey, ListUnitPrice, ContractedUnitPrice, x_BaseUnitPrice) on tmp_SavingsPlanKey
-    | lookup kind=leftouter (prices | where x_SkuPriceType == 'Consumption' | where x_SkuMeterId in (spMeters) | distinct tmp_SavingsPlanKey, ListUnitPrice, ContractedUnitPrice, x_BaseUnitPrice) on tmp_SavingsPlanKey
-    | extend ListUnitPrice = coalesce(ListUnitPrice, ListUnitPrice1)
-    | extend ContractedUnitPrice = coalesce(ContractedUnitPrice, ContractedUnitPrice1)
-    | extend x_BaseUnitPrice = coalesce(x_BaseUnitPrice, x_BaseUnitPrice1)
-    | project-away ListUnitPrice1, ContractedUnitPrice1, x_BaseUnitPrice1, tmp_SavingsPlanKey
-    | union ((prices | where x_SkuPriceType != 'SavingsPlan'))
     //
     // Set CommitmentDiscountCategory for reuse
     | extend CommitmentDiscountCategory = case(
@@ -92,11 +80,11 @@ Prices_transform_v1_2()
         ''
     )
     //
-    // Calculate commitment discount eligibility
-    // TODO: Would a join be faster?
-    // TODO: Check this to ensure it's correct
-    | extend x_CommitmentDiscountSpendEligibility = iff(x_SkuMeterId in (riMeters) and x_SkuPriceType != 'ReservedInstance', 'Eligible', 'Not Eligible')
-    | extend x_CommitmentDiscountUsageEligibility = iff(x_SkuMeterId in (spMeters), 'Eligible', 'Not Eligible')
+    // Commitment discount eligibility is computed in the Hub view (Prices_v1_2)
+    // because it requires cross-row lookups across the full price table.
+    // See https://github.com/microsoft/finops-toolkit/issues/1625
+    | extend x_CommitmentDiscountSpendEligibility = ''
+    | extend x_CommitmentDiscountUsageEligibility = ''
     //
     // TODO: Implement x_CommitmentDiscountNormalizedRatio
     | extend x_CommitmentDiscountNormalizedRatio = real(null)


### PR DESCRIPTION
## Summary

Fixes #1625 — The `Prices_transform_v1_0` and `Prices_transform_v1_2` functions don't work as intended because ADX update policies execute per-ingestion batch, not across the full `Prices_raw` table. When a price sheet is split across multiple parquet files, cross-row operations only see the current file's data.

This PR fixes two issues:

### 1. Removed the savings plan → consumption price lookup

The update policy previously nulled out `ContractedUnitPrice` and `ListUnitPrice` for savings plan rows, then replaced them with on-demand prices from matching Consumption rows via a self-join. This lookup was broken by per-batch execution (SP and Consumption rows could land in different files).

**Why we dropped it rather than moving it:** Per the [EA](https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/price-sheet-ea) and [MCA](https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/price-sheet-mca) price sheet documentation, savings plan rows already have meaningful values:

- `UnitPrice` → the SP contracted rate (negotiated, including EA/MCA discounts)
- `MarketPrice` → the SP retail rate (before negotiated discounts)
- `BasePrice` → the rate at agreement signing

These are the correct prices **for the savings plan price type itself**. The old lookup was replacing them with on-demand reference prices to enable "SP vs. on-demand" savings analysis — but that conflated different price semantics on the same row. Comparing SP rates against on-demand rates is a cross-row analysis that belongs at query time, not baked into the data.

With this change, each price row now has its own correct prices regardless of price type (Consumption, ReservedInstance, or SavingsPlan), and discount columns show the EA/MCA negotiated discount for that specific price type.

### 2. Moved commitment discount eligibility to Hub view functions

The `riMeters`/`spMeters` distinct lookups (`prices | where x_SkuPriceType == 'ReservedInstance' | distinct x_SkuMeterId`) require visibility across all price data to determine which meters have RI/SP variants. These have been moved from the update policy to the `Prices_v1_2()` and `Prices_v1_0()` Hub view functions, which query the full final tables.

Additional fix: eligibility is now set only on `Consumption` rows (`x_SkuPriceType == 'Consumption'`). Previously, spend eligibility excluded RI rows but usage eligibility did not exclude SP rows. Since there are only three price types (Consumption, ReservedInstance, SavingsPlan), eligibility is meaningful only for on-demand rows — RI/SP rows *are* the commitment discounts themselves.

### Impact on downstream consumers

**`Prices_v1_2()` / `Prices_v1_0()` ADX functions** — these are the public-facing functions that users query directly. The semantic change for SP rows:

| Column | Before (when lookup worked) | After this PR |
|--------|---------------------------|---------------|
| `ContractedUnitPrice` | Consumption contracted rate | SP contracted rate |
| `ListUnitPrice` | Consumption retail rate | SP retail rate |
| `x_EffectiveUnitPrice` | SP contracted rate | SP contracted rate (unchanged) |
| `x_EffectiveUnitPriceDiscount` | Consumption - SP = SP savings | SP - SP = **0** |
| `x_ContractedUnitPriceDiscount` | Retail - Contracted (negotiated) | SP retail - SP contracted |
| `x_TotalUnitPriceDiscount` | Retail - SP = total savings | SP retail - SP contracted |

Note: the old behavior was already broken for most users due to the per-batch issue (#1625). The lookup only produced correct results when all price data landed in a single ingestion batch.

**Costs transform functions** — The `Costs_transform_v1_2` and `Costs_transform_v1_0` functions look up prices from `Prices_final` to populate missing `ContractedUnitPrice`/`ListUnitPrice` on cost rows. This lookup is **not affected** because it filters on `x_SkuPriceType == 'Consumption'`, and Consumption rows were never nulled — only SP rows were.

**Power BI reports** — Not affected:
- Storage-based reports read raw parquet files and do their own column mapping — they never go through the KQL transform.
- KQL-based reports have no Prices data table; the Costs table gets `ContractedUnitPrice`/`ListUnitPrice` from cost exports, not price sheets.

**ADX real-time dashboard** (`dashboard.json`) — Not directly affected. The dashboard's SKU prices and cost validation tiles query Costs data (`CostsByDay`, `Costs_v1_2`), not the Prices functions. The only Prices reference is a data ingestion monitoring query that checks table extents, not price values.

### Files changed

- **`IngestionSetup_v1_2.kql`** — Remove SP price nulling, cross-row lookup, and eligibility calculation from update policy
- **`IngestionSetup_v1_0.kql`** — Same changes (deprecated but kept consistent)
- **`HubSetup_v1_2.kql`** — Add eligibility computation with combined meter lookup across both final tables
- **`HubSetup_v1_0.kql`** — Same eligibility computation for FOCUS 1.0 consumers

## Test plan

- [ ] Deploy to a test hub with a price sheet split across multiple parquet files
- [ ] Verify `Prices_final_v1_2` has non-null `ContractedUnitPrice`/`ListUnitPrice` for all price types including SavingsPlan
- [ ] Verify `Prices_v1_2()` returns correct `x_CommitmentDiscountSpendEligibility` and `x_CommitmentDiscountUsageEligibility` on Consumption rows
- [ ] Verify RI and SP rows show `Not Eligible` for both eligibility columns
- [ ] Verify SP rows: `ContractedUnitPrice` = SP contracted rate, `ListUnitPrice` = SP retail rate
- [ ] Verify SP rows: `x_EffectiveUnitPriceDiscount` = 0 (expected, since ContractedUnitPrice and x_EffectiveUnitPrice are now the same value)
- [ ] Verify Consumption rows: discount columns unchanged
- [ ] Verify Costs transform still populates missing prices correctly (Consumption lookup unaffected)
- [ ] Verify ADX dashboard SKU prices tiles render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)