### PR TITLE
fix(powershell): require Az.Accounts >= 2.17.0 for Get-AzAccessToken -AsSecureString (#2185)

### DIFF
--- a/.build/BuildHelper/Build-PsModule.ps1
+++ b/.build/BuildHelper/Build-PsModule.ps1
@@ -58,7 +58,7 @@ function Build-PsModule
         RequiredModules   = @(
             @{
                 ModuleName    = 'Az.Accounts'
-                ModuleVersion = '2.11.1'
+                ModuleVersion = '2.17.0'
             },
             @{
                 ModuleName    = 'Az.Resources'

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -68,7 +68,6 @@ _Released June 2026_
 - **Fixed**
   - Bumped the `Az.Accounts` required-module minimum to 2.17.0 so dependency resolution can't land on a version missing the `Get-AzAccessToken -AsSecureString` parameter that `Invoke-Rest` relies on ([#2185](https://github.com/microsoft/finops-toolkit/issues/2185)).
 
--->
 <!-- prettier-ignore-start -->
 > [!div class="nextstepaction"]
 > [Download](https://github.com/microsoft/finops-toolkit/releases/tag/v15)

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -3,7 +3,7 @@ title: FinOps toolkit changelog
 description: Review the latest features and enhancements in the FinOps toolkit, including updates to FinOps hubs, Power BI reports, and more.
 author: MSBrett
 ms.author: brettwil
-ms.date: 05/26/2026
+ms.date: 06/18/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit
@@ -62,6 +62,11 @@ _Released June 2026_
 
 - **Fixed**
   - Removed call to Azure Classic administrators endpoint (deprecated on May 1, 2026) from Azure RBAC assignments exports ([#2142](https://github.com/microsoft/finops-toolkit/issues/2142)).
+
+### [PowerShell module](powershell/powershell-commands.md) v15
+
+- **Fixed**
+  - Bumped the `Az.Accounts` required-module minimum to 2.17.0 so dependency resolution can't land on a version missing the `Get-AzAccessToken -AsSecureString` parameter that `Invoke-Rest` relies on ([#2185](https://github.com/microsoft/finops-toolkit/issues/2185)).
 
 -->
 <!-- prettier-ignore-start -->

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -3,7 +3,7 @@ title: FinOps toolkit changelog
 description: Review the latest features and enhancements in the FinOps toolkit, including updates to FinOps hubs, Power BI reports, and more.
 author: MSBrett
 ms.author: brettwil
-ms.date: 06/18/2026
+ms.date: 06/19/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit


### PR DESCRIPTION
## Summary

The `FinOpsToolkit` module manifest declared `Az.Accounts >= 2.11.1`, but `src/powershell/Private/Invoke-Rest.ps1` calls `Get-AzAccessToken -AsSecureString` — a parameter that wasn't introduced until **Az.Accounts 2.17.0**. Dependency resolution could therefore land on a version in the `[2.11.1, 2.17.0)` range that then fails at runtime for every cmdlet routing through `Invoke-Rest` (e.g. `Get-FinOpsCostExport`) with:

```
A parameter cannot be found that matches parameter name 'AsSecureString'.
```

## Fix

- Bumped the `Az.Accounts` `RequiredModules` minimum in `.build/BuildHelper/Build-PsModule.ps1` from `2.11.1` → `2.17.0` so dependency resolution cannot pick a version missing `-AsSecureString`.
- Added a changelog entry under the v15 PowerShell module section.

Closes #2185

🤖 Generated with [Claude Code](https://claude.com/claude-code)