### PR TITLE
[DevOps] Fix PR label policies for review feedback

### DIFF
--- a/.github/policies/pulls-03-feedback.yml
+++ b/.github/policies/pulls-03-feedback.yml
@@ -30,6 +30,8 @@ configuration:
                   - payloadType: Pull_Request_Review
                   - isReviewState:
                       reviewState: Commented
+                  - isActivitySender:
+                      issueAuthor: False
           - not:
               targetsBranch:
                 branch: main

--- a/.github/policies/pulls-03-feedback.yml
+++ b/.github/policies/pulls-03-feedback.yml
@@ -26,6 +26,10 @@ configuration:
                   - payloadType: Pull_Request_Review
                   - isReviewState:
                       reviewState: Changes_requested
+              - and:
+                  - payloadType: Pull_Request_Review
+                  - isReviewState:
+                      reviewState: Commented
           - not:
               targetsBranch:
                 branch: main

--- a/.github/policies/pulls-04-respond.yml
+++ b/.github/policies/pulls-04-respond.yml
@@ -23,6 +23,12 @@ configuration:
                   - isActivitySender:
                       issueAuthor: True
               - and:
+                  - payloadType: Issue_Comment
+                  - isAction:
+                      action: Created
+                  - isActivitySender:
+                      issueAuthor: True
+              - and:
                   - payloadType: Pull_Request
                   - isAction:
                       action: Synchronize


### PR DESCRIPTION
## Summary
- Add `Commented` review state trigger to feedback policy so submitting a review with comments (not just "Request changes") flips labels to `Needs: Attention 👋`
- Add `Issue_Comment` trigger to respond policy so authors can clear `Needs: Attention` by replying in the PR conversation thread

## Test plan
- [ ] Submit a "Comment" review on a PR and verify `Needs: Attention 👋` is added and `Needs: Review 👀` is removed
- [ ] Have the PR author reply in the conversation and verify labels flip back
- [ ] Verify existing "Request changes" and inline review comment flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)