### PR TITLE
Deploy hub subnets as child resources so upgrades don't delete customer subnets

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,6 +7,8 @@ on:
       # KQL sources are covered by unit tests (HubsKqlOperators.Tests.ps1)
       - 'src/templates/finops-hub/**/*.kql'
       - 'src/queries/**/*.kql'
+      # Hub networking is covered by unit tests (HubsPrivateNetworking.Tests.ps1)
+      - 'src/templates/finops-hub/**/*.bicep'
 jobs:
   run_pester_tests:
     name: Pester

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -3,7 +3,7 @@ title: FinOps toolkit changelog
 description: Review the latest features and enhancements in the FinOps toolkit, including updates to FinOps hubs, Power BI reports, and more.
 author: MSBrett
 ms.author: brettwil
-ms.date: 07/30/2026
+ms.date: 08/03/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit
@@ -34,6 +34,7 @@ The following section lists features and enhancements that are currently in deve
   - Replaced whole-term `contains` matches with `has` across hub KQL and the query catalog (resource ID paths, licensing phrases, SKU description terms) and added a per-row operator-equivalence regression harness with unit test coverage ([#2220](https://github.com/microsoft/finops-toolkit/pull/2220)).
 - **Fixed**
   - Fixed the `ContractedCost` recompute guard to compare with a null-safe tolerance instead of exact float equality, eliminating millions of no-op rewrites that polluted the `x_SourceValues` audit trail while preserving the null-cost backfill and no longer overwriting an existing cost when the unit price is missing ([#2216](https://github.com/microsoft/finops-toolkit/issues/2216)).
+  - Fixed hub upgrades deleting subnets you added to the hub virtual network, or failing with `InUseSubnetCannotBeDeleted` when those subnets are in use. Hub subnets are now deployed as child resources, so upgrades no longer replace the entire subnet collection ([#2156](https://github.com/microsoft/finops-toolkit/issues/2156)).
 
 ### [Power BI reports](power-bi/reports.md)
 

--- a/src/powershell/Tests/Unit/HubsPrivateNetworking.Tests.ps1
+++ b/src/powershell/Tests/Unit/HubsPrivateNetworking.Tests.ps1
@@ -1,0 +1,193 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+    Regression coverage for FinOps hub private networking (#2156).
+
+    The hub VNet must never declare its subnets through the virtual network's `subnets` property.
+    A PUT that carries that property is authoritative for the whole subnet collection, so ARM
+    deletes every subnet the template doesn't list -- which destroyed customer-added subnets on
+    upgrade and failed with InUseSubnetCannotBeDeleted when those subnets had service association
+    links. The hub now declares only the three subnets it owns, as child resources, leaving any
+    other subnet in the VNet untouched.
+
+    Assertions run against the COMPILED ARM JSON, not the Bicep source text, so a reformat or
+    rewrite that preserves behavior passes and one that changes behavior fails.
+
+    API versions are asserted as a MINIMUM, never as an exact value. Omitting `subnets` from a
+    VNet PUT only preserves existing subnets from api-version 2023-09-01 onward, so that floor is
+    the real requirement. Pinning an exact version here would block routine version upgrades.
+
+    Limitation: no static test can prove Azure's runtime behavior. Validating that an upgrade
+    preserves a customer-added subnet requires a live deployment against a real subscription.
+#>
+
+Describe 'HubsPrivateNetworking' {
+
+    BeforeDiscovery {
+        $script:bicepAvailable = [bool](Get-Command 'bicep' -ErrorAction SilentlyContinue)
+    }
+
+    BeforeAll {
+        $repoRoot = (Resolve-Path "$PSScriptRoot/../../../..").Path
+        $bicepFile = Join-Path $repoRoot 'src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Core/infrastructure.bicep'
+
+        # Behavior floor: VNet PUT without the subnets property preserves existing subnets.
+        # https://learn.microsoft.com/azure/azure-resource-manager/bicep/scenarios-virtual-networks
+        $script:minApiVersion = [datetime]::ParseExact('2023-09-01', 'yyyy-MM-dd', $null)
+
+        $script:finopsHubSubnetName = 'private-endpoint-subnet'
+        $script:scriptSubnetName = 'script-subnet'
+        $script:dataExplorerSubnetName = 'dataExplorer-subnet'
+
+        # The NAT gateway is applied through a conditional spread, which compiles to
+        # if(<enabled>, createObject('natGateway', ...), createObject()). Asserting only that
+        # "natGateways" appears somewhere would also pass if the branches were swapped, so match
+        # the natGateway object in the position the true branch occupies.
+        $script:natGatewayTrueBranch = "if\(parameters\('hub'\)\.options\.natGateway,\s*createObject\('natGateway'"
+
+        if (Get-Command 'bicep' -ErrorAction SilentlyContinue)
+        {
+            $outFile = Join-Path ([System.IO.Path]::GetTempPath()) "ftk-infra-$([guid]::NewGuid()).json"
+            $buildOutput = bicep build $bicepFile --outfile $outFile 2>&1
+            if ($LASTEXITCODE -ne 0)
+            {
+                throw "Bicep compilation failed: $($buildOutput | Out-String)"
+            }
+
+            $script:template = Get-Content -Path $outFile -Raw | ConvertFrom-Json
+            Remove-Item $outFile -Force -ErrorAction SilentlyContinue
+
+            $script:vNet = $script:template.resources.'vNet'
+            $script:subnets = @(
+                $script:template.resources.PSObject.Properties `
+                | Where-Object { $_.Value.type -eq 'Microsoft.Network/virtualNetworks/subnets' } `
+                | ForEach-Object { $_.Value }
+            )
+        }
+
+        function Get-SubnetByName([string] $Name)
+        {
+            # The compiled name is an ARM expression referencing the variable that holds the literal.
+            $variableName = switch ($Name)
+            {
+                $script:finopsHubSubnetName { 'finopsHubSubnetName' }
+                $script:scriptSubnetName { 'scriptSubnetName' }
+                $script:dataExplorerSubnetName { 'dataExplorerSubnetName' }
+            }
+            return $script:subnets | Where-Object { $_.name -match [regex]::Escape($variableName) }
+        }
+
+        # Subnets whose properties are built with a conditional spread compile to a single
+        # shallowMerge() expression string instead of an inspectable object, so those are matched
+        # as text. The literal below is what the compiler emits for the property value.
+        function Get-SubnetPropertyText($Subnet)
+        {
+            return ($Subnet.properties | ConvertTo-Json -Depth 20 -Compress)
+        }
+    }
+
+    Context 'Virtual network' -Skip:(-not $bicepAvailable) {
+
+        It 'Should not declare subnets on the virtual network (#2156)' {
+            $propertyNames = $script:vNet.properties.PSObject.Properties.Name
+            $propertyNames | Should -Not -Contain 'subnets' -Because 'a VNet PUT carrying the subnets property is authoritative for the whole collection and deletes customer-added subnets on upgrade'
+        }
+
+        It 'Should not set subnets to an empty or null value' {
+            # Azure treats "subnets": [] and "subnets": null as "delete every subnet".
+            $json = $script:vNet.properties | ConvertTo-Json -Depth 20 -Compress
+            $json | Should -Not -Match '"subnets"\s*:\s*(\[\]|null)'
+        }
+
+        It 'Should still declare the address space' {
+            $script:vNet.properties.addressSpace | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should use an api-version that preserves subnets when the property is omitted' {
+            $actual = [datetime]::ParseExact($script:vNet.apiVersion, 'yyyy-MM-dd', $null)
+            $actual | Should -BeGreaterOrEqual $script:minApiVersion -Because "omitting subnets only preserves them from 2023-09-01 onward (found $($script:vNet.apiVersion))"
+        }
+    }
+
+    Context 'Hub-owned subnets' -Skip:(-not $bicepAvailable) {
+
+        It 'Should declare exactly three subnets as child resources' {
+            $script:subnets.Count | Should -Be 3
+        }
+
+        It 'Should deploy every subnet rather than only reference it' {
+            foreach ($subnet in $script:subnets)
+            {
+                [bool]$subnet.existing | Should -BeFalse -Because "subnet '$($subnet.name)' must be deployed so the hub owns its configuration"
+            }
+        }
+
+        It 'Should use an api-version at or above the floor for every subnet' {
+            foreach ($subnet in $script:subnets)
+            {
+                $actual = [datetime]::ParseExact($subnet.apiVersion, 'yyyy-MM-dd', $null)
+                $actual | Should -BeGreaterOrEqual $script:minApiVersion
+            }
+        }
+
+        It 'Should attach the network security group to every subnet' {
+            foreach ($subnet in $script:subnets)
+            {
+                # Match the property key, not the resource type name in resourceId().
+                Get-SubnetPropertyText $subnet | Should -Match 'networkSecurityGroup[''"]' -Because "subnet '$($subnet.name)' must stay behind the hub NSG"
+            }
+        }
+
+        It 'Should serialize subnet deployment to avoid AnotherOperationInProgress' {
+            # Concurrent writes to subnets of the same VNet fail, so each subnet after the first
+            # must wait on the previous one.
+            $scriptSubnet = Get-SubnetByName $script:scriptSubnetName
+            $dataExplorerSubnet = Get-SubnetByName $script:dataExplorerSubnetName
+
+            $scriptSubnet.dependsOn | Should -Contain 'vNet::finopsHubSubnet'
+            $dataExplorerSubnet.dependsOn | Should -Contain 'vNet::scriptSubnet'
+        }
+
+        It 'Should give the private endpoint subnet a storage service endpoint' {
+            $subnet = Get-SubnetByName $script:finopsHubSubnetName
+            $subnet.properties.serviceEndpoints.service | Should -Contain 'Microsoft.Storage'
+        }
+
+        It 'Should delegate the script subnet to Azure Container Instances' {
+            $subnet = Get-SubnetByName $script:scriptSubnetName
+            Get-SubnetPropertyText $subnet | Should -Match 'Microsoft.ContainerInstance/containerGroups'
+        }
+
+        It 'Should give the script subnet a storage service endpoint' {
+            $subnet = Get-SubnetByName $script:scriptSubnetName
+            Get-SubnetPropertyText $subnet | Should -Match 'Microsoft.Storage'
+        }
+
+        It 'Should route the script subnet through the NAT gateway when enabled' {
+            $subnet = Get-SubnetByName $script:scriptSubnetName
+            Get-SubnetPropertyText $subnet | Should -Match $script:natGatewayTrueBranch -Because 'the NAT gateway must be attached in the enabled branch, not the disabled one'
+        }
+
+        It 'Should route the Data Explorer subnet through the NAT gateway when enabled' {
+            $subnet = Get-SubnetByName $script:dataExplorerSubnetName
+            Get-SubnetPropertyText $subnet | Should -Match $script:natGatewayTrueBranch -Because 'the NAT gateway must be attached in the enabled branch, not the disabled one'
+        }
+
+        It 'Should keep subnet creation ordered after the NAT gateway' {
+            # natGateway is referenced through resourceId(), which creates no implicit dependency,
+            # so subnets can only be ordered after it via the VNet's explicit dependsOn.
+            $script:vNet.dependsOn | Should -Contain 'natGateway' -Because 'subnets attach the NAT gateway and must not be created before it exists'
+        }
+    }
+
+    Context 'Private endpoint placement' -Skip:(-not $bicepAvailable) {
+
+        It 'Should wait on the subnet the script private endpoint is created in' {
+            # scriptEndpoint lands in hub.routing.subnets.storage, which resolves to
+            # private-endpoint-subnet -- not script-subnet.
+            $endpoint = $script:template.resources.'scriptEndpoint'
+            $endpoint.dependsOn | Should -Contain 'vNet::finopsHubSubnet'
+        }
+    }
+}

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Core/infrastructure.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Core/infrastructure.bicep
@@ -25,67 +25,6 @@ var finopsHubSubnetName = 'private-endpoint-subnet'
 var scriptSubnetName = 'script-subnet'
 var dataExplorerSubnetName = 'dataExplorer-subnet'
 
-var subnets = !hub.options.privateRouting ? [] : [
-  {
-    name: finopsHubSubnetName
-    properties: {
-      addressPrefix: cidrSubnet(hub.options.networkAddressPrefix, 28, 0)
-      defaultOutboundAccess: !hub.options.natGateway
-      networkSecurityGroup: {
-        id: nsg.id
-      }
-      serviceEndpoints: [
-        {
-          service: 'Microsoft.Storage'
-        }
-      ]
-    }
-  }
-  {
-    name: scriptSubnetName
-    properties: {
-      addressPrefix: cidrSubnet(hub.options.networkAddressPrefix, 28, 1)
-      defaultOutboundAccess: !hub.options.natGateway
-      ...(hub.options.natGateway ? {
-        natGateway: {
-          id: resourceId('Microsoft.Network/natGateways', natGatewayName)
-        }
-      } : {})
-      networkSecurityGroup: {
-        id: nsg.id
-      }
-      delegations: [
-        {
-          name: 'Microsoft.ContainerInstance/containerGroups'
-          properties: {
-            serviceName: 'Microsoft.ContainerInstance/containerGroups'
-          }
-        }
-      ]
-      serviceEndpoints: [
-        {
-          service: 'Microsoft.Storage'
-        }
-      ]
-    }
-  }
-  {
-    name: dataExplorerSubnetName
-    properties: {
-      addressPrefix: cidrSubnet(hub.options.networkAddressPrefix, 27, 1)
-      defaultOutboundAccess: !hub.options.natGateway
-      ...(hub.options.natGateway ? {
-        natGateway: {
-          id: resourceId('Microsoft.Network/natGateways', natGatewayName)
-        }
-      } : {})
-      networkSecurityGroup: {
-        id: nsg.id
-      }
-    }
-  }
-]
-
 
 //==============================================================================
 // Resources
@@ -95,7 +34,7 @@ var subnets = !hub.options.privateRouting ? [] : [
 // Network
 //------------------------------------------------------------------------------
 
-resource nsg 'Microsoft.Network/networkSecurityGroups@2023-11-01' = if (hub.options.privateRouting) {
+resource nsg 'Microsoft.Network/networkSecurityGroups@2025-07-01' = if (hub.options.privateRouting) {
   name: nsgName
   location: hub.location
   tags: getHubTags(hub, 'Microsoft.Storage/networkSecurityGroups')
@@ -183,7 +122,7 @@ resource nsg 'Microsoft.Network/networkSecurityGroups@2023-11-01' = if (hub.opti
   }
 }
 
-resource vNet 'Microsoft.Network/virtualNetworks@2023-11-01' = if (hub.options.privateRouting) {
+resource vNet 'Microsoft.Network/virtualNetworks@2025-07-01' = if (hub.options.privateRouting) {
   name: hub.routing.networkName
   location: hub.location
   tags: getHubTags(hub, 'Microsoft.Network/virtualNetworks')
@@ -194,19 +133,81 @@ resource vNet 'Microsoft.Network/virtualNetworks@2023-11-01' = if (hub.options.p
     addressSpace: {
       addressPrefixes: [hub.options.networkAddressPrefix]
     }
-    subnets: subnets
+    // Subnets are intentionally omitted here and declared as child resources below.
+    // A PUT that includes this property is authoritative for the entire subnet list, so ARM
+    // deletes any subnet the hub doesn't declare -- destroying customer-added subnets on upgrade.
+    // Since API version 2023-09-01, omitting it leaves existing subnets untouched, which lets the
+    // hub manage only the subnets it owns. See https://aka.ms/ftk/vnet-subnets and issue #2156.
+    // Never set this to [] or null: both are treated as "delete all subnets".
   }
 
-  resource finopsHubSubnet 'subnets' existing = {
+  // Subnets are serialized via dependsOn. Concurrent writes to subnets of the same virtual
+  // network fail with AnotherOperationInProgress.
+  resource finopsHubSubnet 'subnets' = {
     name: finopsHubSubnetName
+    properties: {
+      addressPrefix: cidrSubnet(hub.options.networkAddressPrefix, 28, 0)
+      defaultOutboundAccess: !hub.options.natGateway
+      networkSecurityGroup: {
+        id: nsg.id
+      }
+      serviceEndpoints: [
+        {
+          service: 'Microsoft.Storage'
+        }
+      ]
+    }
   }
 
-  resource scriptSubnet 'subnets' existing = {
+  resource scriptSubnet 'subnets' = {
     name: scriptSubnetName
+    dependsOn: [
+      finopsHubSubnet
+    ]
+    properties: {
+      addressPrefix: cidrSubnet(hub.options.networkAddressPrefix, 28, 1)
+      defaultOutboundAccess: !hub.options.natGateway
+      ...(hub.options.natGateway ? {
+        natGateway: {
+          id: resourceId('Microsoft.Network/natGateways', natGatewayName)
+        }
+      } : {})
+      networkSecurityGroup: {
+        id: nsg.id
+      }
+      delegations: [
+        {
+          name: 'Microsoft.ContainerInstance/containerGroups'
+          properties: {
+            serviceName: 'Microsoft.ContainerInstance/containerGroups'
+          }
+        }
+      ]
+      serviceEndpoints: [
+        {
+          service: 'Microsoft.Storage'
+        }
+      ]
+    }
   }
 
-  resource dataExplorerSubnet 'subnets' existing = {
+  resource dataExplorerSubnet 'subnets' = {
     name: dataExplorerSubnetName
+    dependsOn: [
+      scriptSubnet
+    ]
+    properties: {
+      addressPrefix: cidrSubnet(hub.options.networkAddressPrefix, 27, 1)
+      defaultOutboundAccess: !hub.options.natGateway
+      ...(hub.options.natGateway ? {
+        natGateway: {
+          id: resourceId('Microsoft.Network/natGateways', natGatewayName)
+        }
+      } : {})
+      networkSecurityGroup: {
+        id: nsg.id
+      }
+    }
   }
 }
 
@@ -216,7 +217,7 @@ resource vNet 'Microsoft.Network/virtualNetworks@2023-11-01' = if (hub.options.p
 // policy and the September 2025 implicit-outbound retirement)
 //------------------------------------------------------------------------------
 
-resource natGatewayPublicIp 'Microsoft.Network/publicIPAddresses@2023-11-01' = if (hub.options.natGateway) {
+resource natGatewayPublicIp 'Microsoft.Network/publicIPAddresses@2025-07-01' = if (hub.options.natGateway) {
   name: natGatewayPipName
   location: hub.location
   tags: getHubTags(hub, 'Microsoft.Network/publicIPAddresses')
@@ -229,7 +230,7 @@ resource natGatewayPublicIp 'Microsoft.Network/publicIPAddresses@2023-11-01' = i
   }
 }
 
-resource natGateway 'Microsoft.Network/natGateways@2023-11-01' = if (hub.options.natGateway) {
+resource natGateway 'Microsoft.Network/natGateways@2025-07-01' = if (hub.options.natGateway) {
   name: natGatewayName
   location: hub.location
   tags: getHubTags(hub, 'Microsoft.Network/natGateways')
@@ -346,7 +347,7 @@ resource tablePrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = if
 // Script storage
 //------------------------------------------------------------------------------
 
-resource scriptStorageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = if (hub.options.privateRouting) {
+resource scriptStorageAccount 'Microsoft.Storage/storageAccounts@2026-04-01' = if (hub.options.privateRouting) {
   name: hub.routing.scriptStorage
   dependsOn: [
     vNet::scriptSubnet
@@ -377,10 +378,10 @@ resource scriptStorageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = i
   }
 }
 
-resource scriptEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = if (hub.options.privateRouting) {
+resource scriptEndpoint 'Microsoft.Network/privateEndpoints@2025-07-01' = if (hub.options.privateRouting) {
   name: '${scriptStorageAccount.name}-blob-ep'
   dependsOn: [
-    vNet::scriptSubnet
+    vNet::finopsHubSubnet
   ]
   location: hub.location
   tags: getHubTags(hub, 'Microsoft.Network/privateEndpoints')
@@ -429,7 +430,7 @@ output vNetId string = !hub.options.privateRouting ? '' : vNet.id
 #disable-next-line BCP318 // Null safety warning for conditional resource access
 output vNetAddressSpace array = !hub.options.privateRouting ? [] : vNet.properties.addressSpace.addressPrefixes
 
-@description('Virtual network subnets.')
+@description('Virtual network subnets. Includes any subnets added by the customer, not only the subnets the hub manages.')
 #disable-next-line BCP318 // Null safety warning for conditional resource access
 output vNetSubnets array = !hub.options.privateRouting ? [] : vNet.properties.subnets
 

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Core/infrastructure.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Core/infrastructure.bicep
@@ -347,7 +347,7 @@ resource tablePrivateDnsZone 'Microsoft.Network/privateDnsZones@2024-06-01' = if
 // Script storage
 //------------------------------------------------------------------------------
 
-resource scriptStorageAccount 'Microsoft.Storage/storageAccounts@2026-04-01' = if (hub.options.privateRouting) {
+resource scriptStorageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = if (hub.options.privateRouting) {
   name: hub.routing.scriptStorage
   dependsOn: [
     vNet::scriptSubnet


### PR DESCRIPTION
Fixes #2156.

## Problem

The hub virtual network declared its three subnets as an inline `subnets:` array. That makes every ARM PUT authoritative for the **entire** subnet collection, so upgrading a hub either:

- silently deleted any subnet a customer had added to the hub VNet (deployment still reported `Succeeded`), or
- failed the whole deployment with `InUseSubnetCannotBeDeleted` when one of those subnets was in use.

## Fix

Subnets are now declared as standalone child resources. This is the pattern Azure documents for exactly this reason:

> Subnets should always be managed as child resources, and the **subnets** property should never be defined within the virtual network resource.
> -- [Bicep: virtual networks scenario guidance](https://learn.microsoft.com/azure/azure-resource-manager/bicep/scenarios-virtual-networks)

Note for reviewers: a different, older Learn page ([deployment modes](https://learn.microsoft.com/azure/azure-resource-manager/templates/deployment-modes)) still shows the inline pattern. The scenario guidance above is the current one, and AVM's own `avm/res/network/virtual-network` also omits `subnets`.

## Changes

- Convert the three hub subnets from an inline array to deployed child resources with identical properties.
- Serialize subnet deployment via `dependsOn` to avoid `AnotherOperationInProgress`.
- Retain the explicit `vNet` `dependsOn` for the NAT gateway. The NAT gateway is referenced by `resourceId()` string, so there is no implicit Bicep edge and ordering depends on it.
- Correct the script private endpoint to depend on the subnet it is actually created in.
- Refresh stale API versions (Network `2023-11-01` to `2025-07-01`). Both API change logs were reviewed: the delta is purely additive, no property removed and no default changed.
- Add a compiled-ARM regression suite (16 tests).
- Run the hub Bicep on pull requests so a bicep-only change actually exercises the suite.

## Validation

**Static**

- `main.bicep` compiles clean.
- 16/16 new tests pass.
- Compiled-ARM diff: 0 resources added or removed. Only apiVersion and subnet-shape changes.
- Mutation tested: reverting the Bicep fails 10/16 tests; inverting the NAT gateway ternary fails the NAT assertions. The tests actually detect the regressions they claim to.

**Live, against a real subscription**

Both modes were deployed end to end using the real compiled templates, unmodified.

`natGateway: false`

| Step | Result |
| --- | --- |
| Pre-fix deploy, then add a customer subnet, then redeploy | Customer subnet **silently deleted**, deployment reported `Succeeded` |
| Pre-fix redeploy with the customer subnet in use by a private endpoint | Failed with **`InUseSubnetCannotBeDeleted`** |
| Fixed template, identical starting state | `Succeeded`, all subnets and the customer private endpoint intact |
| Fixed template applied twice | Idempotent |

`natGateway: true`

| Step | Result |
| --- | --- |
| Fixed deploy | `Succeeded`. NAT gateway attached to the script and Data Explorer subnets, correctly **not** attached to the private endpoint subnet |
| Pre-fix with an in-use customer subnet | **`InUseSubnetCannotBeDeleted`** |
| Fixed, identical state | `Succeeded`, customer subnet and private endpoint preserved, NAT attachments preserved |
| Toggle true to false, and false to true | `Succeeded` both ways, `defaultOutboundAccess` flips correctly |

All test resource groups were deleted afterwards.

## Notes

- `defaultOutboundAccess` is set explicitly on every subnet. Network API versions released after 2026-03-31 default it to `false` for new VNets, so setting it explicitly insulates the hub from that change. The newest available version today is `2026-01-01`, before that cutoff.
- The `vNetSubnets` output is retained, so this is not a breaking change for consumers.
- Not covered here: recovery for a customer already stuck mid-failure with partially applied ARM state.
