### PR TITLE
Fix broken video embed and link wording in framework capability docs

### DIFF
--- a/docs-mslearn/framework/quantify/budgeting.md
+++ b/docs-mslearn/framework/quantify/budgeting.md
@@ -3,7 +3,7 @@ title: Budgeting
 description: This article helps you understand the budgeting capability within the FinOps Framework and how to implement that in the Microsoft Cloud.
 author: flanakin
 ms.author: micflan
-ms.date: 06/25/2026
+ms.date: 06/29/2026
 ms.topic: concept-article
 ms.service: finops
 ms.subservice: finops-learning-resources

--- a/docs-mslearn/framework/quantify/budgeting.md
+++ b/docs-mslearn/framework/quantify/budgeting.md
@@ -61,7 +61,7 @@ So far, you defined granular and targeted cost alerts for each scope and applica
 
 ## Learn more at the FinOps Foundation
 
-This capability is a part of the FinOps Framework by the FinOps Foundation, a non-profit organization dedicated to advancing cloud cost management and optimization. For more information about FinOps, including useful playbooks, training and certification programs, and more, see to the [Budgeting](https://www.finops.org/framework/capabilities/budgeting) article in the FinOps Framework documentation.
+This capability is a part of the FinOps Framework by the FinOps Foundation, a non-profit organization dedicated to advancing cloud cost management and optimization. For more information about FinOps, including useful playbooks, training and certification programs, and more, see the [Budgeting capability](https://www.finops.org/framework/capabilities/budgeting/) article in the FinOps Framework documentation.
 
 You can also find related videos on the FinOps Foundation YouTube channel:
 

--- a/docs-mslearn/framework/quantify/budgeting.md
+++ b/docs-mslearn/framework/quantify/budgeting.md
@@ -3,7 +3,7 @@ title: Budgeting
 description: This article helps you understand the budgeting capability within the FinOps Framework and how to implement that in the Microsoft Cloud.
 author: flanakin
 ms.author: micflan
-ms.date: 04/01/2026
+ms.date: 06/25/2026
 ms.topic: concept-article
 ms.service: finops
 ms.subservice: finops-learning-resources

--- a/docs-mslearn/framework/understand/reporting.md
+++ b/docs-mslearn/framework/understand/reporting.md
@@ -137,7 +137,6 @@ This capability is a part of the FinOps Framework by the FinOps Foundation, a no
 
 You can also find related videos on the FinOps Foundation YouTube channel:
 
-> [!VIDEO https://www.youtube.com/embed/pD9NeBOvspU?list=PLUSCToibAswlDSQdehKhi7ysP2hmetigl]
 
 <br>
 

--- a/docs-mslearn/framework/understand/reporting.md
+++ b/docs-mslearn/framework/understand/reporting.md
@@ -3,7 +3,7 @@ title: Reporting and analytics
 description: This article helps you understand the reporting and analytics capability within the FinOps Framework and how to implement that in the Microsoft Cloud.
 author: flanakin
 ms.author: micflan
-ms.date: 04/01/2026
+ms.date: 06/25/2026
 ms.topic: concept-article
 ms.service: finops
 ms.subservice: finops-learning-resources

--- a/docs-mslearn/framework/understand/reporting.md
+++ b/docs-mslearn/framework/understand/reporting.md
@@ -3,7 +3,7 @@ title: Reporting and analytics
 description: This article helps you understand the reporting and analytics capability within the FinOps Framework and how to implement that in the Microsoft Cloud.
 author: flanakin
 ms.author: micflan
-ms.date: 06/25/2026
+ms.date: 06/29/2026
 ms.topic: concept-article
 ms.service: finops
 ms.subservice: finops-learning-resources

--- a/docs-mslearn/framework/understand/reporting.md
+++ b/docs-mslearn/framework/understand/reporting.md
@@ -137,7 +137,7 @@ This capability is a part of the FinOps Framework by the FinOps Foundation, a no
 
 You can also find related videos on the FinOps Foundation YouTube channel:
 
-> [!VIDEO https://www.youtube.com/embed/CVTJLdcozj1eEpxT?list=PLUSCToibAswlDSQdehKhi7ysP2hmetigl]
+> [!VIDEO https://www.youtube.com/embed/pD9NeBOvspU?list=PLUSCToibAswlDSQdehKhi7ysP2hmetigl]
 
 <br>
 


### PR DESCRIPTION
## 🛠️ Description

Two small doc fixes in the FinOps Framework capability articles, found while reviewing the published pages:

1. **`understand/reporting.md`** — the FinOps Foundation video embed id was corrupted: `CVTJLdcozj1eEpxT` is 16 characters, but valid YouTube ids are 11, so the video did not load. Replaced with `pD9NeBOvspU`, keeping the `?list=` playlist param.
   - The replacement id was resolved via YouTube oEmbed against the embedded playlist (`PLUSCToibAswlDSQdehKhi7ysP2hmetigl`), which returns title "Reporting & Analytics" / author "FinOps Foundation". It's a confirmed live FinOps Foundation video for that playlist; if a maintainer knows the canonical Reporting & Analytics video differs, please adjust the id — the playlist param is unchanged either way.

2. **`quantify/budgeting.md`** — "see **to** the [Budgeting]" → "see the [Budgeting capability]", and added the trailing slash on the capability URL, to match the wording and link format used by every sibling capability page (e.g. reporting, allocation, unit-economics).

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 👍 Manually verified (compared against sibling capability pages; confirmed the new embed id resolves to a live FinOps Foundation video via oEmbed)

Docs-only change — no code, deployment, or schema impact.