### PR TITLE
Add environment section to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -30,6 +30,13 @@ TODO: Add a clear and concise description of what you expected to happen.
 ## 📷 Screenshots
 TODO: If applicable, add screenshots to help explain your problem. Remove if not applicable.
 
+## 🔧 Environment
+TODO: Complete the following (remove any that are not applicable):
+- **FinOps hub version:** (e.g., 0.10, 0.11, 12.0, 13.0)
+- **Billing account type:** EA (Enterprise Agreement) / MCA (Microsoft Customer Agreement) / CSP (Cloud Solution Provider)
+- **Power BI report type:** Storage-based / ADX (Azure Data Explorer)
+- **Cost Management export:** (e.g., FOCUS 1.2-preview, FOCUS 1.0, actual, amortized)
+
 ## ℹ️ Additional context
 TODO: Add any other context about the problem here. Remove if not applicable.
 


### PR DESCRIPTION
## Summary
- Adds an Environment section to the bug report issue template
- Asks reporters for FinOps hub version, billing account type (EA/MCA/CSP), Power BI report type (storage/ADX), and Cost Management export details
- Helps with faster triage by collecting key context upfront

## Test plan
- [ ] Verify the template renders correctly when creating a new issue on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)