### PR TITLE
Docs: document filename convention and pipeline constraints for custom ingestion

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -56,6 +56,7 @@ _Released April 2026_
   - Improved deployment UI to consolidate hub mode selection into a single radio button group with four mutually exclusive options: None (storage only for Power BI reports), Azure Data Explorer, Microsoft Fabric, or Remote Hub ([#1929](https://github.com/microsoft/finops-toolkit/issues/1929)).
   - Remote Hub configuration (storage URI, storage key, and purge protection) is now displayed in the Basics tab when Remote Hub mode is selected, making the mutual exclusivity clear.
   - Data Explorer SKU and retention settings are now only visible when Azure Data Explorer mode is selected.
+  - Documented the `<ingestionId>__<originalFileName>.parquet` filename convention, full-folder replacement requirement, and manifest content rules for ingesting custom FOCUS datasets to prevent silent data loss ([#2096](https://github.com/microsoft/finops-toolkit/issues/2096)).
 - **Fixed**
   - Fixed Init-DataFactory deployment script failing when an Event Grid subscription is already provisioning by checking subscription status before attempting subscribe/unsubscribe and polling separately for completion ([#1996](https://github.com/microsoft/finops-toolkit/issues/1996)).
   - Added row count check in `msexports_ExecuteETL` pipeline to fix error when export files have no rows ([#1535](https://github.com/microsoft/finops-toolkit/issues/1535)).

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -3,7 +3,7 @@ title: FinOps toolkit changelog
 description: Review the latest features and enhancements in the FinOps toolkit, including updates to FinOps hubs, Power BI reports, and more.
 author: MSBrett
 ms.author: brettwil
-ms.date: 04/04/2026
+ms.date: 04/21/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/hubs/deploy.md
+++ b/docs-mslearn/toolkit/hubs/deploy.md
@@ -360,15 +360,13 @@ To ingest data from other data providers that support FOCUS, such as Amazon Web 
      - The pipeline derives the ingestion ID by splitting the file name on `__`. Every file that shares the same `ingestionId` is treated as part of the same run; extents from previous runs in the same folder are dropped once the new run succeeds.
    <!-- prettier-ignore-start -->
    > [!IMPORTANT]
-   > **Each run must rewrite the full contents of its folder path**
+   > **Each run must replace the full contents of its folder path**
    >
-   > The pre-ingest cleanup drops every extent tagged with the current folder path that doesn't share the run's `ingestionId`. Uploading only incremental rows into a folder that was already ingested results in silent data loss — only the new rows survive in Data Explorer.
+   > When re-ingesting into a folder that already contains data, you must both (1) include the complete dataset for the period in the new run (not just incremental rows), and (2) delete all `.parquet` files from previous runs before uploading the new ones. Otherwise, the pipeline processes old and new files together and each file's pre-ingest cleanup drops extents tagged with a different `ingestionId` — only the files sharing the last `ingestionId` processed survive in Data Explorer.
    >
    > If a provider emits nonoverlapping deltas, give each delta its own folder path using a `dd` or `dd/hh` subfolder as described above. Each folder is then independently replaced on its next run instead of being merged.
    >
-   > **Remove parquet files from previous runs before each upload**
-   >
-   > Before uploading a new run's files, delete every `.parquet` file already in the target folder. If files with a different `ingestionId` remain, the pipeline processes them alongside the new ones and each file's pre-ingest cleanup drops extents tagged with a different `ingestionId` — only the files sharing the last `ingestionId` processed survive in Data Explorer. The managed Cost Management export pipeline handles this cleanup automatically, but custom ingestion workflows must implement it themselves.
+   > The managed Cost Management export pipeline handles this cleanup automatically, but custom ingestion workflows must implement it themselves.
    <!-- prettier-ignore-end -->
    <!-- prettier-ignore-start -->
    > [!TIP]

--- a/docs-mslearn/toolkit/hubs/deploy.md
+++ b/docs-mslearn/toolkit/hubs/deploy.md
@@ -3,7 +3,7 @@ title: How to create and update FinOps hubs
 description: This tutorial helps you create a new or update an existing FinOps hubs instance in Azure or Microsoft Fabric.
 author: flanakin
 ms.author: micflan
-ms.date: 04/01/2026
+ms.date: 04/16/2026
 ms.topic: tutorial
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/hubs/deploy.md
+++ b/docs-mslearn/toolkit/hubs/deploy.md
@@ -365,6 +365,10 @@ To ingest data from other data providers that support FOCUS, such as Amazon Web 
    > The pre-ingest cleanup drops every extent tagged with the current folder path that doesn't share the run's `ingestionId`. Uploading only incremental rows into a folder that was already ingested results in silent data loss — only the new rows survive in Data Explorer.
    >
    > If a provider emits nonoverlapping deltas, give each delta its own folder path using a `dd` or `dd/hh` subfolder as described above. Each folder is then independently replaced on its next run instead of being merged.
+   >
+   > **Remove parquet files from previous runs before each upload**
+   >
+   > Before uploading a new run's files, delete every `.parquet` file already in the target folder. If files with a different `ingestionId` remain, the pipeline processes them alongside the new ones and each file's pre-ingest cleanup drops extents tagged with a different `ingestionId` — only the files sharing the last `ingestionId` processed survive in Data Explorer. The managed Cost Management export pipeline handles this cleanup automatically, but custom ingestion workflows must implement it themselves.
    <!-- prettier-ignore-end -->
    <!-- prettier-ignore-start -->
    > [!TIP]

--- a/docs-mslearn/toolkit/hubs/deploy.md
+++ b/docs-mslearn/toolkit/hubs/deploy.md
@@ -3,7 +3,7 @@ title: How to create and update FinOps hubs
 description: This tutorial helps you create a new or update an existing FinOps hubs instance in Azure or Microsoft Fabric.
 author: flanakin
 ms.author: micflan
-ms.date: 04/16/2026
+ms.date: 04/21/2026
 ms.topic: tutorial
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/hubs/deploy.md
+++ b/docs-mslearn/toolkit/hubs/deploy.md
@@ -354,9 +354,26 @@ To ingest data from other data providers that support FOCUS, such as Amazon Web 
      - `{scope}` represents a logical, consistent identifier for the dataset. This value can be any valid path using one or more nested folders.
    - If the provider generates nonoverlapping deltas in each dataset, add an extra folder for the day and/or hour (`dd` or `dd/hh`) between the month and scope folders.
      - The goal is to ensure that overriding datasets should consistently land in the same folder path so they're overwritten each time. Nonoverlapping datasets should be pushed to a new folder path.
-3. Create an empty `manifest.json` file in the same folder.
+   - Name every parquet file using the pattern `<ingestionId>__<originalFileName>.parquet` (two underscores separating the two parts).
+     - `ingestionId` identifies a single logical ingestion run and must be identical on all files produced by that run (for example a timestamp or GUID).
+     - `originalFileName` is any identifier unique within that run (for example a shard or partition number).
+     - The pipeline derives the ingestion ID by splitting the file name on `__`. Every file that shares the same `ingestionId` is treated as part of the same run; extents from previous runs in the same folder are dropped once the new run succeeds.
+   <!-- prettier-ignore-start -->
+   > [!IMPORTANT]
+   > **Each upload must contain the complete month**
+   >
+   > When new rows arrive for a month that was already ingested, you must rewrite the full month's data in the folder under a new `ingestionId`. The pre-ingest cleanup drops every extent in the folder that doesn't share the current run's `ingestionId`, so uploading only incremental deltas results in silent data loss — only the delta survives in Data Explorer.
+   <!-- prettier-ignore-end -->
+   <!-- prettier-ignore-start -->
+   > [!TIP]
+   > **Filter out empty parquet shards before upload**
+   >
+   > Tools that produce partitioned parquet output (for example BigQuery `EXPORT DATA` or Spark `write.parquet`) often emit header-only empty shards. Data Explorer rejects these with `BadRequest_NoRecordsOrWrongFormat`, and each failure is retried three times at 120-second intervals, adding several minutes of delay per empty file. Filter out shards that contain no rows before copying them to the **ingestion** container.
+   <!-- prettier-ignore-end -->
+3. Create a `manifest.json` file in the same folder. The file must contain at least `{}` — a zero-byte file is ignored by the storage event trigger (`ignoreEmptyBlobs: true`) and won't start ingestion.
    - Data Explorer ingestion is triggered when manifest.json files are added or updated.
-4. If there are any columns not covered in the current ingestion process, update the **Costs_raw** and **Costs_final_v1_0** tables, and **Costs_transform_v1_0**, **Costs_v1_0**, and **Costs** functions accordingly.
+   - The pipeline doesn't parse the manifest content, so any valid JSON is accepted. You can embed audit metadata such as the `ingestionId` or an export timestamp if useful.
+4. If there are any columns not covered in the current ingestion process, update the **Costs_raw** and **Costs_final_v1_2** tables, and **Costs_transform_v1_2**, **Costs_v1_2**, and **Costs** functions accordingly.
    - Submit a [feature request](https://aka.ms/ftk/ideas) to add new columns to the default ingestion code to ensure customizations don't block future upgrades.
 
 <br>

--- a/docs-mslearn/toolkit/hubs/deploy.md
+++ b/docs-mslearn/toolkit/hubs/deploy.md
@@ -360,9 +360,11 @@ To ingest data from other data providers that support FOCUS, such as Amazon Web 
      - The pipeline derives the ingestion ID by splitting the file name on `__`. Every file that shares the same `ingestionId` is treated as part of the same run; extents from previous runs in the same folder are dropped once the new run succeeds.
    <!-- prettier-ignore-start -->
    > [!IMPORTANT]
-   > **Each upload must contain the complete month**
+   > **Each run must rewrite the full contents of its folder path**
    >
-   > When new rows arrive for a month that was already ingested, you must rewrite the full month's data in the folder under a new `ingestionId`. The pre-ingest cleanup drops every extent in the folder that doesn't share the current run's `ingestionId`, so uploading only incremental deltas results in silent data loss — only the delta survives in Data Explorer.
+   > The pre-ingest cleanup drops every extent tagged with the current folder path that doesn't share the run's `ingestionId`. Uploading only incremental rows into a folder that was already ingested results in silent data loss — only the new rows survive in Data Explorer.
+   >
+   > If a provider emits nonoverlapping deltas, give each delta its own folder path using a `dd` or `dd/hh` subfolder as described above. Each folder is then independently replaced on its next run instead of being merged.
    <!-- prettier-ignore-end -->
    <!-- prettier-ignore-start -->
    > [!TIP]

--- a/docs-mslearn/toolkit/hubs/deploy.md
+++ b/docs-mslearn/toolkit/hubs/deploy.md
@@ -372,8 +372,8 @@ To ingest data from other data providers that support FOCUS, such as Amazon Web 
    >
    > Tools that produce partitioned parquet output (for example BigQuery `EXPORT DATA` or Spark `write.parquet`) often emit header-only empty shards. Data Explorer rejects these with `BadRequest_NoRecordsOrWrongFormat`, and each failure is retried three times at 120-second intervals, adding several minutes of delay per empty file. Filter out shards that contain no rows before copying them to the **ingestion** container.
    <!-- prettier-ignore-end -->
-3. Create a `manifest.json` file in the same folder. The file must contain at least `{}` — a zero-byte file is ignored by the storage event trigger (`ignoreEmptyBlobs: true`) and won't start ingestion.
-   - Data Explorer ingestion is triggered when manifest.json files are added or updated.
+3. Upload the `manifest.json` file **after** all parquet files have finished uploading. The file must contain at least `{}` — a zero-byte file is ignored by the storage event trigger (`ignoreEmptyBlobs: true`) and won't start ingestion.
+   - Data Explorer ingestion is triggered when manifest.json files are added or updated. The pipeline waits 60 seconds and then enumerates the folder; any parquet files that arrive after that enumeration are skipped by the current run.
    - The pipeline doesn't parse the manifest content, so any valid JSON is accepted. You can embed audit metadata such as the `ingestionId` or an export timestamp if useful.
 4. If there are any columns not covered in the current ingestion process, update the **Costs_raw** and **Costs_final_v1_2** tables, and **Costs_transform_v1_2**, **Costs_v1_2**, and **Costs** functions accordingly.
    - Submit a [feature request](https://aka.ms/ftk/ideas) to add new columns to the default ingestion code to ensure customizations don't block future upgrades.


### PR DESCRIPTION
## Summary

Closes #2096. Expands the **Ingest from other data sources** section of the Hub deploy tutorial with details required for the Data Explorer ingestion pipeline to work correctly. The existing text led integrators into silent data loss when uploading custom FOCUS datasets (e.g. from GCP or AWS).

Changes to [`docs-mslearn/toolkit/hubs/deploy.md`](/microsoft/finops-toolkit/blob/krummrol/docs-ingest-from-other-sources/docs-mslearn/toolkit/hubs/deploy.md):

- Document the `<ingestionId>__<originalFileName>.parquet` filename convention and explain how the pipeline derives `ingestionId` by splitting on `__` (see [`Analytics/app.bicep:1806-1810`](/microsoft/finops-toolkit/blob/dev/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/app.bicep#L1806-L1810)).
- Add an IMPORTANT callout that each upload must rewrite the full month — incremental deltas silently wipe existing extents because of the pre-ingest cleanup at [`Analytics/app.bicep:1352`](/microsoft/finops-toolkit/blob/dev/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/app.bicep#L1352).
- Add a TIP to filter empty parquet shards before upload (Data Explorer rejects them with `BadRequest_NoRecordsOrWrongFormat` and the pipeline retries 3× at 120s intervals, per `retry: 3, retryIntervalInSeconds: 120` on the Ingest Data activity).
- Correct the manifest instruction: the file must contain at minimum `{}` because the storage event trigger sets `ignoreEmptyBlobs: true` ([`fx/hub-eventTrigger.bicep:79`](/microsoft/finops-toolkit/blob/dev/src/templates/finops-hub/modules/fx/hub-eventTrigger.bicep#L79)) — a zero-byte file never triggers ingestion.
- Update table/function references in step 4 from `v1_0` to the current `v1_2` schema (confirmed against `HubSetup_Latest.kql`).

No code changes.

## Test plan

- [ ] Preview the rendered page locally (`docs-mslearn`) and confirm the IMPORTANT/TIP callouts render correctly under the numbered list item.
- [ ] Verify no broken links in the updated section via the existing doc-link test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)