### PR TITLE
Revert test-only changes accidentally merged in #2163

### DIFF
--- a/src/powershell/Tests/Initialize-Tests.ps1
+++ b/src/powershell/Tests/Initialize-Tests.ps1
@@ -3,7 +3,6 @@
 
 Remove-Module FinOpsToolkit -ErrorAction SilentlyContinue
 Import-Module -FullyQualifiedName "$PSScriptRoot/../FinOpsToolkit.psm1"
-Import-Module Pester -Global -ErrorAction Stop
 
 BeforeAll {
     # Bring the Monitor functions in to simplify debugging

--- a/src/powershell/Tests/Integration/CostExports.Tests.ps1
+++ b/src/powershell/Tests/Integration/CostExports.Tests.ps1
@@ -337,7 +337,7 @@ Describe 'CostExports' {
                 -Backfill 12
 
             # Assert
-            Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Write-Progress' -Times 4
+            Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Write-Progress' -Times 4
             $success | Should -Be $true
             ((Get-Date) - $testStartTime).TotalSeconds | Should -BeGreaterThan 60
         }

--- a/src/powershell/Tests/Unit/Deploy-FinOpsHub.Tests.ps1
+++ b/src/powershell/Tests/Unit/Deploy-FinOpsHub.Tests.ps1
@@ -33,9 +33,9 @@ InModuleScope 'FinOpsToolkit' {
                 Deploy-FinOpsHub -WhatIf -Name $hubName -ResourceGroupName $rgName -Location $location
 
                 # Assert
-                Should -Invoke -CommandName 'Initialize-FinOpsHubDeployment' -Times 1 -ParameterFilter { $WhatIf -eq $true }
+                Assert-MockCalled -CommandName 'Initialize-FinOpsHubDeployment' -Times 1 -ParameterFilter { $WhatIf -eq $true }
                 @('CreateResourceGroup', 'CreateTempDirectory', 'DownloadTemplate', 'DeployFinOpsHub') | ForEach-Object {
-                    Should -Invoke -CommandName 'Test-ShouldProcess' -Times 1 -ParameterFilter { $Action -eq $_ }
+                    Assert-MockCalled -CommandName 'Test-ShouldProcess' -Times 1 -ParameterFilter { $Action -eq $_ }
                 }
             }
         }
@@ -55,8 +55,8 @@ InModuleScope 'FinOpsToolkit' {
                 Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location
 
                 # Assert
-                Should -Invoke -CommandName 'Get-AzResourceGroup' -Times 1
-                Should -Invoke -CommandName 'New-AzResourceGroup' -Times 1
+                Assert-MockCalled -CommandName 'Get-AzResourceGroup' -Times 1
+                Assert-MockCalled -CommandName 'New-AzResourceGroup' -Times 1
             }
 
             It 'Should use RG if it exists' {
@@ -69,8 +69,8 @@ InModuleScope 'FinOpsToolkit' {
                 Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location
 
                 # Assert
-                Should -Invoke -CommandName 'Get-AzResourceGroup' -Times 1
-                Should -Invoke -CommandName 'New-AzResourceGroup' -Times 0
+                Assert-MockCalled -CommandName 'Get-AzResourceGroup' -Times 1
+                Assert-MockCalled -CommandName 'New-AzResourceGroup' -Times 0
             }
         }
 
@@ -85,7 +85,7 @@ InModuleScope 'FinOpsToolkit' {
                 Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location
 
                 # Assert
-                Should -Invoke -CommandName 'Initialize-FinOpsHubDeployment' -Times 1
+                Assert-MockCalled -CommandName 'Initialize-FinOpsHubDeployment' -Times 1
             }
         }
 
@@ -111,7 +111,7 @@ InModuleScope 'FinOpsToolkit' {
                 Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location
 
                 # Assert
-                Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -Times 1
+                Assert-MockCalled -CommandName 'New-AzResourceGroupDeployment' -Times 1
             }
             It 'Should add tags to the deployment' -Skip {
             }
@@ -130,7 +130,7 @@ InModuleScope 'FinOpsToolkit' {
             It 'Should throw if template file is not found' {
                 Mock -CommandName 'Get-ChildItem'
                 { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -Version 'latest' } | Should -Throw
-                Should -Invoke -CommandName 'Get-ChildItem' -Times 1
+                Assert-MockCalled -CommandName 'Get-ChildItem' -Times 1
             }
 
             Context 'More' {
@@ -142,14 +142,14 @@ InModuleScope 'FinOpsToolkit' {
 
                 It 'Should deploy the template without throwing' {
                     { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -Version 'latest' } | Should -Not -Throw
-                    Should -Invoke -CommandName 'Get-ChildItem' -Times 1
-                    Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter { @{ TemplateFile = $templateFile } } -Times 1
+                    Assert-MockCalled -CommandName 'Get-ChildItem' -Times 1
+                    Assert-MockCalled -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter { @{ TemplateFile = $templateFile } } -Times 1
                 }
 
                 It 'Should deploy the template with tags' {
                     { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -Tags @{ Test = 'Tag' } -Version 'latest' } | Should -Not -Throw
-                    Should -Invoke -CommandName 'Get-ChildItem' -Times 1
-                    Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
+                    Assert-MockCalled -CommandName 'Get-ChildItem' -Times 1
+                    Assert-MockCalled -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
                         @{
                             TemplateParameterObject = @{
                                 tags = @{
@@ -163,8 +163,8 @@ InModuleScope 'FinOpsToolkit' {
                 It 'Should deploy the template with StorageSku' {
                     $storageSku = 'Premium_ZRS'
                     { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -StorageSku $storageSku -Version 'latest' } | Should -Not -Throw
-                    Should -Invoke -CommandName 'Get-ChildItem' -Times 1
-                    Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
+                    Assert-MockCalled -CommandName 'Get-ChildItem' -Times 1
+                    Assert-MockCalled -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
                         @{
                             TemplateParameterObject = @{
                                 storageSku = $storageSku
@@ -176,8 +176,8 @@ InModuleScope 'FinOpsToolkit' {
                 It 'Should deploy the template with RemoteHubStorageUri' {
                     $remoteHubStorageUri = 'https://primaryhub.dfs.core.windows.net/'
                     { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -RemoteHubStorageUri $remoteHubStorageUri -Version 'latest' } | Should -Not -Throw
-                    Should -Invoke -CommandName 'Get-ChildItem' -Times 1
-                    Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
+                    Assert-MockCalled -CommandName 'Get-ChildItem' -Times 1
+                    Assert-MockCalled -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
                         $TemplateParameterObject.remoteHubStorageUri -eq $remoteHubStorageUri
                     } -Times 1
                 }
@@ -185,8 +185,8 @@ InModuleScope 'FinOpsToolkit' {
                 It 'Should deploy the template with RemoteHubStorageKey' {
                     $remoteHubStorageKey = 'abc123...xyz789=='
                     { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -RemoteHubStorageKey $remoteHubStorageKey -Version 'latest' } | Should -Not -Throw
-                    Should -Invoke -CommandName 'Get-ChildItem' -Times 1
-                    Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
+                    Assert-MockCalled -CommandName 'Get-ChildItem' -Times 1
+                    Assert-MockCalled -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
                         $TemplateParameterObject.remoteHubStorageKey -eq $remoteHubStorageKey
                     } -Times 1
                 }
@@ -195,77 +195,11 @@ InModuleScope 'FinOpsToolkit' {
                     $remoteHubStorageUri = 'https://primaryhub.dfs.core.windows.net/'
                     $remoteHubStorageKey = 'abc123...xyz789=='
                     { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -RemoteHubStorageUri $remoteHubStorageUri -RemoteHubStorageKey $remoteHubStorageKey -Version 'latest' } | Should -Not -Throw
-                    Should -Invoke -CommandName 'Get-ChildItem' -Times 1
-                    Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
+                    Assert-MockCalled -CommandName 'Get-ChildItem' -Times 1
+                    Assert-MockCalled -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
                         $TemplateParameterObject.remoteHubStorageUri -eq $remoteHubStorageUri -and $TemplateParameterObject.remoteHubStorageKey -eq $remoteHubStorageKey
                     } -Times 1
                 }
-            }
-        }
-
-        Context 'Network mode' {
-            BeforeAll {
-                Mock -CommandName 'Get-AzResourceGroup' -MockWith { return @{ ResourceGroupName = $rgName } }
-                Mock -CommandName 'New-AzResourceGroup'
-                Mock -CommandName 'Save-FinOpsHubTemplate'
-                Mock -CommandName 'Initialize-FinOpsHubDeployment'
-                $templateFile = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath 'FinOps/finops-hub-v1.0.0/main.bicep'
-                Mock -CommandName 'Get-ChildItem' -MockWith { return @{ FullName = $templateFile } }
-                Mock -CommandName 'New-AzResourceGroupDeployment'
-            }
-
-            It 'Should default to public access without a NAT Gateway' {
-                { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -Version 'latest' } | Should -Not -Throw
-                Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
-                    $TemplateParameterObject.enablePublicAccess -eq $true -and -not $TemplateParameterObject.ContainsKey('enableNatGateway')
-                } -Times 1
-            }
-
-            It "Should map -NetworkMode 'public' to enablePublicAccess and no NAT Gateway" {
-                { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -NetworkMode 'public' -Version 'latest' } | Should -Not -Throw
-                Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
-                    $TemplateParameterObject.enablePublicAccess -eq $true -and -not $TemplateParameterObject.ContainsKey('enableNatGateway')
-                } -Times 1
-            }
-
-            It "Should map -NetworkMode 'vnet' to private access without a NAT Gateway" {
-                { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -NetworkMode 'vnet' -Version 'latest' } | Should -Not -Throw
-                Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
-                    $TemplateParameterObject.enablePublicAccess -eq $false -and -not $TemplateParameterObject.ContainsKey('enableNatGateway')
-                } -Times 1
-            }
-
-            It "Should map -NetworkMode 'private' to private access with a NAT Gateway" {
-                { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -NetworkMode 'private' -Version 'latest' } | Should -Not -Throw
-                Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
-                    $TemplateParameterObject.enablePublicAccess -eq $false -and $TemplateParameterObject.enableNatGateway -eq $true
-                } -Times 1
-            }
-
-            It 'Should map deprecated -DisablePublicAccess to vnet (no NAT Gateway)' {
-                { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -DisablePublicAccess -Version 'latest' -WarningAction 'SilentlyContinue' } | Should -Not -Throw
-                Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
-                    $TemplateParameterObject.enablePublicAccess -eq $false -and -not $TemplateParameterObject.ContainsKey('enableNatGateway')
-                } -Times 1
-            }
-
-            It 'Should let -NetworkMode win over deprecated -DisablePublicAccess' {
-                { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -NetworkMode 'private' -DisablePublicAccess -Version 'latest' } | Should -Not -Throw
-                Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
-                    $TemplateParameterObject.enablePublicAccess -eq $false -and $TemplateParameterObject.enableNatGateway -eq $true
-                } -Times 1
-            }
-
-            It 'Should throw when private mode targets a version older than 15.0' {
-                { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -NetworkMode 'private' -Version '14.0' } | Should -Throw
-                Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -Times 0
-            }
-
-            It 'Should pass enableNatGateway when private mode targets version 15.0 or later' {
-                { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -NetworkMode 'private' -Version '15.0' } | Should -Not -Throw
-                Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
-                    $TemplateParameterObject.enableNatGateway -eq $true
-                } -Times 1
             }
         }
     }

--- a/src/powershell/Tests/Unit/DocsLinks.Tests.ps1
+++ b/src/powershell/Tests/Unit/DocsLinks.Tests.ps1
@@ -286,56 +286,30 @@ Describe 'Documentation links' {
     }
 
     Context 'docs-mslearn: No learn.microsoft.com URLs' {
-        $learnMicrosoftLinks = @($mslearnUrls | Where-Object { $_.Url -match 'learn\.microsoft\.com' })
-        if ($learnMicrosoftLinks.Count -gt 0) {
-            It 'Should not contain https://learn.microsoft.com links: <SourceRel>:<LineNumber>' -ForEach $learnMicrosoftLinks {
-                $Url | Should -Not -Match 'learn\.microsoft\.com' -Because "links in docs-mslearn should use root-relative paths (e.g., /azure/...) instead of full URLs since docs are deployed to learn.microsoft.com (${SourceRel}:${LineNumber})"
-            }
-        }
-        else {
-            It 'Should not contain https://learn.microsoft.com links' {
-                $learnMicrosoftLinks | Should -BeNullOrEmpty -Because 'docs-mslearn should not contain fully qualified learn.microsoft.com URLs'
-            }
+
+        It 'Should not contain https://learn.microsoft.com links: <SourceRel>:<LineNumber>' -ForEach ($mslearnUrls | Where-Object { $_.Url -match 'learn\.microsoft\.com' }) {
+            $Url | Should -Not -Match 'learn\.microsoft\.com' -Because "links in docs-mslearn should use root-relative paths (e.g., /azure/...) instead of full URLs since docs are deployed to learn.microsoft.com (${SourceRel}:${LineNumber})"
         }
     }
 
     Context 'docs-mslearn: No language locale in MS Learn links' {
-        $localizedMsLearnLinks = @($mslearnUrls | Where-Object { $_.Url -match 'learn\.microsoft\.com/[a-z]{2}-[a-z]{2}/' })
-        if ($localizedMsLearnLinks.Count -gt 0) {
-            It 'Should not contain language locale in URL: <SourceRel>:<LineNumber> <Url>' -ForEach $localizedMsLearnLinks {
-                $Url | Should -Not -Match 'learn\.microsoft\.com/[a-z]{2}-[a-z]{2}/' -Because "MS Learn links should not include language locale segments like /en-us/ (${SourceRel}:${LineNumber})"
-            }
-        }
-        else {
-            It 'Should not contain language locale in MS Learn links' {
-                $localizedMsLearnLinks | Should -BeNullOrEmpty -Because 'MS Learn links should not include language locale segments like /en-us/'
-            }
+
+        It 'Should not contain language locale in URL: <SourceRel>:<LineNumber> <Url>' -ForEach ($mslearnUrls | Where-Object { $_.Url -match 'learn\.microsoft\.com/[a-z]{2}-[a-z]{2}/' }) {
+            $Url | Should -Not -Match 'learn\.microsoft\.com/[a-z]{2}-[a-z]{2}/' -Because "MS Learn links should not include language locale segments like /en-us/ (${SourceRel}:${LineNumber})"
         }
     }
 
     Context 'docs-mslearn: No known broken external URLs' {
-        if ($knownBrokenExternalUrlMatches.Count -gt 0) {
-            It 'Should not contain known broken external URL: <SourceRel>:<LineNumber> <Url>' -ForEach $knownBrokenExternalUrlMatches {
-                $Url | Should -Not -Match $Pattern -Because "known broken external URLs should not appear in docs-mslearn content (${SourceRel}:${LineNumber})"
-            }
-        }
-        else {
-            It 'Should not contain known broken external URLs' {
-                $knownBrokenExternalUrlMatches | Should -BeNullOrEmpty -Because 'docs-mslearn should not contain any known broken external URLs'
-            }
+
+        It 'Should not contain known broken external URL: <SourceRel>:<LineNumber> <Url>' -ForEach $knownBrokenExternalUrlMatches {
+            $Url | Should -Not -Match $Pattern -Because "known broken external URLs should not appear in docs-mslearn content (${SourceRel}:${LineNumber})"
         }
     }
 
     Context 'docs-mslearn: No incomplete placeholder external URLs' {
-        if ($incompleteExternalUrlMatches.Count -gt 0) {
-            It 'Should not contain incomplete placeholder URL: <SourceRel>:<LineNumber> <Url>' -ForEach $incompleteExternalUrlMatches {
-                $Url | Should -Not -Match $Pattern -Because "incomplete placeholder URLs should not appear in docs-mslearn content (${SourceRel}:${LineNumber})"
-            }
-        }
-        else {
-            It 'Should not contain incomplete placeholder external URLs' {
-                $incompleteExternalUrlMatches | Should -BeNullOrEmpty -Because 'docs-mslearn should not contain placeholder external URLs'
-            }
+
+        It 'Should not contain incomplete placeholder URL: <SourceRel>:<LineNumber> <Url>' -ForEach $incompleteExternalUrlMatches {
+            $Url | Should -Not -Match $Pattern -Because "incomplete placeholder URLs should not appear in docs-mslearn content (${SourceRel}:${LineNumber})"
         }
     }
 

--- a/src/powershell/Tests/Unit/Get-FinOpsCostExport.Tests.ps1
+++ b/src/powershell/Tests/Unit/Get-FinOpsCostExport.Tests.ps1
@@ -135,7 +135,7 @@ InModuleScope 'FinOpsToolkit' {
                 $result | Should -HaveCount 1
 
                 # The individual GET endpoint was queried for the export's full run history
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Uri -match 'exports/test-export\?' -and $Uri -match '\$expand=runHistory'
                 }
 
@@ -175,7 +175,7 @@ InModuleScope 'FinOpsToolkit' {
                 Get-FinOpsCostExport -Scope $scope -RunHistory
 
                 # Assert
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Uri -match '\$expand=runHistory'
                 }
             }
@@ -208,8 +208,8 @@ InModuleScope 'FinOpsToolkit' {
 
                 # Assert
                 # Only the list call should be made (no $expand, no per-export GET)
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -Exactly
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -Exactly
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Uri -notmatch '\$expand=runHistory'
                 }
             }
@@ -257,7 +257,7 @@ InModuleScope 'FinOpsToolkit' {
 
                 # Assert
                 # The per-export individual GET must be attempted before falling back
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Uri -match 'exports/test-export\?' -and $Uri -match '\$expand=runHistory'
                 }
                 $result | Should -Not -BeNullOrEmpty
@@ -310,7 +310,7 @@ InModuleScope 'FinOpsToolkit' {
                 # Assert
                 # The cmdlet must still return data (the thrown error is caught and the
                 # list run history is used).
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Uri -match 'exports/test-export\?' -and $Uri -match '\$expand=runHistory'
                 }
                 $result | Should -Not -BeNullOrEmpty
@@ -394,10 +394,10 @@ InModuleScope 'FinOpsToolkit' {
                 # Assert
                 # The throttled GET was retried (2 calls), waited once, and the full
                 # history (2 runs) -- not the truncated list (1 run) -- was returned.
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 2 -Exactly -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 2 -Exactly -ParameterFilter {
                     $Uri -match 'exports/test-export\?'
                 }
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Start-Sleep' -Times 1 -Exactly
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Start-Sleep' -Times 1 -Exactly
                 $result.RunHistory | Should -HaveCount 2
                 $result.RunHistory[1].RunId | Should -Be 'run2'
             }

--- a/src/powershell/Tests/Unit/Get-FinOpsToolkitVersion.Tests.ps1
+++ b/src/powershell/Tests/Unit/Get-FinOpsToolkitVersion.Tests.ps1
@@ -103,13 +103,13 @@ InModuleScope 'FinOpsToolkit' {
             It 'Should return 1 result when [Latest] is used' {
                 $result = Get-FinOpsToolkitVersion -Latest
                 $result.Count | Should -Be 1
-                Should -Invoke -CommandName 'Invoke-WebRequest' -Times 1
+                Assert-MockCalled -CommandName 'Invoke-WebRequest' -Times 1
             }
 
             It 'Should return all versions if [Latest] not used' {
                 $result = Get-FinOpsToolkitVersion
                 $result.Count | Should -Be 2
-                Should -Invoke -CommandName 'Invoke-WebRequest' -Times 1
+                Assert-MockCalled -CommandName 'Invoke-WebRequest' -Times 1
             }
         }
 
@@ -142,8 +142,8 @@ InModuleScope 'FinOpsToolkit' {
 
             It 'Should throw if the Uri is unreachable' {
                 { Get-FinOpsToolkitVersion } | Should -Throw
-                Should -Invoke -CommandName 'Invoke-WebRequest'
-                Should -Invoke -CommandName 'New-Object' -Times 0
+                Assert-MockCalled -CommandName 'Invoke-WebRequest'
+                Assert-MockCalled -CommandName 'New-Object' -Times 0
             }
         }
 
@@ -158,13 +158,13 @@ InModuleScope 'FinOpsToolkit' {
             It 'Should include prereleases when [Preview] is used' {
                 $result = Get-FinOpsToolkitVersion -Preview
                 $result.Count | Should -Be 2
-                Should -Invoke -CommandName 'Invoke-WebRequest' -Times 1
+                Assert-MockCalled -CommandName 'Invoke-WebRequest' -Times 1
             }
 
             It 'Should not include prereleases when [Preview] is not used' {
                 $result = Get-FinOpsToolkitVersion
                 $result.Count | Should -Be 1
-                Should -Invoke -CommandName 'Invoke-WebRequest' -Times 1
+                Assert-MockCalled -CommandName 'Invoke-WebRequest' -Times 1
             }
         }
 
@@ -180,7 +180,7 @@ InModuleScope 'FinOpsToolkit' {
                 $result = Get-FinOpsToolkitVersion -Latest -Preview
                 $result.Count | Should -Be 1
                 $result.Version | Should -Be $previewVersion
-                Should -Invoke -CommandName 'Invoke-WebRequest' -Times 1
+                Assert-MockCalled -CommandName 'Invoke-WebRequest' -Times 1
             }
         }
     }

--- a/src/powershell/Tests/Unit/Initialize-FinOpsHubDeployment.Tests.ps1
+++ b/src/powershell/Tests/Unit/Initialize-FinOpsHubDeployment.Tests.ps1
@@ -19,7 +19,7 @@ InModuleScope FinOpsToolkit {
                 Initialize-FinOpsHubDeployment
 
                 # Assert
-                Should -Invoke -CommandName 'Register-FinOpsHubProviders' -Times 1
+                Assert-MockCalled -CommandName 'Register-FinOpsHubProviders' -Times 1
             }
         }
     }

--- a/src/powershell/Tests/Unit/New-Directory.Tests.ps1
+++ b/src/powershell/Tests/Unit/New-Directory.Tests.ps1
@@ -105,8 +105,8 @@ InModuleScope 'FinOpsToolkit' {
             New-Directory -Path $path
 
             # Assert
-            Should -Invoke -CommandName 'Test-Path'
-            Should -Invoke -CommandName 'New-Item' -Times 0
+            Assert-MockCalled -CommandName 'Test-Path'
+            Assert-MockCalled -CommandName 'New-Item' -Times 0
         }
 
         It 'Should create a directory if it does not exist' {
@@ -117,8 +117,8 @@ InModuleScope 'FinOpsToolkit' {
             New-Directory -Path $path
 
             # Assert
-            Should -Invoke -CommandName 'Test-Path'
-            Should -Invoke -CommandName 'New-Item' -Times 1
+            Assert-MockCalled -CommandName 'Test-Path'
+            Assert-MockCalled -CommandName 'New-Item' -Times 1
         }
     }
 }

--- a/src/powershell/Tests/Unit/New-FinOpsCostExport.Tests.ps1
+++ b/src/powershell/Tests/Unit/New-FinOpsCostExport.Tests.ps1
@@ -42,8 +42,8 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams
 
                 # Assert
-                Should -Invoke -CommandName 'Get-AzResourceProvider' -Times 1
-                Should -Invoke -CommandName 'Register-AzResourceProvider' -Times 1
+                Assert-MockCalled -CommandName 'Get-AzResourceProvider' -Times 1
+                Assert-MockCalled -CommandName 'Register-AzResourceProvider' -Times 1
             }
 
             It 'Should create export' {
@@ -52,11 +52,11 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams
     
                 # Assert
-                Should -Invoke -CommandName 'Get-AzResourceProvider' -Times 1
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Get-FinOpsCostExport' -Times 2
+                Assert-MockCalled -CommandName 'Get-AzResourceProvider' -Times 1
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Get-FinOpsCostExport' -Times 2
                 # TODO: Validate request body via parameter filter in Invoke-Rest call
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Start-FinOpsCostExport' -Times 0
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Start-FinOpsCostExport' -Times 0
             }
 
             It 'Should create and run scheduled export' {
@@ -65,11 +65,11 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams -Execute
 
                 # Assert
-                Should -Invoke -CommandName 'Get-AzResourceProvider' -Times 1
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Get-FinOpsCostExport' -Times 2
+                Assert-MockCalled -CommandName 'Get-AzResourceProvider' -Times 1
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Get-FinOpsCostExport' -Times 2
                 # TODO: Validate request body via parameter filter in Invoke-Rest call
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Start-FinOpsCostExport' -Times 1
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Start-FinOpsCostExport' -Times 1
             }
 
             It 'Should create and backfill scheduled export' {
@@ -80,11 +80,11 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams -Backfill $backfillMonths
 
                 # Assert
-                Should -Invoke -CommandName 'Get-AzResourceProvider' -Times 1
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Get-FinOpsCostExport' -Times 2
+                Assert-MockCalled -CommandName 'Get-AzResourceProvider' -Times 1
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Get-FinOpsCostExport' -Times 2
                 # TODO: Validate request body via parameter filter in Invoke-Rest call
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Start-FinOpsCostExport' -Times 1 -ParameterFilter { $Backfill -eq $backfillMonths }
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Start-FinOpsCostExport' -Times 1 -ParameterFilter { $Backfill -eq $backfillMonths }
             }
 
             It 'Should create and run one-time export' {
@@ -93,11 +93,11 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams -OneTime
 
                 # Assert
-                Should -Invoke -CommandName 'Get-AzResourceProvider' -Times 1
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Get-FinOpsCostExport' -Times 2
+                Assert-MockCalled -CommandName 'Get-AzResourceProvider' -Times 1
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Get-FinOpsCostExport' -Times 2
                 # TODO: Validate request body via parameter filter in Invoke-Rest call
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Start-FinOpsCostExport' -Times 1
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Start-FinOpsCostExport' -Times 1
             }
         }
 
@@ -108,7 +108,7 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams
     
                 # Assert
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Uri -match 'api-version=2025-03-01'
                 }
             }
@@ -119,7 +119,7 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams
     
                 # Assert
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Body.properties.definition.type -eq 'FocusCost'
                 }
             }
@@ -130,7 +130,7 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams
     
                 # Assert
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $null -eq $Body.identity
                 }
             }
@@ -141,7 +141,7 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams
     
                 # Assert
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Body.properties.schedule.status -eq 'Active'
                 }
             }
@@ -161,7 +161,7 @@ InModuleScope 'FinOpsToolkit' {
                     New-FinOpsCostExport @newExportParams -Dataset $_.dataset
     
                     # Assert
-                    Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                    Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                         $Body.properties.definition.type -eq $_.dataset `
                             -and $Body.properties.schedule.recurrence -eq $_.schedule
                     }
@@ -173,7 +173,7 @@ InModuleScope 'FinOpsToolkit' {
                     New-FinOpsCostExport @newExportParams -Dataset $_.dataset
     
                     # Assert
-                    Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                    Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                         $Body.properties.definition.type -eq $_.dataset `
                             -and $Body.properties.definition.dataSet.configuration.dataVersion -eq $_.version
                     }
@@ -188,7 +188,7 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams -SystemAssignedIdentity
     
                 # Assert
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Body.identity.type -eq 'SystemAssigned' `
                         -and $Body.location -eq 'global'
                 }
@@ -202,7 +202,7 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams -SystemAssignedIdentity -Location $location
 
                 # Assert
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Body.identity.type -eq 'SystemAssigned' `
                         -and $Body.location -eq $location
                 }
@@ -216,7 +216,7 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams
 
                 # Assert
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Body.properties.format -eq 'Csv'
                 }
             }
@@ -227,7 +227,7 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams -Format 'Parquet'
 
                 # Assert
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Body.properties.format -eq 'Parquet'
                 }
             }
@@ -238,7 +238,7 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams
 
                 # Assert
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Body.properties.compressionMode -eq 'None'
                 }
             }
@@ -249,7 +249,7 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @newExportParams -CompressionMode 'Snappy'
 
                 # Assert
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Body.properties.compressionMode -eq 'Snappy'
                 }
             }
@@ -269,7 +269,7 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @paramsWithColons
                 
                 # Assert
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Body.properties.deliveryInfo.destination.rootFolderPath -eq (($scopeWithColons -replace ':','-').Trim('/'))
                 }
             }
@@ -289,7 +289,7 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @paramsWithExplicitPath
                 
                 # Assert
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Body.properties.deliveryInfo.destination.rootFolderPath -eq $explicitPathWithColons
                 }
             }
@@ -307,7 +307,7 @@ InModuleScope 'FinOpsToolkit' {
                 New-FinOpsCostExport @paramsWithoutColons
                 
                 # Assert
-                Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+                Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                     $Body.properties.deliveryInfo.destination.rootFolderPath -eq $scopeWithoutColons.Trim('/')
                 }
             }

--- a/src/powershell/Tests/Unit/Register-FinOpsHubProviders.Tests.ps1
+++ b/src/powershell/Tests/Unit/Register-FinOpsHubProviders.Tests.ps1
@@ -21,8 +21,8 @@ InModuleScope 'FinOpsToolkit' {
 
                 # Assert
                 $requiredRPs | ForEach-Object {
-                    Should -Invoke -CommandName 'Get-AzResourceProvider' -Times 1 -ParameterFilter { $ProviderNamespace -eq $_ }
-                    Should -Invoke -CommandName 'Register-AzResourceProvider' -Times 1 -ParameterFilter { $ProviderNamespace -eq $_ -and $WhatIf -eq $true }
+                    Assert-MockCalled -CommandName 'Get-AzResourceProvider' -Times 1 -ParameterFilter { $ProviderNamespace -eq $_ }
+                    Assert-MockCalled -CommandName 'Register-AzResourceProvider' -Times 1 -ParameterFilter { $ProviderNamespace -eq $_ -and $WhatIf -eq $true }
                 }
             }
         }
@@ -40,8 +40,8 @@ InModuleScope 'FinOpsToolkit' {
                 Register-FinOpsHubProviders
 
                 # Assert
-                Should -Invoke -CommandName 'Get-AzResourceProvider' -Times $requiredRPs.Count
-                Should -Invoke -CommandName 'Register-AzResourceProvider' -Times ($state -eq 'Registered' ? 0 : $requiredRPs.Count)
+                Assert-MockCalled -CommandName 'Get-AzResourceProvider' -Times $requiredRPs.Count
+                Assert-MockCalled -CommandName 'Register-AzResourceProvider' -Times ($state -eq 'Registered' ? 0 : $requiredRPs.Count)
             }
         }
     }

--- a/src/powershell/Tests/Unit/Save-FinOpsHubTemplate.Tests.ps1
+++ b/src/powershell/Tests/Unit/Save-FinOpsHubTemplate.Tests.ps1
@@ -39,8 +39,8 @@ InModuleScope FinOpsToolkit {
                 Save-FinOpsHubTemplate
 
                 # Assert
-                Should -Invoke -CommandName 'Get-FinOpsToolkitVersion' -Times 1
-                Should -Invoke -CommandName 'Invoke-WebRequest' -Times 0
+                Assert-MockCalled -CommandName 'Get-FinOpsToolkitVersion' -Times 1
+                Assert-MockCalled -CommandName 'Invoke-WebRequest' -Times 0
             }
         }
 
@@ -59,8 +59,8 @@ InModuleScope FinOpsToolkit {
                 Save-FinOpsHubTemplate
 
                 # Assert
-                Should -Invoke -CommandName 'Get-FinOpsToolkitVersion' -Times 1
-                Should -Invoke -CommandName 'Invoke-WebRequest' -Times 1
+                Assert-MockCalled -CommandName 'Get-FinOpsToolkitVersion' -Times 1
+                Assert-MockCalled -CommandName 'Invoke-WebRequest' -Times 1
             }
         }
 
@@ -75,9 +75,9 @@ InModuleScope FinOpsToolkit {
                 Save-FinOpsHubTemplate -Version $downloadVersion
 
                 # Assert
-                Should -Invoke -CommandName 'Invoke-WebRequest' -Times 1 -ParameterFilter { $Uri -eq $downloadUrl }
-                Should -Invoke -CommandName 'Expand-Archive' -Times 1
-                Should -Invoke -CommandName 'Remove-Item' -Times 1
+                Assert-MockCalled -CommandName 'Invoke-WebRequest' -Times 1 -ParameterFilter { $Uri -eq $downloadUrl }
+                Assert-MockCalled -CommandName 'Expand-Archive' -Times 1
+                Assert-MockCalled -CommandName 'Remove-Item' -Times 1
             }
         }
 
@@ -88,7 +88,7 @@ InModuleScope FinOpsToolkit {
 
             It 'Should throw' {
                 { Save-FinOpsHubTemplate } | Should -Throw
-                Should -Invoke -CommandName 'Invoke-WebRequest' -Times 0
+                Assert-MockCalled -CommandName 'Invoke-WebRequest' -Times 0
             }
         }
 
@@ -102,7 +102,7 @@ InModuleScope FinOpsToolkit {
                 Save-FinOpsHubTemplate -Version '0.2'
 
                 # Assert
-                Should -Invoke -CommandName 'Test-Path' -Times 1 -ParameterFilter { $Path.EndsWith('0.3.zip') }
+                Assert-MockCalled -CommandName 'Test-Path' -Times 1 -ParameterFilter { $Path.EndsWith('0.3.zip') }
             }
     
             It 'Should not redirect 0.2 to 0.1.1 for Azure Gov' {
@@ -114,7 +114,7 @@ InModuleScope FinOpsToolkit {
                 Save-FinOpsHubTemplate -Version '0.3'
 
                 # Assert
-                Should -Invoke -CommandName 'Test-Path' -Times 1 -ParameterFilter { $Path.EndsWith('0.3.zip') }
+                Assert-MockCalled -CommandName 'Test-Path' -Times 1 -ParameterFilter { $Path.EndsWith('0.3.zip') }
             }
 
             It 'Should not redirect 0.2 to 0.1.1 for Azure China' {
@@ -126,7 +126,7 @@ InModuleScope FinOpsToolkit {
                 Save-FinOpsHubTemplate -Version '0.3'
 
                 # Assert
-                Should -Invoke -CommandName 'Test-Path' -Times 1 -ParameterFilter { $Path.EndsWith('0.3.zip') }
+                Assert-MockCalled -CommandName 'Test-Path' -Times 1 -ParameterFilter { $Path.EndsWith('0.3.zip') }
             }
     
             It 'Should support 0.3 for Azure Gov' {
@@ -138,7 +138,7 @@ InModuleScope FinOpsToolkit {
                 Save-FinOpsHubTemplate -Version '0.3'
     
                 # Assert
-                Should -Invoke -CommandName 'Test-Path' -Times 1 -ParameterFilter { $Path.EndsWith('0.3.zip') }
+                Assert-MockCalled -CommandName 'Test-Path' -Times 1 -ParameterFilter { $Path.EndsWith('0.3.zip') }
             }
     
             It 'Should support 0.3 for Azure China' {
@@ -150,7 +150,7 @@ InModuleScope FinOpsToolkit {
                 Save-FinOpsHubTemplate -Version '0.3'
     
                 # Assert
-                Should -Invoke -CommandName 'Test-Path' -Times 1 -ParameterFilter { $Path.EndsWith('0.3.zip') }
+                Assert-MockCalled -CommandName 'Test-Path' -Times 1 -ParameterFilter { $Path.EndsWith('0.3.zip') }
             }
         }
     }

--- a/src/powershell/Tests/Unit/Start-FinOpsCostExport.Tests.ps1
+++ b/src/powershell/Tests/Unit/Start-FinOpsCostExport.Tests.ps1
@@ -31,7 +31,7 @@ Describe 'Start-FinOpsCostExport' {
         { Start-FinOpsCostExport @params } | Should -Throw
 
         # Assert
-        Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Get-FinOpsCostExport' -Times 1
+        Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Get-FinOpsCostExport' -Times 1
     }
 
     It 'Should call /run with default dates' {
@@ -47,7 +47,7 @@ Describe 'Start-FinOpsCostExport' {
         $success = Start-FinOpsCostExport @params
 
         # Assert
-        Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 `
+        Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 `
             -ParameterFilter { return $body -eq $null }
         $success | Should -Be $true
     }
@@ -66,7 +66,7 @@ Describe 'Start-FinOpsCostExport' {
         $success = Start-FinOpsCostExport @params
 
         # Assert
-        Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 `
+        Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 `
             -ParameterFilter { $body.timePeriod.from -eq $params.StartDate.ToUniversalTime().ToString("yyyy-01-01'T'00:00:00'Z'") -and $body.timePeriod.to -eq $params.StartDate.ToUniversalTime().ToString("yyyy-01-31'T'00:00:00'Z'") }
         $success | Should -Be $true
     }
@@ -86,7 +86,7 @@ Describe 'Start-FinOpsCostExport' {
         $success = Start-FinOpsCostExport @params
 
         # Assert
-        Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 `
+        Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 `
             -ParameterFilter { $body.timePeriod.from -eq $params.StartDate.ToUniversalTime().Date.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'") -and $body.timePeriod.to -eq $params.EndDate.ToUniversalTime().Date.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'") }
         $success | Should -Be $true
     }
@@ -107,15 +107,15 @@ Describe 'Start-FinOpsCostExport' {
         $success = Start-FinOpsCostExport @params
 
         # Assert
-        Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times ($params.Backfill + 1)
-        Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+        Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times ($params.Backfill + 1)
+        Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
             $startDate = $startOfMonth.ToUniversalTime().Date
             $body.timePeriod.from -eq $startDate.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'") `
                 -and $body.timePeriod.to -eq $today.AddDays(-1).ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
         }
         foreach ($i in 1..($params.Backfill))
         {
-            Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
+            Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 -ParameterFilter {
                 $startDate = $startOfMonth.AddMonths($i * -1).ToUniversalTime().Date
                 $body.timePeriod.from -eq $startDate.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'") `
                     -and $body.timePeriod.to -eq $startDate.AddMonths(1).AddMilliseconds(-1).ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
@@ -137,7 +137,7 @@ Describe 'Start-FinOpsCostExport' {
             -Backfill 3
 
         # Assert
-        Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Write-Progress' -Times 4
+        Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Write-Progress' -Times 4
         $success | Should -Be $true
     }
 
@@ -166,7 +166,7 @@ Describe 'Start-FinOpsCostExport' {
             $success = Start-FinOpsCostExport @params
 
             # Assert
-            Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 `
+            Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 1 `
                 -ParameterFilter {
                 $body.timePeriod.from -eq $firstDayOfCurrentMonth.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'") -and
                 $body.timePeriod.to -eq $today.AddDays(-1).ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
@@ -213,8 +213,8 @@ Describe 'Start-FinOpsCostExport' {
         $success = Start-FinOpsCostExport @params
 
         # Assert
-        Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 2
-        Should -Invoke -ModuleName FinOpsToolkit -CommandName 'Start-Sleep' -Times 1
+        Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Invoke-Rest' -Times 2
+        Assert-MockCalled -ModuleName FinOpsToolkit -CommandName 'Start-Sleep' -Times 1
         $success | Should -Be $true
     }
 }


### PR DESCRIPTION
## Summary
- remove the 12 PowerShell test-file changes that were unintentionally merged with #2163
- preserve the NAT Gateway product changes shipped by #2163
- return the test suite to the pre-merge test baseline

## Validation
- Invoke-Pester -Output Detailed -Path ./src/powershell/Tests/Unit

## Context
PR #2163 was intended to ship the NAT Gateway product change plus the changelog nit fix. The additional PowerShell test-file edits were out of scope and should not have been merged.