### PR TITLE
docs-mslearn: remove broken external links and add DocsLinks guardrails

### DIFF
--- a/docs-mslearn/best-practices/storage.md
+++ b/docs-mslearn/best-practices/storage.md
@@ -3,7 +3,7 @@ title: FinOps best practices for Storage
 description: This article outlines proven FinOps practices for storage services, focusing on cost optimization, efficiency improvements, and resource insights.
 author: flanakin
 ms.author: micflan
-ms.date: 04/01/2026
+ms.date: 05/12/2026
 ms.topic: concept-article
 ms.service: finops
 ms.subservice: finops-learning-resources
@@ -76,7 +76,6 @@ Azure managed disks are block-level storage volumes that are managed by Azure an
 
 Related resources:
 
-- [Managed disks product page](https://azure.microsoft.com/products/managed-disks)
 - [Managed disks pricing](https://azure.microsoft.com/pricing/details/managed-disks)
 - [Managed disks documentation](/azure/virtual-machines/managed-disks-overview)
 

--- a/docs-mslearn/framework/manage/onboarding.md
+++ b/docs-mslearn/framework/manage/onboarding.md
@@ -73,7 +73,7 @@ Document your onboarding process. Using existing tools and processes where avail
 
 ## Learn more at the FinOps Foundation
 
-This capability is a part of the FinOps Framework by the FinOps Foundation, a non-profit organization dedicated to advancing cloud cost management and optimization. For more information about FinOps, including useful playbooks, training and certification programs, and more, see the Onboarding workloads capability article in the FinOps Framework documentation.
+This capability is a part of the FinOps Framework by the FinOps Foundation, a non-profit organization dedicated to advancing cloud cost management and optimization. For more information about FinOps, including useful playbooks, training and certification programs, and more, refer to the FinOps Framework documentation.
 
 You can also find related videos on the FinOps Foundation YouTube channel:
 

--- a/docs-mslearn/framework/manage/onboarding.md
+++ b/docs-mslearn/framework/manage/onboarding.md
@@ -3,7 +3,7 @@ title: Onboarding workloads
 description: This article helps you understand the onboarding workloads capability within the FinOps Framework and how to implement that in the Microsoft Cloud.
 author: flanakin
 ms.author: micflan
-ms.date: 04/01/2026
+ms.date: 05/12/2026
 ms.topic: concept-article
 ms.service: finops
 ms.subservice: finops-learning-resources
@@ -73,7 +73,7 @@ Document your onboarding process. Using existing tools and processes where avail
 
 ## Learn more at the FinOps Foundation
 
-This capability is a part of the FinOps Framework by the FinOps Foundation, a non-profit organization dedicated to advancing cloud cost management and optimization. For more information about FinOps, including useful playbooks, training and certification programs, and more, see the [Onboarding workloads capability](https://www.finops.org/framework/capabilities/onboarding-workloads/) article in the FinOps Framework documentation.
+This capability is a part of the FinOps Framework by the FinOps Foundation, a non-profit organization dedicated to advancing cloud cost management and optimization. For more information about FinOps, including useful playbooks, training and certification programs, and more, see the Onboarding workloads capability article in the FinOps Framework documentation.
 
 You can also find related videos on the FinOps Foundation YouTube channel:
 

--- a/docs-mslearn/framework/manage/onboarding.md
+++ b/docs-mslearn/framework/manage/onboarding.md
@@ -73,7 +73,7 @@ Document your onboarding process. Using existing tools and processes where avail
 
 ## Learn more at the FinOps Foundation
 
-This capability is a part of the FinOps Framework by the FinOps Foundation, a non-profit organization dedicated to advancing cloud cost management and optimization. For more information about FinOps, including useful playbooks, training and certification programs, and more, refer to the FinOps Framework documentation.
+This capability is a part of the FinOps Framework by the FinOps Foundation, a non-profit organization dedicated to advancing cloud cost management and optimization. For more information about FinOps, including useful playbooks, training and certification programs, and more, refer to the [FinOps Framework documentation](https://www.finops.org/framework/).
 
 You can also find related videos on the FinOps Foundation YouTube channel:
 

--- a/docs-mslearn/framework/quantify/benchmarking.md
+++ b/docs-mslearn/framework/quantify/benchmarking.md
@@ -58,7 +58,7 @@ At this point, you implemented best practices based on cross-company benchmarks 
 
 ## Learn more at the FinOps Foundation
 
-This capability is a part of the FinOps Framework by the FinOps Foundation, a non-profit organization dedicated to advancing cloud cost management and optimization. For more information about FinOps, including useful playbooks, training and certification programs, and more, refer to the FinOps Framework documentation.
+This capability is a part of the FinOps Framework by the FinOps Foundation, a non-profit organization dedicated to advancing cloud cost management and optimization. For more information about FinOps, including useful playbooks, training and certification programs, and more, refer to the [FinOps Framework documentation](https://www.finops.org/framework/).
 
 <br>
 

--- a/docs-mslearn/framework/quantify/benchmarking.md
+++ b/docs-mslearn/framework/quantify/benchmarking.md
@@ -3,7 +3,7 @@ title: FinOps benchmarking
 description: This article helps you understand the benchmarking capability within the FinOps Framework and how to implement that in the Microsoft Cloud.
 author: flanakin
 ms.author: micflan
-ms.date: 04/01/2026
+ms.date: 05/12/2026
 ms.topic: concept-article
 ms.service: finops
 ms.subservice: finops-learning-resources
@@ -58,7 +58,7 @@ At this point, you implemented best practices based on cross-company benchmarks 
 
 ## Learn more at the FinOps Foundation
 
-This capability is a part of the FinOps Framework by the FinOps Foundation, a non-profit organization dedicated to advancing cloud cost management and optimization. For more information about FinOps, including useful playbooks, training and certification programs, and more, see to the [benchmarking](https://www.finops.org/framework/capabilities/benchmarking) article in the FinOps Framework documentation.
+This capability is a part of the FinOps Framework by the FinOps Foundation, a non-profit organization dedicated to advancing cloud cost management and optimization. For more information about FinOps, including useful playbooks, training and certification programs, and more, see the benchmarking article in the FinOps Framework documentation.
 
 <br>
 

--- a/docs-mslearn/framework/quantify/benchmarking.md
+++ b/docs-mslearn/framework/quantify/benchmarking.md
@@ -58,7 +58,7 @@ At this point, you implemented best practices based on cross-company benchmarks 
 
 ## Learn more at the FinOps Foundation
 
-This capability is a part of the FinOps Framework by the FinOps Foundation, a non-profit organization dedicated to advancing cloud cost management and optimization. For more information about FinOps, including useful playbooks, training and certification programs, and more, see the benchmarking article in the FinOps Framework documentation.
+This capability is a part of the FinOps Framework by the FinOps Foundation, a non-profit organization dedicated to advancing cloud cost management and optimization. For more information about FinOps, including useful playbooks, training and certification programs, and more, refer to the FinOps Framework documentation.
 
 <br>
 

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -3,7 +3,7 @@ title: FinOps toolkit changelog
 description: Review the latest features and enhancements in the FinOps toolkit, including updates to FinOps hubs, Power BI reports, and more.
 author: MSBrett
 ms.author: brettwil
-ms.date: 04/29/2026
+ms.date: 05/12/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit
@@ -1058,7 +1058,7 @@ _**Breaking change**_
     - Added param to disable external access to Azure Data Lake and Azure Data Explorer.
     - Added param to specify subnet range of virtual network - minimum size = /26
   - Support for storage account infrastructure encryption.
-  - Published a [schema file](https://aka.ms/finops/hubs/settings-schema) for the hub settings.json file.
+  - Published a schema file for the hub settings.json file.
 - **Changed**
   - Changed dataset names in the ingestion container to facilitate Azure Data Explorer ingestion.
     > [!IMPORTANT]

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -1058,7 +1058,7 @@ _**Breaking change**_
     - Added param to disable external access to Azure Data Lake and Azure Data Explorer.
     - Added param to specify subnet range of virtual network - minimum size = /26
   - Support for storage account infrastructure encryption.
-  - Published a schema file for the hub settings.json file.
+  - Published a schema file for the hub settings.json file in this release.
 - **Changed**
   - Changed dataset names in the ingestion container to facilitate Azure Data Explorer ingestion.
     > [!IMPORTANT]

--- a/docs-mslearn/toolkit/hubs/deploy.md
+++ b/docs-mslearn/toolkit/hubs/deploy.md
@@ -3,7 +3,7 @@ title: How to create and update FinOps hubs
 description: This tutorial helps you create a new or update an existing FinOps hubs instance in Azure or Microsoft Fabric.
 author: flanakin
 ms.author: micflan
-ms.date: 04/21/2026
+ms.date: 05/12/2026
 ms.topic: tutorial
 ms.service: finops
 ms.subservice: finops-toolkit
@@ -560,7 +560,7 @@ For more information, see [Configure Data Explorer dashboards](configure-dashboa
    - **Azure Data Explorer (Kusto)** &ndash; Use an account that has at least viewer access to the Hub and Ingestion databases.
    - **Azure Resource Graph** &ndash; Use an account that has direct access to any subscriptions you would like to report on.
    - **(your storage account)** &ndash; Use a SAS token or an account that has Storage Blob Data Reader or greater access.
-   - **<https://ccmstorageprod>...** &ndash; Anonymous access. This URL is used for reservation size flexibility data.
+   - **<https://ccmstorageprod.blob.core.windows.net/costmanagementconnector-data/AutofitComboMeterData.csv>** &ndash; Anonymous access. This URL is used for reservation size flexibility data.
    - **<https://github.com/>...** &ndash; Anonymous access. This URL is used for FinOps toolkit open data files.
 
 For more information, see [Set up Power BI reports](../power-bi/setup.md).

--- a/docs-mslearn/toolkit/power-bi/setup.md
+++ b/docs-mslearn/toolkit/power-bi/setup.md
@@ -3,7 +3,7 @@ title: Set up Power BI reports
 description: Learn how to set up Power BI FinOps reports using the FinOps toolkit, customize visuals, and connect to your cost data for detailed analysis.
 author: flanakin
 ms.author: micflan
-ms.date: 04/01/2026
+ms.date: 05/12/2026
 ms.topic: how-to
 ms.service: finops
 ms.subservice: finops-toolkit
@@ -115,7 +115,7 @@ The FinOps toolkit Power BI reports include preconfigured visuals, but aren't co
    - **Azure Data Explorer (Kusto)** &ndash; Use an account that has at least viewer access to the Hub database.
    - **Azure Resource Graph** &ndash; Use an account that has direct access to any subscriptions you would like to report on.
    - **(your storage account)** &ndash; Use a SAS token or an account that has Storage Blob Data Reader or greater access.
-   - **<https://ccmstorageprod>...** &ndash; Anonymous access. This URL is used for reservation size flexibility data.
+   - **<https://ccmstorageprod.blob.core.windows.net/costmanagementconnector-data/AutofitComboMeterData.csv>** &ndash; Anonymous access. This URL is used for reservation size flexibility data.
    - **<https://github.com/>...** &ndash; Anonymous access. This URL is used for FinOps toolkit open data files.
 
 If you run into any issues syncing your data, see [Troubleshooting Power BI reports](../help/troubleshooting.md).

--- a/src/powershell/Tests/Unit/DocsLinks.Tests.ps1
+++ b/src/powershell/Tests/Unit/DocsLinks.Tests.ps1
@@ -108,14 +108,17 @@ BeforeDiscovery {
         'https://www.finops.org/framework/capabilities/benchmarking',
         'https://aka.ms/finops/hubs/settings-schema'
     )
+    # Match incomplete ccmstorageprod URLs (no domain suffix), while allowing valid hosts like ccmstorageprod.blob.core.windows.net.
+    $incompletePlaceholderUrlPattern = 'https://ccmstorageprod(?!\.)'
     $knownBrokenExternalUrlMatches = @()
+    $incompleteExternalUrlMatches = @()
     foreach ($file in $mslearnFiles)
     {
         $cleanContent = Remove-HtmlComments $file.Content
         foreach ($url in $knownBrokenExternalUrls)
         {
-            $matches = [regex]::Matches($cleanContent, [regex]::Escape($url))
-            foreach ($match in $matches)
+            $urlMatches = [regex]::Matches($cleanContent, [regex]::Escape($url))
+            foreach ($match in $urlMatches)
             {
                 $knownBrokenExternalUrlMatches += @{
                     SourceFile = $file.FullName
@@ -125,13 +128,9 @@ BeforeDiscovery {
                 }
             }
         }
-    }
-    $incompleteExternalUrlMatches = @()
-    foreach ($file in $mslearnFiles)
-    {
-        $cleanContent = Remove-HtmlComments $file.Content
-        $matches = [regex]::Matches($cleanContent, 'https://ccmstorageprod(?!\.)')
-        foreach ($match in $matches)
+
+        $placeholderMatches = [regex]::Matches($cleanContent, $incompletePlaceholderUrlPattern)
+        foreach ($match in $placeholderMatches)
         {
             $incompleteExternalUrlMatches += @{
                 SourceFile = $file.FullName

--- a/src/powershell/Tests/Unit/DocsLinks.Tests.ps1
+++ b/src/powershell/Tests/Unit/DocsLinks.Tests.ps1
@@ -102,6 +102,45 @@ BeforeDiscovery {
     $mslearnFiles = Get-MarkdownFiles $mslearnRoot $mslearnRoot
     $mslearnInternalLinks = Get-InternalMdLinks $mslearnFiles
     $mslearnUrls = Get-MarkdownUrls $mslearnFiles
+    $knownBrokenExternalUrls = @(
+        'https://azure.microsoft.com/products/managed-disks',
+        'https://www.finops.org/framework/capabilities/onboarding-workloads/',
+        'https://www.finops.org/framework/capabilities/benchmarking',
+        'https://aka.ms/finops/hubs/settings-schema'
+    )
+    $knownBrokenExternalUrlMatches = @()
+    foreach ($file in $mslearnFiles)
+    {
+        $cleanContent = Remove-HtmlComments $file.Content
+        foreach ($url in $knownBrokenExternalUrls)
+        {
+            $matches = [regex]::Matches($cleanContent, [regex]::Escape($url))
+            foreach ($match in $matches)
+            {
+                $knownBrokenExternalUrlMatches += @{
+                    SourceFile = $file.FullName
+                    SourceRel  = $file.RelativePath
+                    Url        = $url
+                    LineNumber = ($cleanContent.Substring(0, $match.Index) -split "`n").Count
+                }
+            }
+        }
+    }
+    $incompleteExternalUrlMatches = @()
+    foreach ($file in $mslearnFiles)
+    {
+        $cleanContent = Remove-HtmlComments $file.Content
+        $matches = [regex]::Matches($cleanContent, 'https://ccmstorageprod(?!\.)')
+        foreach ($match in $matches)
+        {
+            $incompleteExternalUrlMatches += @{
+                SourceFile = $file.FullName
+                SourceRel  = $file.RelativePath
+                Url        = $match.Value
+                LineNumber = ($cleanContent.Substring(0, $match.Index) -split "`n").Count
+            }
+        }
+    }
     #endregion
 
     #region docs (Jekyll site)
@@ -256,6 +295,20 @@ Describe 'Documentation links' {
 
         It 'Should not contain language locale in URL: <SourceRel>:<LineNumber> <Url>' -ForEach ($mslearnUrls | Where-Object { $_.Url -match 'learn\.microsoft\.com/[a-z]{2}-[a-z]{2}/' }) {
             $Url | Should -Not -Match 'learn\.microsoft\.com/[a-z]{2}-[a-z]{2}/' -Because "MS Learn links should not include language locale segments like /en-us/ (${SourceRel}:${LineNumber})"
+        }
+    }
+
+    Context 'docs-mslearn: No known broken external URLs' {
+
+        It 'Should not contain known broken external URLs' {
+            $knownBrokenExternalUrlMatches | Should -BeNullOrEmpty -Because 'known broken external URLs should not appear in docs-mslearn content'
+        }
+    }
+
+    Context 'docs-mslearn: No incomplete placeholder external URLs' {
+
+        It 'Should not contain incomplete placeholder URLs' {
+            $incompleteExternalUrlMatches | Should -BeNullOrEmpty -Because 'incomplete placeholder URLs should not appear in docs-mslearn content'
         }
     }
 

--- a/src/powershell/Tests/Unit/DocsLinks.Tests.ps1
+++ b/src/powershell/Tests/Unit/DocsLinks.Tests.ps1
@@ -124,6 +124,7 @@ BeforeDiscovery {
                     SourceFile = $file.FullName
                     SourceRel  = $file.RelativePath
                     Url        = $url
+                    Pattern    = "^$([regex]::Escape($url))$"
                     LineNumber = ($cleanContent.Substring(0, $match.Index) -split "`n").Count
                 }
             }
@@ -136,6 +137,7 @@ BeforeDiscovery {
                 SourceFile = $file.FullName
                 SourceRel  = $file.RelativePath
                 Url        = $match.Value
+                Pattern    = $incompletePlaceholderUrlPattern
                 LineNumber = ($cleanContent.Substring(0, $match.Index) -split "`n").Count
             }
         }
@@ -300,14 +302,14 @@ Describe 'Documentation links' {
     Context 'docs-mslearn: No known broken external URLs' {
 
         It 'Should not contain known broken external URL: <SourceRel>:<LineNumber> <Url>' -ForEach $knownBrokenExternalUrlMatches {
-            $Url | Should -Not -Match '^(https://azure.microsoft.com/products/managed-disks|https://www.finops.org/framework/capabilities/onboarding-workloads/|https://www.finops.org/framework/capabilities/benchmarking|https://aka.ms/finops/hubs/settings-schema)$' -Because "known broken external URLs should not appear in docs-mslearn content (${SourceRel}:${LineNumber})"
+            $Url | Should -Not -Match $Pattern -Because "known broken external URLs should not appear in docs-mslearn content (${SourceRel}:${LineNumber})"
         }
     }
 
     Context 'docs-mslearn: No incomplete placeholder external URLs' {
 
         It 'Should not contain incomplete placeholder URL: <SourceRel>:<LineNumber> <Url>' -ForEach $incompleteExternalUrlMatches {
-            $Url | Should -Not -Match '^https://ccmstorageprod(?!\.)' -Because "incomplete placeholder URLs should not appear in docs-mslearn content (${SourceRel}:${LineNumber})"
+            $Url | Should -Not -Match $Pattern -Because "incomplete placeholder URLs should not appear in docs-mslearn content (${SourceRel}:${LineNumber})"
         }
     }
 

--- a/src/powershell/Tests/Unit/DocsLinks.Tests.ps1
+++ b/src/powershell/Tests/Unit/DocsLinks.Tests.ps1
@@ -299,15 +299,15 @@ Describe 'Documentation links' {
 
     Context 'docs-mslearn: No known broken external URLs' {
 
-        It 'Should not contain known broken external URLs' {
-            $knownBrokenExternalUrlMatches | Should -BeNullOrEmpty -Because 'known broken external URLs should not appear in docs-mslearn content'
+        It 'Should not contain known broken external URL: <SourceRel>:<LineNumber> <Url>' -ForEach $knownBrokenExternalUrlMatches {
+            $Url | Should -Not -Match '^(https://azure.microsoft.com/products/managed-disks|https://www.finops.org/framework/capabilities/onboarding-workloads/|https://www.finops.org/framework/capabilities/benchmarking|https://aka.ms/finops/hubs/settings-schema)$' -Because "known broken external URLs should not appear in docs-mslearn content (${SourceRel}:${LineNumber})"
         }
     }
 
     Context 'docs-mslearn: No incomplete placeholder external URLs' {
 
-        It 'Should not contain incomplete placeholder URLs' {
-            $incompleteExternalUrlMatches | Should -BeNullOrEmpty -Because 'incomplete placeholder URLs should not appear in docs-mslearn content'
+        It 'Should not contain incomplete placeholder URL: <SourceRel>:<LineNumber> <Url>' -ForEach $incompleteExternalUrlMatches {
+            $Url | Should -Not -Match '^https://ccmstorageprod(?!\.)' -Because "incomplete placeholder URLs should not appear in docs-mslearn content (${SourceRel}:${LineNumber})"
         }
     }
 


### PR DESCRIPTION
Fixes #2139.

Replaces #2140, which could not be reopened because its original head branch was deleted.

Restores the same PR changes from inactive pull request ref #2140.

Includes:
- Broken external URI fixes in docs-mslearn.
- DocsLinks regression guardrails for known broken/incomplete external URLs.
- Follow-up test fix so the guard assertions execute via foreach cases.