### PR TITLE
Fix PathNotFound error in msexports ETL ingestion on first run

### DIFF
--- a/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep
@@ -1129,7 +1129,7 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
             {
               activity: 'Get Existing Parquet Files'
               dependencyConditions: [
-                'Completed'
+                'Succeeded'
               ]
             }
           ]

--- a/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep
@@ -1109,6 +1109,7 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
               }
             }
             fieldList: [
+              'exists'
               'childItems'
             ]
             storeSettings: {
@@ -1135,7 +1136,7 @@ resource dataFactory 'Microsoft.DataFactory/factories@2018-06-01' existing = {
           userProperties: []
           typeProperties: {
             items: {
-              value: '@if(contains(activity(\'Get Existing Parquet Files\').output, \'childItems\'), activity(\'Get Existing Parquet Files\').output.childItems, json(\'[]\'))'
+              value: '@if(and(activity(\'Get Existing Parquet Files\').output.exists, contains(activity(\'Get Existing Parquet Files\').output, \'childItems\')), activity(\'Get Existing Parquet Files\').output.childItems, json(\'[]\'))'
               type: 'Expression'
             }
             condition: {

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/app.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/app.bicep
@@ -1694,6 +1694,7 @@ resource pipeline_ExecuteIngestionETL 'Microsoft.DataFactory/factories/pipelines
             }
           }
           fieldList: [
+            'exists'
             'childItems'
           ]
           storeSettings: {
@@ -1720,7 +1721,7 @@ resource pipeline_ExecuteIngestionETL 'Microsoft.DataFactory/factories/pipelines
         userProperties: []
         typeProperties: {
           items: {
-            value: '@if(contains(activity(\'Get Existing Parquet Files\').output, \'childItems\'), activity(\'Get Existing Parquet Files\').output.childItems, json(\'[]\'))'
+            value: '@if(and(activity(\'Get Existing Parquet Files\').output.exists, contains(activity(\'Get Existing Parquet Files\').output, \'childItems\')), activity(\'Get Existing Parquet Files\').output.childItems, json(\'[]\'))'
             type: 'Expression'
           }
           condition: {


### PR DESCRIPTION
## 🛠️ Description

The "Get Existing Parquet Files" `GetMetadata` activity fails with `PathNotFound` when the destination folder doesn't exist yet (e.g. first ingestion for a scope/dataset/month combination). Reservation recommendation exports hit this most often because their destination path adds an extra `exportName` segment, but any export type can hit it on a first run.

Fixed in both places this pattern exists: `msexports_ETL_ingestion` (`Microsoft.CostManagement/Exports/app.bicep`) and the analytics ingestion ETL pipeline (`Microsoft.FinOpsHubs/Analytics/app.bicep`). The two call sites aren't failing for the same reason, though: Exports writes to a *destination* folder that legitimately may not exist yet on first run, so this is a genuine fix there. Analytics reads a *source* folder that a manifest file just landed in, so that folder exists by construction whenever the pipeline runs — the change there is diagnostic, replacing an opaque `PathNotFound` ADLS error with the pipeline's own `IngestionFilesNotFound` error code if the folder is ever missing for some other reason (e.g. a malformed `folderPath`). It does not make a missing ingestion folder a no-op.

Fix: add `'exists'` to the `GetMetadata` activity's `fieldList`. Per [ADF's GetMetadata docs](https://learn.microsoft.com/azure/data-factory/control-flow-get-metadata-activity#supported-capabilities), specifying `exists` makes the activity return `exists: false` instead of throwing when the path is missing — "If `exists` isn't specified in the field list, the Get Metadata activity fails if the object isn't found." The downstream `Filter` activity's `items` expression now checks `.output.exists` before reading `.output.childItems`, so a missing folder resolves to an empty list instead of propagating the failure.

This is the same idiom already used elsewhere in this codebase for "path may not exist yet" scenarios: `Check Schema` in `Exports/app.bicep`, and both `GetMetadata` activities in `IngestionQueries/app.bicep` (one of which — "Get Existing Parquet Files" — already combines `exists` + `childItems` exactly like this fix does).

### Root cause verification (re: issue #2088 comment)

A prior comment on the issue did solid root-cause analysis but its line numbers had drifted and its proposed fix options were speculative (custom error handling / parent-folder existence checks / wrapping in an If Condition). Re-verified against the current code:

- `Microsoft.CostManagement/Exports/app.bicep`: `GetMetadata` activity is at lines 1090-1122, `Filter Out Current Exports` at 1123-1147 (comment's estimate of ~1090-1122 / ~1123-1147 was accurate).
- `Microsoft.FinOpsHubs/Analytics/app.bicep`: identical vulnerable pattern confirmed at lines 1668-1707 (comment said ~1667-1706, essentially correct).
- The actual cleanest fix is ADF's documented, built-in behavior for this exact case (`exists` in `fieldList`), not a custom If Condition or Web-activity workaround — and this idiom was already present elsewhere in the repo, so this change makes the two vulnerable call sites consistent with the rest of the codebase rather than introducing a new pattern.

Fixes #2088

## 📷 Screenshots

Not applicable — backend ETL pipeline fix, no UI changes.

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [x] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

- `bicep build src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep --stdout` — builds cleanly
- `bicep build src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/app.bicep --stdout` — builds cleanly
- Verified compiled ARM JSON includes `"exists"` in both `fieldList` arrays
- `pwsh -Command "./src/scripts/Test-PowerShell.ps1 -Lint"` — 3418/3418 passed
- Manually verified against `pr-2247-manual`: `msexports_ETL_ingestion` ran against a scope/month with no prior parquet files. `Get Existing Parquet Files` succeeded with `exists: false` (previously would have thrown `PathNotFound`), and `Filter Out Current Exports` succeeded with an empty item list. Confirms the fix resolves the first-run failure end-to-end, not just at the Bicep/ARM level.

### 📦 Deploy to test?

> - [x] Hubs + ADX (managed)
> - [ ] Hubs + Fabric (manual) — URI: <!-- paste eventhouse query URI -->
> - [x] Hubs (manual)
> - [ ] Hubs (no data)
> - [ ] Workbooks
> - [ ] Alerts

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [x] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)


