### PR TITLE
fix(hubs): use max() when duplicate on-demand price rows collapse under one lookup key

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -52,6 +52,7 @@ _Released June 2026_
 - **Fixed**
   - Fixed Data Factory ingestion memory pressure during emptiness filtering.
     - Replaced `isnotempty(strcat(x_SkuMeterId, x_SkuOfferId))` with separate `isnotempty()` checks in FinOps hub ingestion scripts to avoid temporary string allocation.
+  - Fixed underreported commitment discount savings caused by `min()` selecting an anomalously low price when duplicate on-demand price rows collapse under one lookup key (for example, MCA price sheets that emit a blank `x_SkuOfferId`) ([#2176](https://github.com/microsoft/finops-toolkit/issues/2176)).
 
 ### [Power BI reports](power-bi/reports.md) v15
 

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -3,7 +3,7 @@ title: FinOps toolkit changelog
 description: Review the latest features and enhancements in the FinOps toolkit, including updates to FinOps hubs, Power BI reports, and more.
 author: MSBrett
 ms.author: brettwil
-ms.date: 06/19/2026
+ms.date: 06/22/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -52,7 +52,7 @@ _Released June 2026_
 - **Fixed**
   - Fixed Data Factory ingestion memory pressure during emptiness filtering.
     - Replaced `isnotempty(strcat(x_SkuMeterId, x_SkuOfferId))` with separate `isnotempty()` checks in FinOps hub ingestion scripts to avoid temporary string allocation.
-  - Fixed underreported commitment discount savings caused by `min()` selecting an anomalously low price when duplicate on-demand price rows collapse under one lookup key (for example, MCA price sheets that emit a blank `x_SkuOfferId`) ([#2176](https://github.com/microsoft/finops-toolkit/issues/2176)).
+  - Hardened the reservation price backfill to select the highest on-demand price (`max()` instead of `min()`) when duplicate price rows collapse under a single reservation price lookup key, preventing understated commitment discount savings ([#2189](https://github.com/microsoft/finops-toolkit/pull/2189)).
 
 ### [Power BI reports](power-bi/reports.md) v15
 

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_0.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_0.kql
@@ -417,7 +417,8 @@ Costs_transform_v1_0()
         Prices_final_v1_0
         | extend tmp_ReservationPriceLookupKey = tolower(strcat(x_BillingProfileId, substring(x_EffectivePeriodStart, 0, 7), x_SkuMeterId, x_SkuOfferId))
         | where x_SkuPriceType == 'Consumption' and tmp_ReservationPriceLookupKey in ((costsWithMissingPrices | summarize by tmp_ReservationPriceLookupKey))
-        | summarize ListUnitPrice = min(ListUnitPrice), ContractedUnitPrice = min(ContractedUnitPrice) by tmp_ReservationPriceLookupKey, x_PricingBlockSize, PricingUnit
+        // When the key collapses duplicate prices for one meter (e.g., MCA price sheets emit a blank x_SkuOfferId), use the highest on-demand price as the savings baseline; min() picks anomalously low rows and underreports savings
+        | summarize ListUnitPrice = max(ListUnitPrice), ContractedUnitPrice = max(ContractedUnitPrice) by tmp_ReservationPriceLookupKey, x_PricingBlockSize, PricingUnit
     ) on tmp_ReservationPriceLookupKey
     //
     // Select the best price to use for each row

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_0.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_0.kql
@@ -417,7 +417,7 @@ Costs_transform_v1_0()
         Prices_final_v1_0
         | extend tmp_ReservationPriceLookupKey = tolower(strcat(x_BillingProfileId, substring(x_EffectivePeriodStart, 0, 7), x_SkuMeterId, x_SkuOfferId))
         | where x_SkuPriceType == 'Consumption' and tmp_ReservationPriceLookupKey in ((costsWithMissingPrices | summarize by tmp_ReservationPriceLookupKey))
-        // When the key collapses duplicate prices for one meter (e.g., MCA price sheets emit a blank x_SkuOfferId), use the highest on-demand price as the savings baseline; min() picks anomalously low rows and underreports savings
+        // When duplicate price rows collapse under one lookup key, use the highest on-demand price as the savings baseline; min() can pick an anomalously low row and underreport savings
         | summarize ListUnitPrice = max(ListUnitPrice), ContractedUnitPrice = max(ContractedUnitPrice) by tmp_ReservationPriceLookupKey, x_PricingBlockSize, PricingUnit
     ) on tmp_ReservationPriceLookupKey
     //

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_2.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_2.kql
@@ -422,7 +422,8 @@ Costs_transform_v1_2()
         Prices_final_v1_2
         | extend tmp_ReservationPriceLookupKey = tolower(strcat(x_BillingProfileId, substring(x_EffectivePeriodStart, 0, 7), x_SkuMeterId, x_SkuOfferId))
         | where x_SkuPriceType == 'Consumption' and tmp_ReservationPriceLookupKey in ((costsWithMissingPrices | summarize by tmp_ReservationPriceLookupKey))
-        | summarize ListUnitPrice = min(ListUnitPrice), ContractedUnitPrice = min(ContractedUnitPrice) by tmp_ReservationPriceLookupKey, x_PricingBlockSize, PricingUnit
+        // When the key collapses duplicate prices for one meter (e.g., MCA price sheets emit a blank x_SkuOfferId), use the highest on-demand price as the savings baseline; min() picks anomalously low rows and underreports savings
+        | summarize ListUnitPrice = max(ListUnitPrice), ContractedUnitPrice = max(ContractedUnitPrice) by tmp_ReservationPriceLookupKey, x_PricingBlockSize, PricingUnit
     ) on tmp_ReservationPriceLookupKey
     //
     // Select the best price to use for each row

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_2.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_2.kql
@@ -422,7 +422,7 @@ Costs_transform_v1_2()
         Prices_final_v1_2
         | extend tmp_ReservationPriceLookupKey = tolower(strcat(x_BillingProfileId, substring(x_EffectivePeriodStart, 0, 7), x_SkuMeterId, x_SkuOfferId))
         | where x_SkuPriceType == 'Consumption' and tmp_ReservationPriceLookupKey in ((costsWithMissingPrices | summarize by tmp_ReservationPriceLookupKey))
-        // When the key collapses duplicate prices for one meter (e.g., MCA price sheets emit a blank x_SkuOfferId), use the highest on-demand price as the savings baseline; min() picks anomalously low rows and underreports savings
+        // When duplicate price rows collapse under one lookup key, use the highest on-demand price as the savings baseline; min() can pick an anomalously low row and underreport savings
         | summarize ListUnitPrice = max(ListUnitPrice), ContractedUnitPrice = max(ContractedUnitPrice) by tmp_ReservationPriceLookupKey, x_PricingBlockSize, PricingUnit
     ) on tmp_ReservationPriceLookupKey
     //


### PR DESCRIPTION
## 🛠️ Summary

General robustness fix for the FinOps hubs reservation price backfill. When duplicate on-demand price rows collapse under a single reservation price lookup key, prefer the **highest** price as the savings baseline instead of the lowest.

> [!NOTE]
> This is a general hardening, **not** a complete fix for #2176 (MCA underreported savings). See "Scope / relationship to #2176" below.

## 🐛 Behavior change

Missing on-demand prices are backfilled via a leftouter join against the `Prices` table, aggregated by the reservation price lookup key (`x_BillingProfileId` + `YYYY-MM` + `x_SkuMeterId` + `x_SkuOfferId`). When multiple Consumption price rows collapse under one key and differ only in price, `min()` selects the lowest row — which can be an anomalously low value — deflating the on-demand baseline and understating commitment discount savings.

Switching the `ListUnitPrice` / `ContractedUnitPrice` aggregation from `min()` to `max()` selects the genuine on-demand price in those collision cases.

- `IngestionSetup_v1_2.kql`
- `IngestionSetup_v1_0.kql`

For tenants whose price rows carry distinct, populated offer IDs (e.g. EA), the lookup key already separates rows, so each `summarize` group has a single row and `min == max` — a no-op. The change therefore only affects genuine collision cases and is safe across billing account types.

## 🔎 Scope / relationship to #2176

This PR does **not** close #2176. In the reporter's MCA scenario, the affected price rows carry a **blank** `x_SkuOfferId`. The cost-side `tmp_MissingPrices` gate requires `isnotempty(x_SkuOfferId)`, and the lookup key on both sides includes the offer ID — so blank-offer rows are filtered out before this join and never reach the `min()`/`max()` collapse. The MCA fix requires relaxing that offer-ID gate and/or keying on a field populated for MCA; tracked in #2176.

## 📝 Notes

- `release/` and fabric KQL copies are regenerated at release time and are intentionally not included here (consistent with prior KQL fixes).
- Changelog entry added under FinOps hubs v15 → Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)