### PR TITLE
fix(docs): Rewrite Copilot Studio doc for v14 partner-center publish

### DIFF
--- a/docs-mslearn/toolkit/hubs/configure-ai-copilot-studio.md
+++ b/docs-mslearn/toolkit/hubs/configure-ai-copilot-studio.md
@@ -1,7 +1,7 @@
 ---
 title: Configure a FinOps hub agent in Microsoft Copilot Studio
 description: Learn how to create a FinOps hub AI agent in Microsoft Copilot Studio with the Kusto Query MCP Server.
-author: MSBrett
+author: RolandKrummenacher
 ms.author: brettwil
 ms.date: 05/11/2026
 ms.topic: how-to

--- a/docs-mslearn/toolkit/hubs/configure-ai-copilot-studio.md
+++ b/docs-mslearn/toolkit/hubs/configure-ai-copilot-studio.md
@@ -13,37 +13,43 @@ ms.reviewer: brettwil
 
 # Configure a FinOps hub agent in Microsoft Copilot Studio
 
-[Microsoft Copilot Studio](https://copilotstudio.microsoft.com) lets you create AI agents that integrate with Microsoft 365 Copilot. This article describes how to create a FinOps hub agent in Copilot Studio that connects to your FinOps hub database via the Kusto Query MCP Server. The agent answers cost questions by executing KQL queries.
+This article describes how to configure a [Microsoft Copilot Studio](https://copilotstudio.microsoft.com) agent that connects to your FinOps hub Data Explorer database and answers cost questions by executing KQL queries. The agent uses the Kusto Query MCP Server to run queries and knowledge files from the FinOps toolkit to construct accurate KQL.
 
 <br>
 
 ## Prerequisites
 
-- [Deployed a FinOps hub instance](finops-hubs-overview.md#create-a-new-hub) with Data Explorer running **FinOps hubs v12 or later**. The agent instructions use the `Costs_v1_2()` function, which is not available in earlier versions. [Learn how to upgrade](upgrade.md).
-- [Configured scopes](configure-scopes.md) and ingested data successfully.
+Before you start, make sure you have the following:
+
+- A [FinOps hub instance](finops-hubs-overview.md#create-a-new-hub) with Data Explorer running **FinOps hubs v12 or later**. The agent instructions use the `Costs_v1_2()` function, which isn't available in earlier versions. [Learn how to upgrade](upgrade.md).
+- [Configured scopes](configure-scopes.md) with data ingested successfully.
 - Database viewer or greater access to the Data Explorer **Hub** database. [Learn more](/kusto/management/manage-database-security-roles#database-level-security-roles).
-- Access to [Microsoft Copilot Studio](https://copilotstudio.microsoft.com).
-- A [Microsoft Copilot Studio license](/microsoft-copilot-studio/billing-licensing) or Microsoft 365 Copilot user license.
+- A Copilot Studio license or Microsoft 365 Copilot user license. For licensing details, see [Copilot Studio licensing](/microsoft-copilot-studio/billing-licensing).
+
+If you're new to Copilot Studio, see [Quickstart: Create and deploy an agent](/microsoft-copilot-studio/fundamentals-get-started) to learn the basics of agent creation before continuing.
 
 <br>
 
-## Create the agent
+## Create and configure the agent
 
-1. Open [Microsoft Copilot Studio](https://copilotstudio.microsoft.com).
-2. Select **Agents** in the left navigation, then select **+ Create blank agent**. Wait for the agent to be provisioned.
-3. On the **Overview** page, in the **Details** section, select **Edit**. Set the name to **FinOps Hub Agent** (or your preferred name) and set the description:
+[Create a blank agent](/microsoft-copilot-studio/fundamentals-get-started) in Copilot Studio, then configure it with the following FinOps hub settings.
 
-   > FinOps Hub Agent provides governed, real time insights from your FinOps Toolkit Hub database. It translates natural language questions into validated KQL queries and delivers structured analysis on cloud spend, commitments, savings plans, anomalies, and optimization opportunities.
+### Agent details
 
-4. Under **Select your agent's model**, choose a model with deep reasoning capabilities. The agent instructions require multistep reasoning for KQL query generation and structured report formatting.
+Set the agent name to **FinOps Hub Agent** (or your preferred name) and use the following description:
 
-   For available models, regional availability, and data residency considerations, see [Select a primary AI model for your agent](/microsoft-copilot-studio/authoring-select-agent-model). External models require tenant administrator approval; see [Choose an external model](/microsoft-copilot-studio/authoring-select-external-response-model).
+> FinOps Hub Agent provides governed, real-time insights from your FinOps Toolkit Hub database. It translates natural language questions into validated KQL queries and delivers structured analysis on cloud spend, commitments, savings plans, anomalies, and optimization opportunities.
 
-   > [!NOTE]
-   > The agent instructions in this guide were tested with a deep reasoning model. General-category models might produce lower-quality results for complex KQL queries.
+### Model selection
 
-5. Download the [Copilot Studio instructions for FinOps hubs](https://github.com/microsoft/finops-toolkit/releases/latest/download/finops-hub-copilot-studio.zip) and extract the contents.
-6. Open the `agent-instructions.md` file and update the **Environment** section with your cluster URI:
+The agent instructions require a model with deep reasoning capabilities for multistep KQL generation and structured report formatting. General-category models might produce lower-quality results for complex queries.
+
+For available models, regional availability, and data residency considerations, see [Select a primary AI model for your agent](/microsoft-copilot-studio/authoring-select-agent-model). If you want to use an external model, your tenant administrator must enable it first; see [Choose an external model](/microsoft-copilot-studio/authoring-select-external-response-model).
+
+### Agent instructions
+
+1. Download the [Copilot Studio instructions for FinOps hubs](https://github.com/microsoft/finops-toolkit/releases/latest/download/finops-hub-copilot-studio.zip) and extract the contents.
+2. Open `agent-instructions.md` and update the **Environment** section with your cluster URI:
 
    ```text
    Cluster URI: <your-cluster>.kusto.windows.net
@@ -53,112 +59,79 @@ ms.reviewer: brettwil
    > [!NOTE]
    > Don't include `https://` in the cluster URI. Copilot Studio removes HTTP links from the Instructions field.
 
-7. In the **Instructions** section, select **Edit**, paste the full content of `agent-instructions.md`, and select **Save**.
+3. Paste the full content of `agent-instructions.md` into the agent's **Instructions** field and save.
 
 <br>
 
 ## Add tools
 
-The agent requires the Kusto Query MCP Server to execute KQL queries against your FinOps hub database. You can optionally add the Microsoft Learn Docs MCP to look up FinOps concepts and Azure documentation.
+The agent needs the following MCP tools to function. For general steps on adding MCP tools to an agent, see [Add tools from an MCP server](/microsoft-copilot-studio/copilot-ai-plugins).
 
-### Add the Kusto Query MCP Server
+### Kusto Query MCP Server (required)
 
-1. In your agent, select the **Tools** tab.
-2. Select **+ Add a tool**.
-3. In the **Add tool** dialog, search for **Kusto Query MCP Server**.
-4. Select the **Model Context Protocol** filter to narrow the results.
-5. Select **Kusto Query MCP Server** (by Azure Data Explorer).
-6. Expand **Additional details** and configure the following settings:
-   - **Ask the end user before running**: No
-   - **Credentials to use**: End user credentials
-7. Ensure the **Enabled** toggle in the top right is on, then select **Save**.
+Add **Kusto Query MCP Server** (by Azure Data Explorer) with these settings:
 
-### Add Microsoft Learn Docs MCP (optional)
+- **Ask the end user before running**: No
+- **Credentials to use**: End user credentials
 
-1. Select **+ Add a tool**.
-2. Search for **Microsoft Learn Docs MCP Server** and select the **Model Context Protocol** filter.
-3. Select **Microsoft Learn Docs MCP Server** (by Microsoft Learn Docs MCP) and enable it.
+This tool lets the agent execute KQL queries against your hub's Data Explorer database. The agent uses end-user credentials so query results respect each user's database permissions.
 
-This tool allows the agent to look up FinOps concepts, FOCUS specification details, and Azure service documentation when answering questions.
+### Microsoft Learn Docs MCP Server (optional)
 
-### Verify connections
+Add **Microsoft Learn Docs MCP Server** (by Microsoft Learn Docs MCP) to let the agent look up FinOps concepts, FOCUS specification details, and Azure service documentation when answering questions.
 
-1. Select **Settings** in the top right corner of the agent.
-2. Select **Connection Settings** in the left navigation.
-3. Verify that both **Azure Data Explorer** and **Microsoft Learn Docs MCP** (if added) show a **Connected** status. If a connection shows as **Not Connected**, select **Manage** to authenticate.
+After adding tools, verify that each shows a **Connected** status in your agent's connection settings. If a connection shows as **Not Connected**, select **Manage** to authenticate.
 
 <br>
 
 ## Add knowledge files
 
-Knowledge files give the agent reference information for constructing accurate KQL queries. The agent instructions are designed to use these files as query-building references, not as data sources.
+The agent instructions reference knowledge files for constructing accurate KQL queries. These files are query-building references, not data sources. For general steps on adding knowledge to an agent, see [Add knowledge sources](/microsoft-copilot-studio/knowledge-add-existing-copilot).
 
-1. In your agent, select the **Knowledge** tab.
-2. Select **+ Add knowledge**.
-3. In the **Add knowledge** dialog, drag and drop or browse to upload each file from the extracted `knowledge/` folder:
+Upload each file from the extracted `knowledge/` folder and set the **Description** field for each file as shown:
 
-   | File | Description |
-   |------|-------------|
-   | `schema-reference.md` | Column reference for `Costs_v1_2()` including names, data types, usage notes, and edge cases. Use to look up correct column names before writing queries. |
-   | `query-catalog.md` | Ready-to-use KQL query templates for cost breakdowns, monthly trends, anomaly detection, forecasting, savings summary, and commitment utilization. |
-   | `weekly-report-guide.md` | Step-by-step workflow for producing structured weekly cost anomaly reports with seven KQL queries, post-processing rules, and the final report structure. |
+| File | Description |
+|------|-------------|
+| `schema-reference.md` | Column reference for `Costs_v1_2()` including names, data types, usage notes, and edge cases. Use to look up correct column names before writing queries. |
+| `query-catalog.md` | Ready-to-use KQL query templates for cost breakdowns, monthly trends, anomaly detection, forecasting, savings summary, and commitment utilization. |
+| `weekly-report-guide.md` | Step-by-step workflow for producing structured weekly cost anomaly reports with seven KQL queries, post-processing rules, and the final report structure. |
 
-4. For each file, select it to open the details and enter the description from the table above in the **Description** field. These descriptions help the agent decide when to retrieve each file.
-5. Wait for all files to show a **Ready** status on the Knowledge tab. Processing may take a few minutes.
+The descriptions help the agent decide when to retrieve each file. Wait for all files to show a **Ready** status before testing.
 
 <br>
 
 ## Test your agent
 
-After configuration, test your agent in the **Test** panel:
+Test the agent in the **Test** panel to verify it connects to your hub data correctly. The agent should detect your billing currency and ask you to select an analysis scope. Try these sample prompts:
 
-1. Start a new test session.
-2. The agent should automatically detect your billing currency and ask you to select an analysis scope.
-3. Try these sample prompts:
+```text
+What are my top 5 subscriptions by cost?
+```
 
-   ```text
-   What are my top 5 subscriptions by cost?
-   ```
+```text
+Create a week over week summary
+```
 
-   ```text
-   Create a week over week summary
-   ```
+```text
+Are there any unusual spikes in cost over the last 3 months?
+```
 
-   ```text
-   Are there any unusual spikes in cost over the last 3 months?
-   ```
+```text
+What was my savings rate last month?
+```
 
-   ```text
-   What was my savings rate last month?
-   ```
+Verify that the agent:
 
-4. Verify that the agent:
-   - Executes KQL queries (not just quoting from knowledge files).
-   - Presents results as formatted tables.
-   - Shows the KQL query in a separate code block. Review the query to verify correct filters, time ranges, and aggregation logic.
-   - Includes confidence level, time range, and scope.
+- Executes KQL queries against your hub database, not just quoting from knowledge files.
+- Presents results as formatted tables.
+- Shows the KQL query in a separate code block. Review the query to verify correct filters, time ranges, and aggregation logic.
+- Includes confidence level, time range, and scope in the response.
 
 <br>
 
 ## Publish your agent
 
-Once testing is complete, publish your agent to make it available to your team:
-
-1. Select **Publish** in the top right corner.
-2. Choose your preferred channel (Microsoft Teams, Microsoft 365 Copilot, or other supported channels).
-
-For details about publishing and channel configuration, see [Publish your agent](/microsoft-copilot-studio/publication-fundamentals-publish-channels).
-
-<br>
-
-## Pricing and licensing
-
-There are two licensing paths for using Copilot Studio agents:
-
-- **Microsoft 365 Copilot users** — Interactive, employee-facing usage of Copilot Studio agents is included at no extra charge, subject to fair usage limits. If your team already has Microsoft 365 Copilot licenses, you can get started without additional purchases. Note that scheduled actions and agent flows are not included and consume Copilot Credits separately.
-- **Standalone Copilot Studio license** — Uses a consumption-based billing model measured in Copilot Credits. For details on credit rates and capacity options, see [Copilot Studio billing rates and management](/microsoft-copilot-studio/requirements-messages-management#copilot-credits-billing-rates).
-
-For full licensing details, see [Copilot Studio licensing](/microsoft-copilot-studio/billing-licensing).
+After testing, publish your agent and configure channels to make it available to your team. For details, see [Publish your agent](/microsoft-copilot-studio/publication-fundamentals-publish-channels).
 
 <br>
 
@@ -188,9 +161,12 @@ Related FinOps hubs articles:
 - [FinOps hubs overview](finops-hubs-overview.md)
 - [Data model](data-model.md)
 
-Related products:
+Related Copilot Studio articles:
 
-- [Microsoft Copilot Studio](/microsoft-copilot-studio/fundamentals-what-is-copilot-studio)
-- [Azure Data Explorer](/azure/data-explorer/)
+- [Quickstart: Create and deploy an agent](/microsoft-copilot-studio/fundamentals-get-started)
+- [Select a primary AI model for your agent](/microsoft-copilot-studio/authoring-select-agent-model)
+- [Add tools from an MCP server](/microsoft-copilot-studio/copilot-ai-plugins)
+- [Add knowledge sources](/microsoft-copilot-studio/knowledge-add-existing-copilot)
+- [Publish your agent](/microsoft-copilot-studio/publication-fundamentals-publish-channels)
 
 <br>

--- a/docs-mslearn/toolkit/hubs/configure-ai-copilot-studio.md
+++ b/docs-mslearn/toolkit/hubs/configure-ai-copilot-studio.md
@@ -1,19 +1,19 @@
 ---
 title: Configure a FinOps hub agent in Microsoft Copilot Studio
 description: Learn how to create a FinOps hub AI agent in Microsoft Copilot Studio with the Kusto Query MCP Server.
-author: rkrummenacher
-ms.author: rkrummenacher
-ms.date: 04/02/2026
+author: MSBrett
+ms.author: brettwil
+ms.date: 05/11/2026
 ms.topic: how-to
 ms.service: finops
 ms.subservice: finops-toolkit
-ms.reviewer: micflan
+ms.reviewer: brettwil
 # customer intent: As a FinOps hub admin, I want to create a Copilot Studio agent that can query my FinOps hub data so that my team can ask cost questions in natural language.
 ---
 
 # Configure a FinOps hub agent in Microsoft Copilot Studio
 
-[Microsoft Copilot Studio](https://copilotstudio.microsoft.com) enables you to create AI agents that integrate with Microsoft 365 Copilot. This article describes how to create a FinOps hub agent in Copilot Studio that connects to your FinOps hub database via the Kusto Query MCP Server and answers cost questions by executing KQL queries.
+[Microsoft Copilot Studio](https://copilotstudio.microsoft.com) lets you create AI agents that integrate with Microsoft 365 Copilot. This article describes how to create a FinOps hub agent in Copilot Studio that connects to your FinOps hub database via the Kusto Query MCP Server. The agent answers cost questions by executing KQL queries.
 
 <br>
 
@@ -35,10 +35,12 @@ ms.reviewer: micflan
 
    > FinOps Hub Agent provides governed, real time insights from your FinOps Toolkit Hub database. It translates natural language questions into validated KQL queries and delivers structured analysis on cloud spend, commitments, savings plans, anomalies, and optimization opportunities.
 
-4. Under **Select your agent's model**, select **Claude Opus 4.6** or later.
+4. Under **Select your agent's model**, choose a model with deep reasoning capabilities. The agent instructions require multistep reasoning for KQL query generation and structured report formatting.
+
+   For available models, regional availability, and data residency considerations, see [Select a primary AI model for your agent](/microsoft-copilot-studio/authoring-select-agent-model). External models require tenant administrator approval; see [Choose an external model](/microsoft-copilot-studio/authoring-select-external-response-model).
 
    > [!NOTE]
-   > The agent instructions have been tested and validated with **Claude Opus 4.6**. Other models may produce lower-quality results, especially for complex KQL generation and structured report formatting.
+   > The agent instructions in this guide were tested with a deep reasoning model. General-category models might produce lower-quality results for complex KQL queries.
 
 5. Download the [Copilot Studio instructions for FinOps hubs](https://github.com/microsoft/finops-toolkit/releases/latest/download/finops-hub-copilot-studio.zip) and extract the contents.
 6. Open the `agent-instructions.md` file and update the **Environment** section with your cluster URI:
@@ -49,7 +51,7 @@ ms.reviewer: micflan
    ```
 
    > [!NOTE]
-   > Do not include `https://` in the cluster URI. Copilot Studio strips HTTP links from the Instructions field.
+   > Don't include `https://` in the cluster URI. Copilot Studio removes HTTP links from the Instructions field.
 
 7. In the **Instructions** section, select **Edit**, paste the full content of `agent-instructions.md`, and select **Save**.
 
@@ -97,9 +99,9 @@ Knowledge files give the agent reference information for constructing accurate K
 
    | File | Description |
    |------|-------------|
-   | `schema-reference.md` | Column reference for building KQL queries against Costs_v1_2(). Contains all column names, data types, usage notes, and edge cases like blank meter categories and BilledCost vs EffectiveCost divergence. Use to look up correct column names before writing queries. |
-   | `query-catalog.md` | Ready-to-use KQL query templates for FinOps analysis. Covers cost breakdowns by subscription/service/region, monthly trends, anomaly detection, forecasting, savings summary, commitment utilization, and reservation recommendations. Adapt these patterns to answer cost questions. |
-   | `weekly-report-guide.md` | Step-by-step workflow for producing structured weekly cost anomaly reports. Contains 7 KQL queries (totals, category summary, resource increases/decreases, commitment coverage drops, marketplace), post-processing rules for grouping and severity classification, and the final report structure. |
+   | `schema-reference.md` | Column reference for `Costs_v1_2()` including names, data types, usage notes, and edge cases. Use to look up correct column names before writing queries. |
+   | `query-catalog.md` | Ready-to-use KQL query templates for cost breakdowns, monthly trends, anomaly detection, forecasting, savings summary, and commitment utilization. |
+   | `weekly-report-guide.md` | Step-by-step workflow for producing structured weekly cost anomaly reports with seven KQL queries, post-processing rules, and the final report structure. |
 
 4. For each file, select it to open the details and enter the description from the table above in the **Description** field. These descriptions help the agent decide when to retrieve each file.
 5. Wait for all files to show a **Ready** status on the Knowledge tab. Processing may take a few minutes.


### PR DESCRIPTION
Rewrites the Copilot Studio agent configuration doc to fix blocking partner-center validation issues, reduce maintenance surface, and restore correct author attribution before the v14 docs publish.

## Changes

### Commit 1: Fix metadata and model guidance

- **Metadata**: Fixed invalid `author: rkrummenacher` (lowercase, doesn't exist on GitHub) and `ms.author: rkrummenacher` (not a valid Microsoft alias). These blocked [partner-center build validation](https://github.com/MicrosoftDocs/partner-center-pr/pull/12047#issuecomment-4421936929).
- **Model guidance**: Replaced hardcoded Claude Opus 4.6 recommendation with a link to the [canonical model selection docs](https://learn.microsoft.com/microsoft-copilot-studio/authoring-select-agent-model). Notes the deep reasoning requirement without naming specific models, so the doc doesn't go stale when models are revised.
- **Voice**: Microsoft style guide fixes (contractions, sentence splitting, tighter knowledge file descriptions)

### Commit 2: Offload generic procedures to canonical docs

Restructured the doc to focus on FinOps-hub-specific configuration and link to canonical Copilot Studio docs for generic procedures that go stale with product UI changes.

**Offloaded to canonical docs (no longer our maintenance):**
- Agent creation steps → [Quickstart: Create and deploy an agent](https://learn.microsoft.com/microsoft-copilot-studio/fundamentals-get-started)
- MCP tool add flow → [Add tools from an MCP server](https://learn.microsoft.com/microsoft-copilot-studio/copilot-ai-plugins)
- Knowledge upload steps → [Add knowledge sources](https://learn.microsoft.com/microsoft-copilot-studio/knowledge-add-existing-copilot)
- Licensing details → [Copilot Studio licensing](https://learn.microsoft.com/microsoft-copilot-studio/billing-licensing)
- Publishing steps → [Publish your agent](https://learn.microsoft.com/microsoft-copilot-studio/publication-fundamentals-publish-channels)

**Kept (FinOps-specific content):**
- Hub prerequisites (v12+, scopes, Kusto viewer access)
- Agent name, description, and deep-reasoning model requirement
- Instructions zip download and cluster URI configuration
- Which MCP tools to add and their specific settings (no user prompt, end user creds)
- Knowledge file table with descriptions
- Test prompts and verification criteria

### Commit 3: Restore correct author attribution

- **`author: RolandKrummenacher`** — correct case-sensitive GitHub ID for [Roland Krummenacher](https://github.com/RolandKrummenacher), original author of this doc via [PR #2075](https://github.com/microsoft/finops-toolkit/pull/2075). The previous `rkrummenacher` was an incorrect lowercase variant that doesn't exist on GitHub.
- **`ms.author: brettwil`** — Microsoft contact (Roland is an external contributor without a Microsoft alias).

## Why

The partner-center v14 docs PR ([MicrosoftDocs/partner-center-pr#12047](https://github.com/MicrosoftDocs/partner-center-pr/pull/12047)) flagged `rkrummenacher` as an invalid author/alias (blocking). The doc also contained ~40% generic Copilot Studio UI procedures that go stale when the product team updates their UI — including MCP tool flows that are still in preview.

## Scope

1 file: `docs-mslearn/toolkit/hubs/configure-ai-copilot-studio.md` (197 → 172 lines)