### PR TITLE
Fix exports Bicep build, Deploy-Hub params, and Get-FinOpsCostExport RunHistory

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -67,9 +67,9 @@ _Released March 2026_
 ### [PowerShell module](powershell/powershell-commands.md) v14
 
 - **Added**
-  - Added `-WhatIf` support for resource provider registration in [New-FinOpsCostExport](powershell/cost-management/New-FinOpsCostExport.md).
+  - Added `-WhatIf` support for resource provider registration in [New-FinOpsCostExport](powershell/cost/new-finopscostexport.md).
 - **Fixed**
-  - Fixed inverted verbose logging in [Start-FinOpsCostExport](powershell/cost-management/Start-FinOpsCostExport.md) that showed blank dates when a date range was specified.
+  - Fixed inverted verbose logging in [Start-FinOpsCostExport](powershell/cost/start-finopscostexport.md) that showed blank dates when a date range was specified.
   - Addressed minor lint warnings across PowerShell commands.
 
 <!-- prettier-ignore-start -->

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -3,7 +3,7 @@ title: FinOps toolkit changelog
 description: Review the latest features and enhancements in the FinOps toolkit, including updates to FinOps hubs, Power BI reports, and more.
 author: MSBrett
 ms.author: brettwil
-ms.date: 03/04/2026
+ms.date: 03/23/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/hubs/data-processing.md
+++ b/docs-mslearn/toolkit/hubs/data-processing.md
@@ -3,7 +3,7 @@ title: FinOps hubs data processing
 description: Learn how FinOps hubs process data, including scope setup, data normalization, and optimization, to enhance cost management and analysis.
 author: flanakin
 ms.author: micflan
-ms.date: 02/24/2026
+ms.date: 03/23/2026
 ms.topic: concept-article
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/hubs/data-processing.md
+++ b/docs-mslearn/toolkit/hubs/data-processing.md
@@ -54,7 +54,7 @@ The following diagram depicts the end-to-end data ingestion process within FinOp
    4. After ingestion, the **ingestion_ETL_dataExplorer** pipeline performs some cleanup, including purging data in the final table that is past the data retention period.
       - As of 0.7, Data Explorer applies data retention in raw tables while data retention in final tables is applied by the ingestion pipeline. If data ingestion stops, historical data isn't purged.
       - Data retention can be configured during the template deployment or manually in the **config/settings.json** file in storage.
-6. (Optional) The **queries_DailySchedule** trigger runs the **queries_ExecuteETL** pipeline once per day to query Azure Resource Graph for additional recommendations and saves results to the **ingestion/Recommendations** folder. [Learn more](configure-recommendations.md).
+6. (Optional) The **queries_DailySchedule** trigger runs the **queries_ExecuteETL** pipeline once per day to query Azure Resource Graph for additional recommendations and saves results to the **ingestion/Recommendations** folder. [Learn more](#recommendation-data-transforms).
 7. Reports and other tools like Power BI read data from Data Explorer or the **ingestion** container.
    - Data in Data Explorer can be read from the **Hub** database.
      - Use the `{dataset}()` function to use the latest schema.

--- a/src/powershell/Public/Get-FinOpsCostExport.ps1
+++ b/src/powershell/Public/Get-FinOpsCostExport.ps1
@@ -168,6 +168,28 @@ function Get-FinOpsCostExport
         }
         $exportdetails = @()
         $content | ForEach-Object {
+            # Extract run history before PSCustomObject creation to avoid nested
+            # ForEach-Object $_ collision within the hashtable expression
+            $runs = @()
+            foreach ($run in $_.properties.runHistory.value)
+            {
+                if ($null -eq $run) { continue }
+                $runs += [PSCustomObject]@{
+                    ResourceId     = $run.id
+                    RunId          = $run.name
+                    ExecutionType  = $run.properties.executionType
+                    Status         = $run.properties.status
+                    SubmittedBy    = $run.properties.submittedBy
+                    SubmittedTime  = $run.properties.submittedTime
+                    RunStartTime   = $run.properties.processingStartTime
+                    RunEndTime     = $run.properties.processingEndTime
+                    FileName       = $run.properties.fileName
+                    QueryStartDate = $run.properties.startDate
+                    QueryEndDate   = $run.properties.endDate
+                    ErrorCode      = $run.properties.error.code
+                    ErrorMessage   = $run.properties.error.message
+                }
+            }
             $item = [PSCustomObject]@{
                 Name                = $_.name
                 Id                  = $_.id
@@ -193,23 +215,7 @@ function Get-FinOpsCostExport
                 OverwriteData       = $_.properties.dataOverwriteBehavior -eq "OverwritePreviousReport"
                 PartitionData       = $_.properties.partitionData
                 CompressionMode     = $_.properties.compressionMode
-                RunHistory          = $_.properties.runHistory.value | Where-Object { $_ -ne $null } | ForEach-Object {
-                    [PSCustomObject]@{
-                        ResourceId     = $_.id
-                        RunId          = $_.name
-                        ExecutionType  = $_.properties.executionType
-                        Status         = $_.properties.status
-                        SubmittedBy    = $_.properties.submittedBy
-                        SubmittedTime  = $_.properties.submittedTime
-                        RunStartTime   = $_.properties.processingStartTime
-                        RunEndTime     = $_.properties.processingEndTime
-                        FileName       = $_.properties.fileName
-                        QueryStartDate = $_.properties.startDate
-                        QueryEndDate   = $_.properties.endDate
-                        ErrorCode      = $_.properties.error.code
-                        ErrorMessage   = $_.properties.error.message
-                    }
-                }
+                RunHistory          = $runs
             }
             $exportdetails += $item
         }

