### PR TITLE
Fix HTML rendering in Infrastructure encryption description

### DIFF
--- a/src/templates/finops-hub/createUiDefinition.json
+++ b/src/templates/finops-hub/createUiDefinition.json
@@ -850,7 +850,23 @@
                 "type": "Microsoft.Common.TextBlock",
                 "visible": true,
                 "options": {
-                  "text": "Infrastructure encryption can be enabled for the entire storage account. To enable infrastructure encryption for this storage account, you must check this box at the time that you deploy this template. <a href='https://learn.microsoft.com/azure/storage/common/infrastructure-encryption-enable?tabs=portal'>Learn more</a>. To learn about pricing for encryption scopes, see <a href= 'https://azure.microsoft.com/pricing/details/storage/blobs/'>Blob Storage pricing</a>."
+                  "text": "Infrastructure encryption can be enabled for the entire storage account. To enable infrastructure encryption for this storage account, you must check this box at the time that you deploy this template.",
+                  "link": {
+                    "label": "Learn more",
+                    "uri": "https://learn.microsoft.com/azure/storage/common/infrastructure-encryption-enable?tabs=portal"
+                  }
+                }
+              },
+              {
+                "name": "infraEncryptionPricing",
+                "type": "Microsoft.Common.TextBlock",
+                "visible": true,
+                "options": {
+                  "text": "To learn about pricing for encryption scopes, see",
+                  "link": {
+                    "label": "Blob Storage pricing",
+                    "uri": "https://azure.microsoft.com/pricing/details/storage/blobs/"
+                  }
                 }
               },
               {


### PR DESCRIPTION
## Summary
- `Microsoft.Common.TextBlock` does not render inline HTML, so the `<a>` tags in the Infrastructure encryption description on the Advanced tab of the FinOps hub deployment UI appeared as raw markup.
- Split the description into two text blocks, each using the supported `options.link` (`label` + `uri`) instead of embedded HTML.

## Test plan
- [ ] Deploy the FinOps hub template via the portal and open the Advanced tab.
- [ ] Confirm the Infrastructure encryption section shows clean text with clickable "Learn more" and "Blob Storage pricing" links (no raw HTML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)