### PR TITLE
[Hubs] Don't ingest empty export files

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -50,6 +50,7 @@ The following section lists features and enhancements that are currently in deve
   - Data Explorer SKU and retention settings are now only visible when Azure Data Explorer mode is selected.
 - **Fixed**
   - Fixed Init-DataFactory deployment script failing when an Event Grid subscription is already provisioning by checking subscription status before attempting subscribe/unsubscribe and polling separately for completion ([#1996](https://github.com/microsoft/finops-toolkit/issues/1996)).
+  - Added row count check in `msexports_ExecuteETL` pipeline to fix error when export files have no rows ([#1535](https://github.com/microsoft/finops-toolkit/issues/1535)).
 
 ### [FinOps workbooks](workbooks/finops-workbooks-overview.md) v14
 

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -3,7 +3,7 @@ title: FinOps toolkit changelog
 description: Review the latest features and enhancements in the FinOps toolkit, including updates to FinOps hubs, Power BI reports, and more.
 author: MSBrett
 ms.author: brettwil
-ms.date: 03/03/2026
+ms.date: 03/04/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep
@@ -304,7 +304,7 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
         }
         { // Set Has No Rows
           name: 'Set Has No Rows'
-          description: 'Check the row count '
+          description: 'Check if there are no blobs or no data rows in the export.'
           type: 'SetVariable'
           dependsOn: [
             {
@@ -322,7 +322,7 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
           typeProperties: {
             variableName: 'hasNoRows'
             value: {
-              value: '@or(equals(activity(\'Read Manifest\').output.firstRow.blobCount, null), equals(activity(\'Read Manifest\').output.firstRow.blobCount, 0))'
+              value: '@or(equals(activity(\'Read Manifest\').output.firstRow.blobCount, null), equals(activity(\'Read Manifest\').output.firstRow.blobCount, 0), equals(activity(\'Read Manifest\').output.firstRow.dataRowCount, null), equals(activity(\'Read Manifest\').output.firstRow.dataRowCount, 0))'
               type: 'Expression'
             }
           }

--- a/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep
@@ -322,7 +322,7 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
           typeProperties: {
             variableName: 'hasNoRows'
             value: {
-              value: '@or(equals(activity(\'Read Manifest\').output.firstRow.blobCount, null), equals(activity(\'Read Manifest\').output.firstRow.blobCount, 0), equals(activity(\'Read Manifest\').output.firstRow.dataRowCount, null), equals(activity(\'Read Manifest\').output.firstRow.dataRowCount, 0))'
+              value: '@or(equals(activity(\'Read Manifest\').output.firstRow.blobCount, null), equals(activity(\'Read Manifest\').output.firstRow.blobCount, 0), and(contains(activity(\'Read Manifest\').output.firstRow, \'dataRowCount\'), or(equals(activity(\'Read Manifest\').output.firstRow.dataRowCount, null), equals(activity(\'Read Manifest\').output.firstRow.dataRowCount, 0))))'
               type: 'Expression'
             }
           }
@@ -942,8 +942,8 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
         }
         { // Copy Manifest
           name: 'Copy Manifest'
-          description: 'Copy the manifest to the ingestion container to trigger ADX ingestion'
-          type: 'Copy'
+          description: 'Copy the manifest to the ingestion container to trigger ADX ingestion. Skipped when there are no data rows to avoid triggering downstream ingestion with no parquet files.'
+          type: 'IfCondition'
           dependsOn: [
             {
               activity: 'For Each Blob'
@@ -952,63 +952,78 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
               ]
             }
           ]
-          policy: {
-            timeout: '0.12:00:00'
-            retry: 0
-            retryIntervalInSeconds: 30
-            secureOutput: false
-            secureInput: false
-          }
           userProperties: []
           typeProperties: {
-            source: {
-              type: 'JsonSource'
-              storeSettings: {
-                type: 'AzureBlobFSReadSettings'
-                recursive: true
-                enablePartitionDiscovery: false
-              }
-              formatSettings: {
-                type: 'JsonReadSettings'
-              }
+            expression: {
+              value: '@not(variables(\'hasNoRows\'))'
+              type: 'Expression'
             }
-            sink: {
-              type: 'JsonSink'
-              storeSettings: {
-                type: 'AzureBlobFSWriteSettings'
+            ifTrueActivities: [
+              {
+                name: 'Copy Manifest to Ingestion'
+                description: 'Copy the manifest to the ingestion container to trigger ADX ingestion.'
+                type: 'Copy'
+                dependsOn: []
+                policy: {
+                  timeout: '0.12:00:00'
+                  retry: 0
+                  retryIntervalInSeconds: 30
+                  secureOutput: false
+                  secureInput: false
+                }
+                userProperties: []
+                typeProperties: {
+                  source: {
+                    type: 'JsonSource'
+                    storeSettings: {
+                      type: 'AzureBlobFSReadSettings'
+                      recursive: true
+                      enablePartitionDiscovery: false
+                    }
+                    formatSettings: {
+                      type: 'JsonReadSettings'
+                    }
+                  }
+                  sink: {
+                    type: 'JsonSink'
+                    storeSettings: {
+                      type: 'AzureBlobFSWriteSettings'
+                    }
+                    formatSettings: {
+                      type: 'JsonWriteSettings'
+                    }
+                  }
+                  enableStaging: false
+                }
+                inputs: [
+                  {
+                    referenceName: dataFactory::dataset_msexports_manifest.name
+                    type: 'DatasetReference'
+                    parameters: {
+                      fileName: 'manifest.json'
+                      folderPath: {
+                        value: '@pipeline().parameters.folderPath'
+                        type: 'Expression'
+                      }
+                    }
+                  }
+                ]
+                outputs: [
+                  {
+                    referenceName: dataFactory::dataset_ingestion_manifest.name
+                    type: 'DatasetReference'
+                    parameters: {
+                      fileName: 'manifest.json'
+                      folderPath: {
+                        value: '@concat(\'${INGESTION}/\', variables(\'destinationFolder\'))'
+                        type: 'Expression'
+                      }
+                    }
+                  }
+                ]
               }
-              formatSettings: {
-                type: 'JsonWriteSettings'
-              }
-            }
-            enableStaging: false
+            ]
           }
-          inputs: [
-            {
-              referenceName: dataFactory::dataset_msexports_manifest.name
-              type: 'DatasetReference'
-              parameters: {
-                fileName: 'manifest.json'
-                folderPath: {
-                  value: '@pipeline().parameters.folderPath'
-                  type: 'Expression'
-                }
-              }
-            }
-          ]
-          outputs: [
-            {
-              referenceName: dataFactory::dataset_ingestion_manifest.name
-              type: 'DatasetReference'
-              parameters: {
-                fileName: 'manifest.json'
-                folderPath: {
-                  value: '@concat(\'${INGESTION}/\', variables(\'destinationFolder\'))'
-                  type: 'Expression'
-                }
-              }
-            }
-          ]
         }
       ]
       parameters: {


### PR DESCRIPTION
## 🛠️ Description

When Cost Management exports a file with column headers but zero data rows (e.g., reservation transactions with no activity), the `msexports_ExecuteETL` pipeline fails. The manifest reports `blobCount = 1` (the file exists), but the pipeline tries to read the first data row for channel detection and convert the empty file to parquet, both of which fail.

This fix updates the `hasNoRows` check to also verify `dataRowCount`, so exports with no data rows are gracefully skipped instead of causing pipeline failures.

Fixes #1535
Fixes #1738 

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 📦 Deploy to test?

> - [x] Hubs + ADX (managed)
> - [ ] Hubs + Fabric (manual) — URI:
> - [x] Hubs (manual)
> - [ ] Hubs (no data)
> - [ ] Workbooks
> - [ ] Alerts

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [x] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)