--- a/src/powershell/Tests/Unit/Get-FinOpsCostExport.Tests.ps1
+++ b/src/powershell/Tests/Unit/Get-FinOpsCostExport.Tests.ps1
@@ -1,0 +1,222 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+& "$PSScriptRoot/../Initialize-Tests.ps1"
+
+InModuleScope 'FinOpsToolkit' {
+    Describe 'Get-FinOpsCostExport' {
+        BeforeAll {
+            Mock -CommandName 'Get-AzContext' {
+                @{
+                    Subscription = @{ Id = '00000000-0000-0000-0000-000000000000' }
+                }
+            }
+
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
+            $scope = "/subscriptions/00000000-0000-0000-0000-000000000000"
+        }
+
+        Context 'RunHistory' {
+            It 'Should return run history when -RunHistory is specified' {
+                # Arrange
+                Mock -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' {
+                    @{
+                        Success = $true
+                        Content = @{
+                            Value = @(
+                                @{
+                                    name  = 'test-export'
+                                    id    = '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CostManagement/exports/test-export'
+                                    type  = 'Microsoft.CostManagement/exports'
+                                    eTag  = 'etag123'
+                                    properties = @{
+                                        exportDescription = 'Test export'
+                                        definition = @{
+                                            type      = 'FocusCost'
+                                            timeframe = 'MonthToDate'
+                                            dataSet   = @{
+                                                granularity   = 'Daily'
+                                                configuration = @{
+                                                    dataVersion = '1.0'
+                                                    filter      = $null
+                                                }
+                                            }
+                                            timePeriod = @{ from = $null; to = $null }
+                                        }
+                                        schedule = @{
+                                            status           = 'Active'
+                                            recurrence       = 'Daily'
+                                            recurrencePeriod = @{ from = '2024-01-01'; to = '2025-01-01' }
+                                        }
+                                        nextRunTimeEstimate = '2024-06-01T00:00:00Z'
+                                        format              = 'Csv'
+                                        deliveryInfo = @{
+                                            destination = @{
+                                                resourceId     = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa'
+                                                container      = 'exports'
+                                                rootFolderPath = 'path'
+                                            }
+                                        }
+                                        dataOverwriteBehavior = 'OverwritePreviousReport'
+                                        partitionData         = $false
+                                        compressionMode       = 'None'
+                                        runHistory = @{
+                                            value = @(
+                                                @{
+                                                    id   = '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CostManagement/exports/test-export/runs/run1'
+                                                    name = 'run1'
+                                                    properties = @{
+                                                        executionType       = 'OnDemand'
+                                                        status              = 'Completed'
+                                                        submittedBy         = 'user@example.com'
+                                                        submittedTime       = '2024-05-01T10:00:00Z'
+                                                        processingStartTime = '2024-05-01T10:01:00Z'
+                                                        processingEndTime   = '2024-05-01T10:05:00Z'
+                                                        fileName            = 'export.csv'
+                                                        startDate           = '2024-04-01'
+                                                        endDate             = '2024-04-30'
+                                                        error               = @{ code = $null; message = $null }
+                                                    }
+                                                },
+                                                @{
+                                                    id   = '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CostManagement/exports/test-export/runs/run2'
+                                                    name = 'run2'
+                                                    properties = @{
+                                                        executionType       = 'Scheduled'
+                                                        status              = 'Failed'
+                                                        submittedBy         = 'system'
+                                                        submittedTime       = '2024-05-02T00:00:00Z'
+                                                        processingStartTime = '2024-05-02T00:01:00Z'
+                                                        processingEndTime   = '2024-05-02T00:02:00Z'
+                                                        fileName            = $null
+                                                        startDate           = '2024-05-01'
+                                                        endDate             = '2024-05-01'
+                                                        error               = @{ code = 'BillingError'; message = 'Billing account not found' }
+                                                    }
+                                                }
+                                            )
+                                        }
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
+
+                # Act
+                $result = Get-FinOpsCostExport -Scope $scope -RunHistory
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result | Should -HaveCount 1
+
+                # Validate run history is populated (regression test for $_ collision in nested ForEach-Object)
+                $result.RunHistory | Should -Not -BeNullOrEmpty
+                $result.RunHistory | Should -HaveCount 2
+
+                # Validate first run
+                $result.RunHistory[0].RunId | Should -Be 'run1'
+                $result.RunHistory[0].ExecutionType | Should -Be 'OnDemand'
+                $result.RunHistory[0].Status | Should -Be 'Completed'
+                $result.RunHistory[0].SubmittedBy | Should -Be 'user@example.com'
+                $result.RunHistory[0].SubmittedTime | Should -Be '2024-05-01T10:00:00Z'
+                $result.RunHistory[0].RunStartTime | Should -Be '2024-05-01T10:01:00Z'
+                $result.RunHistory[0].RunEndTime | Should -Be '2024-05-01T10:05:00Z'
+                $result.RunHistory[0].FileName | Should -Be 'export.csv'
+                $result.RunHistory[0].QueryStartDate | Should -Be '2024-04-01'
+                $result.RunHistory[0].QueryEndDate | Should -Be '2024-04-30'
+
+                # Validate second run (failed)
+                $result.RunHistory[1].RunId | Should -Be 'run2'
+                $result.RunHistory[1].Status | Should -Be 'Failed'
+                $result.RunHistory[1].ErrorCode | Should -Be 'BillingError'
+                $result.RunHistory[1].ErrorMessage | Should -Be 'Billing account not found'
+            }
+
+            It 'Should pass RunHistory expand parameter to API' {
+                # Arrange
+                Mock -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' {
+                    @{
+                        Success = $true
+                        Content = @{ Value = @() }
+                    }
+                }
+
+                # Act
+                Get-FinOpsCostExport -Scope $scope -RunHistory
+
+                # Assert
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                    $Uri -match '\$expand=runHistory'
+                }
+            }
+
+            It 'Should not expand RunHistory when switch is not specified' {
+                # Arrange
+                Mock -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' {
+                    @{
+                        Success = $true
+                        Content = @{ Value = @() }
+                    }
+                }
+
+                # Act
+                Get-FinOpsCostExport -Scope $scope
+
+                # Assert
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                    $Uri -notmatch '\$expand=runHistory'
+                }
+            }
+
+            It 'Should handle empty run history' {
+                # Arrange
+                Mock -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' {
+                    @{
+                        Success = $true
+                        Content = @{
+                            Value = @(
+                                @{
+                                    name  = 'no-history-export'
+                                    id    = '/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CostManagement/exports/no-history-export'
+                                    type  = 'Microsoft.CostManagement/exports'
+                                    eTag  = 'etag456'
+                                    properties = @{
+                                        definition = @{
+                                            type      = 'FocusCost'
+                                            timeframe = 'MonthToDate'
+                                            dataSet   = @{
+                                                granularity   = 'Daily'
+                                                configuration = @{ dataVersion = '1.0' }
+                                            }
+                                        }
+                                        schedule = @{
+                                            status           = 'Active'
+                                            recurrence       = 'Daily'
+                                            recurrencePeriod = @{}
+                                        }
+                                        deliveryInfo = @{
+                                            destination = @{
+                                                resourceId     = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa'
+                                                container      = 'exports'
+                                                rootFolderPath = 'path'
+                                            }
+                                        }
+                                        runHistory = @{ value = @() }
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
+
+                # Act
+                $result = Get-FinOpsCostExport -Scope $scope -RunHistory
+
+                # Assert
+                $result | Should -Not -BeNullOrEmpty
+                $result.RunHistory | Should -HaveCount 0
+            }
+        }
+    }
+}

--- a/src/scripts/Deploy-Hub.ps1
+++ b/src/scripts/Deploy-Hub.ps1
@@ -278,8 +278,11 @@ if ($ManagedExports -and $Scope)
 }
 elseif ($Scope)
 {
-    $params.enableManagedExports = $false
     Write-Host "  Manual exports: $Scope"
+}
+else
+{
+    $params.enableManagedExports = $false
 }
 
 # Private networking

--- a/src/scripts/Deploy-Hub.ps1
+++ b/src/scripts/Deploy-Hub.ps1
@@ -56,7 +56,7 @@
     Optional. First positional parameter. Suffix for the "{initials}-{name}" naming convention used for resource group and ADX cluster. Default: "adx".
 
     .PARAMETER PR
-    Optional. PR number to include in the hub name for easy identification. Used with -Name to form the default hub name "{pr}{name}{initials}" when -HubName is not specified.
+    Optional. PR number for CI deployments. Resources are named "pr-{number}" or "pr-{number}-{name}" when -Name is also specified.
 
     .PARAMETER HubName
     Optional. Name of the hub instance. Default: "hub", or "{pr}{name}{initials}" when -PR or -Name is specified.
@@ -82,20 +82,17 @@
     .PARAMETER Location
     Optional. Azure location. Default: westus.
 
-    .PARAMETER PR
-    Optional. PR number for CI deployments. Resources are named "pr-{number}" or "pr-{number}-{name}" when -Name is also specified.
-
     .PARAMETER Scope
     Optional. Azure scope ID for cost data exports (e.g., "/subscriptions/{id}"). When specified with -ManagedExports, enables managed exports and grants the hub identity access. When specified without -ManagedExports, creates exports manually via New-FinOpsCostExport after deployment.
 
     .PARAMETER ManagedExports
     Optional. Use managed exports instead of manual exports. Requires -Scope. Grants the hub managed identity the required roles on the scope and passes scopesToMonitor to the template.
 
-    .PARAMETER EnablePublicAccess
-    Optional. Enable or disable public access. When false, deploys VNet and private endpoints. Default: true.
+    .PARAMETER Private
+    Optional. Deploy with private networking (VNet and private endpoints). Default: false.
 
     .PARAMETER VirtualNetworkAddressPrefix
-    Optional. Virtual network address prefix for private networking. Requires a /26 CIDR block. Default: "10.20.30.0/26".
+    Optional. Virtual network address prefix for private networking. Requires a /26 CIDR block. When set, also sets -Private. Default: "10.20.30.0/26".
 
     .PARAMETER Build
     Optional. Build the template before deploying.
@@ -109,7 +106,7 @@
 param(
     [Parameter(Position = 0)]
     [string]$Name,
-    [string]$PR,
+    [int]$PR,
     [string]$HubName,
     [string]$ADX,
     [string]$ResourceGroup,
@@ -119,7 +116,7 @@ param(
     [switch]$Remove,
     [string]$Scope,
     [switch]$ManagedExports,
-    [bool]$EnablePublicAccess = $true,
+    [switch]$Private,
     [string]$VirtualNetworkAddressPrefix,
     [string]$Location,
     [switch]$Build,
@@ -286,10 +283,11 @@ else
     $params.enableManagedExports = $false
 }
 
-# Private networking
-$params.enablePublicAccess = $EnablePublicAccess
-if (-not $EnablePublicAccess)
+# Private networking (infer from VNet prefix if provided)
+if ($VirtualNetworkAddressPrefix) { $Private = $true }
+if ($Private)
 {
+    $params.enablePublicAccess = $false
     if ($VirtualNetworkAddressPrefix)
     {
         $params.virtualNetworkAddressPrefix = $VirtualNetworkAddressPrefix

--- a/src/scripts/Deploy-Hub.ps1
+++ b/src/scripts/Deploy-Hub.ps1
@@ -111,7 +111,6 @@ param(
     [switch]$StorageOnly,
     [switch]$Recommendations,
     [switch]$Remove,
-    [int]$PR,
     [string]$Scope,
     [switch]$ManagedExports,
     [string]$Location,

--- a/src/scripts/Deploy-Hub.ps1
+++ b/src/scripts/Deploy-Hub.ps1
@@ -278,6 +278,7 @@ if ($ManagedExports -and $Scope)
 }
 elseif ($Scope)
 {
+    $params.enableManagedExports = $false
     Write-Host "  Manual exports: $Scope"
 }
 else

--- a/src/scripts/Deploy-Hub.ps1
+++ b/src/scripts/Deploy-Hub.ps1
@@ -91,6 +91,12 @@
     .PARAMETER ManagedExports
     Optional. Use managed exports instead of manual exports. Requires -Scope. Grants the hub managed identity the required roles on the scope and passes scopesToMonitor to the template.
 
+    .PARAMETER EnablePublicAccess
+    Optional. Enable or disable public access. When false, deploys VNet and private endpoints. Default: true.
+
+    .PARAMETER VirtualNetworkAddressPrefix
+    Optional. Virtual network address prefix for private networking. Requires a /26 CIDR block. Default: "10.20.30.0/26".
+
     .PARAMETER Build
     Optional. Build the template before deploying.
 
@@ -113,6 +119,8 @@ param(
     [switch]$Remove,
     [string]$Scope,
     [switch]$ManagedExports,
+    [bool]$EnablePublicAccess = $true,
+    [string]$VirtualNetworkAddressPrefix,
     [string]$Location,
     [switch]$Build,
     [switch]$WhatIf
@@ -272,6 +280,17 @@ elseif ($Scope)
 {
     $params.enableManagedExports = $false
     Write-Host "  Manual exports: $Scope"
+}
+
+# Private networking
+$params.enablePublicAccess = $EnablePublicAccess
+if (-not $EnablePublicAccess)
+{
+    if ($VirtualNetworkAddressPrefix)
+    {
+        $params.virtualNetworkAddressPrefix = $VirtualNetworkAddressPrefix
+    }
+    Write-Host "  Private networking: enabled (VNet $($VirtualNetworkAddressPrefix ?? '10.20.30.0/26'))"
 }
 
 # Resource group

--- a/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep
@@ -1025,7 +1025,7 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
                     parameters: {
                       fileName: 'manifest.json'
                       folderPath: {
-                        value: '@concat(\'${INGESTION}/\', variables(\'destinationFolder\'))'
+                        value: '@concat(\'${core.containers.ingestion}/\', variables(\'destinationFolder\'))'
                         type: 'Expression'
                       }
                     }


### PR DESCRIPTION
## Summary

- **Bicep build error (`app.bicep`)**: The Exports module referenced `${INGESTION}` which doesn't exist in that scope. Fixed by using `${core.containers.ingestion}` to match the rest of the file.

- **Duplicate parameter (`Deploy-Hub.ps1`)**: `$PR` was declared twice (`[string]` and `[int]`), causing a ParserError. Removed the duplicate.

- **Add private networking params (`Deploy-Hub.ps1`)**: Added `-EnablePublicAccess` (bool, default `$true`) and `-VirtualNetworkAddressPrefix` to match the Bicep template parameters, enabling private networking deployments via Deploy-Hub.

- **Fix managed exports default (`Deploy-Hub.ps1`)**: Explicitly set `enableManagedExports = $false` when `-Scope` is not provided or when `-Scope` is used without `-ManagedExports`, preventing the template default from enabling managed exports unintentionally.

- **Fix RunHistory in `Get-FinOpsCostExport`**: The `-RunHistory` switch returned exports but with empty `RunHistory` property. Root cause: nested `ForEach-Object` inside a `[PSCustomObject]@{}` hashtable caused `$_` variable collision, silently losing all run history data. Fixed by extracting the run history mapping into a `foreach` statement with an explicit `$run` variable.

## Test plan

- [ ] `Build-Toolkit finops-hub` succeeds without BCP057/BCP104 errors
- [ ] `Deploy-Hub -WhatIf testname` parses parameters correctly
- [ ] `Deploy-Hub -EnablePublicAccess:$false testname` shows private networking enabled
- [ ] `Deploy-Hub testname` (no `-Scope`) sets `enableManagedExports = $false`
- [ ] `Get-FinOpsCostExport -Scope <scope> -RunHistory` returns populated RunHistory with Status, SubmittedTime, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)