### PR TITLE
Fix Power BI storage report Term parsing for P10Y / unknown values (#2106)

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -3,7 +3,7 @@ title: FinOps toolkit changelog
 description: Review the latest features and enhancements in the FinOps toolkit, including updates to FinOps hubs, Power BI reports, and more.
 author: MSBrett
 ms.author: brettwil
-ms.date: 04/24/2026
+ms.date: 04/27/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -25,6 +25,11 @@ This article summarizes the features and enhancements in each release of the Fin
 
 The following section lists features and enhancements that are currently in development.
 
+### [Power BI reports](power-bi/reports.md)
+
+- **Fixed**
+  - Fixed Power BI storage report refresh errors caused by unrecognized `Term` values like `P10Y` (10-year reservations) in pricesheet exports. The `Prices` and `ReservationRecommendations` queries now handle `P10Y` explicitly and fall back to a generic ISO-8601 `PnY`/`PnM` parser for any future term values, preventing row-level refresh errors ([#2106](https://github.com/microsoft/finops-toolkit/issues/2106)).
+
 ### [Optimization engine](optimization-engine/overview.md) v14
 
 - **Fixed**
@@ -76,11 +81,6 @@ _Released April 2026_
   - Added row count check in `msexports_ExecuteETL` pipeline to fix error when export files have no rows ([#1535](https://github.com/microsoft/finops-toolkit/issues/1535)).
   - Fixed Data Explorer dashboard cost totals and savings KPIs producing invalid sums in multi-billing-currency tenants by adding a Currency parameter that scopes all tile queries to a single currency, with a warning indicator when multiple currencies are present ([#2093](https://github.com/microsoft/finops-toolkit/issues/2093)).
   - Fixed hub deployment failure in US Government cloud regions caused by missing region-to-time-zone mappings and an invalid default value for Data Factory schedule triggers ([#2087](https://github.com/microsoft/finops-toolkit/issues/2087)).
-
-### [Power BI reports](power-bi/reports.md) v14
-
-- **Fixed**
-  - Fixed Power BI storage report refresh errors caused by unrecognized `Term` values like `P10Y` (10-year reservations) in pricesheet exports. The `Prices` and `ReservationRecommendations` queries now handle `P10Y` explicitly and fall back to a generic ISO-8601 `PnY`/`PnM` parser for any future term values, preventing row-level refresh errors ([#2106](https://github.com/microsoft/finops-toolkit/issues/2106)).
 
 ### [FinOps workbooks](workbooks/finops-workbooks-overview.md) v14
 

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -77,6 +77,11 @@ _Released April 2026_
   - Fixed Data Explorer dashboard cost totals and savings KPIs producing invalid sums in multi-billing-currency tenants by adding a Currency parameter that scopes all tile queries to a single currency, with a warning indicator when multiple currencies are present ([#2093](https://github.com/microsoft/finops-toolkit/issues/2093)).
   - Fixed hub deployment failure in US Government cloud regions caused by missing region-to-time-zone mappings and an invalid default value for Data Factory schedule triggers ([#2087](https://github.com/microsoft/finops-toolkit/issues/2087)).
 
+### [Power BI reports](power-bi/reports.md) v14
+
+- **Fixed**
+  - Fixed Power BI storage report refresh errors caused by unrecognized `Term` values like `P10Y` (10-year reservations) in pricesheet exports. The `Prices` and `ReservationRecommendations` queries now handle `P10Y` explicitly and fall back to a generic ISO-8601 `PnY`/`PnM` parser for any future term values, preventing row-level refresh errors ([#2106](https://github.com/microsoft/finops-toolkit/issues/2106)).
+
 ### [FinOps workbooks](workbooks/finops-workbooks-overview.md) v14
 
 - **Fixed**

--- a/src/power-bi/storage/Shared.Dataset/definition/tables/Prices.tmdl
+++ b/src/power-bi/storage/Shared.Dataset/definition/tables/Prices.tmdl
@@ -325,9 +325,18 @@ table Prices
 				    HackToWorkAroundDateParsingBug = Table.Sort(RawData,{{"EffectiveStartDate", Order.Ascending}}),
 				
 				    FixTypes = Table.TransformColumnTypes(
-				        Table.ReplaceValue(HackToWorkAroundDateParsingBug, 
-				            // Fix inconsistent Microsoft term values
-				            each [Term], each if [Term] = "P1M" then 1 else if [Term] = "P1Y" then 12 else if [Term] = "P3Y" then 36 else if [Term] = "P5Y" then 60 else [Term], Replacer.ReplaceValue, {"Term"}),
+				        Table.ReplaceValue(HackToWorkAroundDateParsingBug,
+				            // Fix inconsistent Microsoft term values. Known mappings + ISO-8601 PnY/PnM fallback for future values (e.g. P10Y).
+				            each [Term], each
+				                if [Term] = "P1M" then 1
+				                else if [Term] = "P1Y" then 12
+				                else if [Term] = "P3Y" then 36
+				                else if [Term] = "P5Y" then 60
+				                else if [Term] = "P10Y" then 120
+				                else if [Term] <> null and Text.StartsWith([Term], "P") and Text.EndsWith([Term], "Y") then try Number.FromText(Text.Range([Term], 1, Text.Length([Term]) - 2)) * 12 otherwise null
+				                else if [Term] <> null and Text.StartsWith([Term], "P") and Text.EndsWith([Term], "M") then try Number.FromText(Text.Range([Term], 1, Text.Length([Term]) - 2)) otherwise null
+				                else null,
+				            Replacer.ReplaceValue, {"Term"}),
 				        {
 				            // Date columns
 				            {"EffectiveEndDate",   type datetime},

--- a/src/power-bi/storage/Shared.Dataset/definition/tables/ReservationRecommendations.tmdl
+++ b/src/power-bi/storage/Shared.Dataset/definition/tables/ReservationRecommendations.tmdl
@@ -277,8 +277,17 @@ table ReservationRecommendations
 				                "SkuName", type text),
 				            // Normalize frequency
 				            each [LookBackPeriod], each Text.Replace(Text.Replace([LookBackPeriod], "Last", ""), "Days", " Days"), Replacer.ReplaceValue, {"LookBackPeriod"}),
-				            // Fix inconsistent Microsoft term values
-				            each [Term], each if [Term] = "P1M" then 1 else if [Term] = "P1Y" then 12 else if [Term] = "P3Y" then 36 else if [Term] = "P5Y" then 60 else Number.FromText([Term]), Replacer.ReplaceValue, {"Term"}),
+				            // Fix inconsistent Microsoft term values. Known mappings + ISO-8601 PnY/PnM fallback for future values (e.g. P10Y).
+				            each [Term], each
+				                if [Term] = "P1M" then 1
+				                else if [Term] = "P1Y" then 12
+				                else if [Term] = "P3Y" then 36
+				                else if [Term] = "P5Y" then 60
+				                else if [Term] = "P10Y" then 120
+				                else if [Term] <> null and Text.StartsWith([Term], "P") and Text.EndsWith([Term], "Y") then try Number.FromText(Text.Range([Term], 1, Text.Length([Term]) - 2)) * 12 otherwise null
+				                else if [Term] <> null and Text.StartsWith([Term], "P") and Text.EndsWith([Term], "M") then try Number.FromText(Text.Range([Term], 1, Text.Length([Term]) - 2)) otherwise null
+				                else null,
+				            Replacer.ReplaceValue, {"Term"}),
 				        {
 				            // Dates
 				            {"FirstUsageDate",                 type datetime},

--- a/src/power-bi/storage/Shared.Dataset/definition/tables/ReservationTransactions.tmdl
+++ b/src/power-bi/storage/Shared.Dataset/definition/tables/ReservationTransactions.tmdl
@@ -289,8 +289,17 @@ table ReservationTransactions
 				            each [BillingFrequency], each if [BillingFrequency] = "OneTime" then "One-Time" else [BillingFrequency], Replacer.ReplaceValue, {"BillingFrequency"}),
 				            // Use fully-qulified resrvation ID
 				            each [BillingMonth], each DateTime.From(Text.Range([BillingMonth], 0, 4) & "-" & Text.Range([BillingMonth], 4, 2) & "-" & Text.Range([BillingMonth], 6, 2)), Replacer.ReplaceValue, {"BillingMonth"}),
-				            // Fix inconsistent Microsoft term values
-				            each [Term], each if [Term] = "P1M" then 1 else if [Term] = "P1Y" then 12 else if [Term] = "P3Y" then 36 else if [Term] = "P5Y" then 60 else Number.FromText([Term]), Replacer.ReplaceValue, {"Term"}),
+				            // Fix inconsistent Microsoft term values. Known mappings + ISO-8601 PnY/PnM fallback for future values (e.g. P10Y).
+				            each [Term], each
+				                if [Term] = "P1M" then 1
+				                else if [Term] = "P1Y" then 12
+				                else if [Term] = "P3Y" then 36
+				                else if [Term] = "P5Y" then 60
+				                else if [Term] = "P10Y" then 120
+				                else if [Term] <> null and Text.StartsWith([Term], "P") and Text.EndsWith([Term], "Y") then try Number.FromText(Text.Range([Term], 1, Text.Length([Term]) - 2)) * 12 otherwise null
+				                else if [Term] <> null and Text.StartsWith([Term], "P") and Text.EndsWith([Term], "M") then try Number.FromText(Text.Range([Term], 1, Text.Length([Term]) - 2)) otherwise null
+				                else null,
+				            Replacer.ReplaceValue, {"Term"}),
 				        {
 				            // Dates
 				            {"BillingMonth",         type datetime},


### PR DESCRIPTION
## 🛠️ Description

Fixes #2106. Microsoft has started shipping `P10Y` (10-year) values in the EA pricesheet `Term` column. Note: `P10Y` is **not** documented in the EA/MCA pricesheet schema, the Azure reservation SDKs (`KnownReservationTerm`, `KnownTerm`, `KnownSavingsPlanTerm` all only list P1Y/P3Y/P5Y), or the Azure CLI — but Microsoft is shipping these values anyway. A customer reported 38,749 row-level refresh errors traced to rows with `x_SkuTerm = P10Y` in their pricesheet exports.

The Power BI storage reports' M code only mapped `P1M`/`P1Y`/`P3Y`/`P5Y` and fell back to the raw text for anything else, which then failed the `type number` coercion and caused row-level errors during refresh. The dataset would still load (errors are non-fatal), but tens of thousands of rows were dropped.

## Changes

Replace the hard-coded mapping in both `Prices` and `ReservationRecommendations` queries (storage dataset) with:
- Explicit lookups for `P1M`/`P1Y`/`P3Y`/`P5Y`/`P10Y`
- ISO-8601 `PnY` / `PnM` fallback parser to handle any future term values gracefully (e.g. P7Y, P15Y)
- `null` fallback for genuinely unparseable values (no more refresh crashes)

This means future surprises from Microsoft will load with correct numeric values rather than breaking the refresh.

**Files modified:**
- `src/power-bi/storage/Shared.Dataset/definition/tables/Prices.tmdl`
- `src/power-bi/storage/Shared.Dataset/definition/tables/ReservationRecommendations.tmdl`

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests