### PR TITLE
[DevOps] Add missing comment triggers to Needs: Attention policy

### DIFF
--- a/.github/policies/pulls-03-feedback.yml
+++ b/.github/policies/pulls-03-feedback.yml
@@ -20,8 +20,6 @@ configuration:
                   - payloadType: Pull_Request_Review_Comment
                   - isAction:
                       action: Created
-                  - isActivitySender:
-                      issueAuthor: False
               - and:
                   - payloadType: Pull_Request_Review
                   - isReviewState:
@@ -30,8 +28,10 @@ configuration:
                   - payloadType: Pull_Request_Review
                   - isReviewState:
                       reviewState: Commented
-                  - isActivitySender:
-                      issueAuthor: False
+              - and:
+                  - payloadType: Issue_Comment
+                  - isAction:
+                      action: Created
           - not:
               targetsBranch:
                 branch: main

--- a/.github/policies/pulls-03-feedback.yml
+++ b/.github/policies/pulls-03-feedback.yml
@@ -36,6 +36,9 @@ configuration:
                   - payloadType: Issue_Comment
                   - isAction:
                       action: Created
+                  - not:
+                      commentContains:
+                        pattern: '#needs-review'
                   - isActivitySender:
                       issueAuthor: False
                   - isPullRequest

--- a/.github/policies/pulls-03-feedback.yml
+++ b/.github/policies/pulls-03-feedback.yml
@@ -20,6 +20,8 @@ configuration:
                   - payloadType: Pull_Request_Review_Comment
                   - isAction:
                       action: Created
+                  - isActivitySender:
+                      issueAuthor: False
               - and:
                   - payloadType: Pull_Request_Review
                   - isReviewState:
@@ -28,10 +30,14 @@ configuration:
                   - payloadType: Pull_Request_Review
                   - isReviewState:
                       reviewState: Commented
+                  - isActivitySender:
+                      issueAuthor: False
               - and:
                   - payloadType: Issue_Comment
                   - isAction:
                       action: Created
+                  - isActivitySender:
+                      issueAuthor: False
           - not:
               targetsBranch:
                 branch: main

--- a/.github/policies/pulls-03-feedback.yml
+++ b/.github/policies/pulls-03-feedback.yml
@@ -38,6 +38,8 @@ configuration:
                       action: Created
                   - isActivitySender:
                       issueAuthor: False
+                  - isPullRequest
+                  - isOpen
           - not:
               targetsBranch:
                 branch: main


### PR DESCRIPTION
## 🛠️ Description

Updates the `pulls-03-feedback` GitOps policy to trigger `Needs: Attention 👋` for general PR conversation comments from non-authors, not just review comments and change requests.

**Changes:**
- Added the `Issue_Comment` payload type to catch general PR conversation comments
- Limited the trigger to non-author comments on open pull requests
- Excluded comments containing `#needs-review` so the response policy handles that command without conflicting label or assignment changes

Previously, regular PR conversation comments would not trigger the label.

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests

### 🙋‍♀️ Do any of the following that apply?

> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [x] ❎ Docs not needed (small/internal change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)