### PR TITLE
[Hubs] Fix hub-app conditional outputs and Deploy-Hub bugs

### DIFF
--- a/src/scripts/Deploy-Hub.ps1
+++ b/src/scripts/Deploy-Hub.ps1
@@ -70,6 +70,9 @@
     .PARAMETER StorageOnly
     Deploy a storage-only hub (no Azure Data Explorer or Fabric).
 
+    .PARAMETER Recommendations
+    Enable recommendations with all noisy recommendation types (AHB, Spot). Requires the hub template to have recommendation parameters.
+
     .PARAMETER Remove
     Remove test environments. With a name, deletes the target resource group. Alone, lists all resource groups matching "{initials}-*".
 
@@ -93,6 +96,7 @@ param(
     [string]$ResourceGroup,
     [string]$Fabric,
     [switch]$StorageOnly,
+    [switch]$Recommendations,
     [switch]$Remove,
     [string]$Location,
     [switch]$Build,
@@ -195,10 +199,13 @@ $params = @{}
 if ($HubName) { $params.hubName = $HubName }
 else { $params.hubName = "hub" }
 
-# Always enable recommendations for testing
-$params.enableRecommendations = $true
-$params.enableAHBRecommendations = $true
-$params.enableSpotRecommendations = $true
+# Recommendations (requires enableRecommendations param in hub template)
+if ($Recommendations)
+{
+    $params.enableRecommendations = $true
+    $params.enableAHBRecommendations = $true
+    $params.enableSpotRecommendations = $true
+}
 
 # Analytics backend
 if ($StorageOnly)

--- a/src/scripts/Deploy-Hub.ps1
+++ b/src/scripts/Deploy-Hub.ps1
@@ -195,6 +195,11 @@ $params = @{}
 if ($HubName) { $params.hubName = $HubName }
 else { $params.hubName = "hub" }
 
+# Always enable recommendations for testing
+$params.enableRecommendations = $true
+$params.enableAHBRecommendations = $true
+$params.enableSpotRecommendations = $true
+
 # Analytics backend
 if ($StorageOnly)
 {

--- a/src/templates/finops-hub/modules/fx/hub-app.bicep
+++ b/src/templates/finops-hub/modules/fx/hub-app.bicep
@@ -285,12 +285,26 @@ module approveStoragePrivateEndpointConnections 'storageEndpoints.bicep' = if (u
 
 // Grant ADF identity access to storage
 resource storageRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
-  for role in factoryStorageRoles: {
+  for role in factoryStorageRoles: if (usesDataFactory && usesStorage) {
     name: guid(storageAccount.id, role, dataFactory.id)
     scope: storageAccount
     properties: {
       roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', role)
-      #disable-next-line BCP318 // Null safety warning for conditional resource access // Null safety warning for conditional resource access
+      #disable-next-line BCP318 // Null safety warning for conditional resource access
+      principalId: dataFactory.identity.principalId
+      principalType: 'ServicePrincipal'
+    }
+  }
+]
+
+// Grant ADF identity access to execute its own pipelines (e.g., for dynamic pipeline dispatch via REST API)
+resource factorySelfRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for role in autoStartRbacRoles: if (usesDataFactory) {
+    name: guid(dataFactory.id, role, dataFactory.id)
+    scope: dataFactory
+    properties: {
+      roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', role)
+      #disable-next-line BCP318 // Null safety warning for conditional resource access
       principalId: dataFactory.identity.principalId
       principalType: 'ServicePrincipal'
     }
@@ -542,19 +556,20 @@ resource keyVaultEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = if (
 
 @description('Resource ID of the Data Factory instance used by the FinOps hub app.')
 #disable-next-line BCP318 // Null safety warning for conditional resource access
-output dataFactoryId string = dataFactory.id
+output dataFactoryId string = usesDataFactory ? dataFactory.id : ''
 
 @description('Resource ID of the Key Vault instance used by the FinOps hub app.')
 #disable-next-line BCP318 // Null safety warning for conditional resource access
-output keyVaultId string = keyVault.id
+output keyVaultId string = usesKeyVault ? keyVault.id : ''
 
 @description('Resource ID of the storage account instance used by the FinOps hub app.')
 #disable-next-line BCP318 // Null safety warning for conditional resource access
-output storageAccountId string = storageAccount.id
+output storageAccountId string = usesStorage ? storageAccount.id : ''
 
 @description('Principal ID for the managed identity used by Data Factory.')
 #disable-next-line BCP318 // Null safety warning for conditional resource access
-output principalId string = dataFactory.identity.principalId
+output principalId string = usesDataFactory ? dataFactory.identity.principalId : ''
 
 @description('Name of the managed identity used to create and stop ADF triggers.')
-output triggerManagerIdentityName string = triggerManagerIdentity.name
+#disable-next-line BCP318 // Null safety warning for conditional resource access
+output triggerManagerIdentityName string = usesDataFactory ? triggerManagerIdentity.name : ''

--- a/src/templates/finops-hub/modules/fx/hub-app.bicep
+++ b/src/templates/finops-hub/modules/fx/hub-app.bicep
@@ -56,10 +56,10 @@ var telemetryProps = {
   }
 }
 
-// Roles needed to auto-start Data Factory triggers
-var autoStartRbacRoles = [
+// Roles needed for Data Factory management (trigger start/stop, pipeline dispatch)
+var factoryManagementRoles = [
   // Data Factory contributor -- https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#data-factory-contributor
-  // Used to start/stop triggers and delete old pipelines/triggers
+  // Used to start/stop triggers, delete old pipelines/triggers, and execute pipelines via REST API
   '673868aa-7521-48a0-acc6-0f60742d39f5'
 ]
 
@@ -299,7 +299,7 @@ resource storageRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04
 
 // Grant ADF identity access to execute its own pipelines (e.g., for dynamic pipeline dispatch via REST API)
 resource factorySelfRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
-  for role in autoStartRbacRoles: if (usesDataFactory) {
+  for role in factoryManagementRoles: if (usesDataFactory) {
     name: guid(dataFactory.id, role, dataFactory.id)
     scope: dataFactory
     properties: {
@@ -323,7 +323,7 @@ resource triggerManagerIdentity 'Microsoft.ManagedIdentity/userAssignedIdentitie
 }
 
 resource triggerManagerRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
-  for role in autoStartRbacRoles: if (usesDataFactory) {
+  for role in factoryManagementRoles: if (usesDataFactory) {
     name: guid(dataFactory.id, role, triggerManagerIdentity.id)
     scope: dataFactory
     properties: {
@@ -554,22 +554,22 @@ resource keyVaultEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = if (
 // Outputs
 //==============================================================================
 
-@description('Resource ID of the Data Factory instance used by the FinOps hub app.')
+@description('Resource ID of the Data Factory instance used by the FinOps hub app. Empty when not deployed.')
 #disable-next-line BCP318 // Null safety warning for conditional resource access
 output dataFactoryId string = usesDataFactory ? dataFactory.id : ''
 
-@description('Resource ID of the Key Vault instance used by the FinOps hub app.')
+@description('Resource ID of the Key Vault instance used by the FinOps hub app. Empty when not deployed.')
 #disable-next-line BCP318 // Null safety warning for conditional resource access
 output keyVaultId string = usesKeyVault ? keyVault.id : ''
 
-@description('Resource ID of the storage account instance used by the FinOps hub app.')
+@description('Resource ID of the storage account instance used by the FinOps hub app. Empty when not deployed.')
 #disable-next-line BCP318 // Null safety warning for conditional resource access
 output storageAccountId string = usesStorage ? storageAccount.id : ''
 
-@description('Principal ID for the managed identity used by Data Factory.')
+@description('Principal ID for the managed identity used by Data Factory. Empty when not deployed.')
 #disable-next-line BCP318 // Null safety warning for conditional resource access
 output principalId string = usesDataFactory ? dataFactory.identity.principalId : ''
 
-@description('Name of the managed identity used to create and stop ADF triggers.')
+@description('Name of the managed identity used to create and stop ADF triggers. Empty when not deployed.')
 #disable-next-line BCP318 // Null safety warning for conditional resource access
 output triggerManagerIdentityName string = usesDataFactory ? triggerManagerIdentity.name : ''


### PR DESCRIPTION
## Summary
- Add conditional guards to `hub-app.bicep` outputs so they return empty strings when the resource is not deployed (prevents Bicep null safety errors for optional resources)
- Add `usesDataFactory && usesStorage` guard to storage role assignment loop
- Add ADF self-role assignment for dynamic pipeline dispatch via REST API
- Fix `Deploy-Hub.ps1` deployment issues

## Test plan
- [ ] Verify hub deploys successfully with ADX configuration
- [ ] Verify hub deploys successfully with storage-only configuration
- [ ] Verify Deploy-Hub.ps1 runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)