### PR TITLE
Add opt-in Key Vault RBAC authorization for CAF/landing zone compliance

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -29,6 +29,7 @@ The following section lists features and enhancements that are currently in deve
 
 - **Added**
   - Added VNet and private network modes, including opt-in NAT Gateway support for private mode; NAT Gateway incurs additional cost when enabled ([#2163](https://github.com/microsoft/finops-toolkit/pull/2163)).
+  - Added an opt-in `enableRbacAuthorization` parameter to switch the remote hub Key Vault from access policies to Azure RBAC, satisfying Cloud Adoption Framework / Enterprise-Scale landing zone guardrails that require RBAC-authorized key vaults; the Data Factory managed identity is granted an equivalent Key Vault Secrets User role assignment so secret access keeps working when enabled ([#1067](https://github.com/microsoft/finops-toolkit/issues/1067)).
 - **Changed**
   - Replaced redundant `tolower()` comparisons in hub KQL with case-insensitive operators (`has`, `=~`, `!~`) so the engine can use the term index instead of scanning every row ([#2213](https://github.com/microsoft/finops-toolkit/issues/2213)).
   - Replaced whole-term `contains` matches with `has` across hub KQL and the query catalog (resource ID paths, licensing phrases, SKU description terms) and added a per-row operator-equivalence regression harness with unit test coverage ([#2220](https://github.com/microsoft/finops-toolkit/pull/2220)).

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -3,7 +3,7 @@ title: FinOps toolkit changelog
 description: Review the latest features and enhancements in the FinOps toolkit, including updates to FinOps hubs, Power BI reports, and more.
 author: MSBrett
 ms.author: brettwil
-ms.date: 08/12/2026
+ms.date: 08/26/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit
@@ -29,7 +29,7 @@ The following section lists features and enhancements that are currently in deve
 
 - **Added**
   - Added VNet and private network modes, including opt-in NAT Gateway support for private mode; NAT Gateway incurs additional cost when enabled ([#2163](https://github.com/microsoft/finops-toolkit/pull/2163)).
-  - Added an opt-in `enableRbacAuthorization` parameter to switch the remote hub Key Vault from access policies to Azure RBAC, satisfying Cloud Adoption Framework / Enterprise-Scale landing zone guardrails that require RBAC-authorized key vaults; the Data Factory managed identity is granted an equivalent Key Vault Secrets User role assignment so secret access keeps working when enabled ([#1067](https://github.com/microsoft/finops-toolkit/issues/1067)).
+  - Added an opt-in `enableKeyVaultRbacAuthorization` parameter to switch the remote hub Key Vault from access policies to Azure RBAC, satisfying Cloud Adoption Framework / Enterprise-Scale landing zone guardrails that require RBAC-authorized key vaults; the Data Factory managed identity is granted an equivalent Key Vault Secrets User role assignment so secret access keeps working when enabled ([#1067](https://github.com/microsoft/finops-toolkit/issues/1067)).
 - **Changed**
   - Replaced redundant `tolower()` comparisons in hub KQL with case-insensitive operators (`has`, `=~`, `!~`) so the engine can use the term index instead of scanning every row ([#2213](https://github.com/microsoft/finops-toolkit/issues/2213)).
   - Replaced whole-term `contains` matches with `has` across hub KQL and the query catalog (resource ID paths, licensing phrases, SKU description terms) and added a per-row operator-equivalence regression harness with unit test coverage ([#2220](https://github.com/microsoft/finops-toolkit/pull/2220)).

--- a/src/templates/finops-hub/createUiDefinition.json
+++ b/src/templates/finops-hub/createUiDefinition.json
@@ -207,7 +207,7 @@
             "visible": "[equals(basics('analyticsBackend').analyticsEngine, 'remote')]"
           },
           {
-            "name": "enableRbacAuthorization",
+            "name": "enableKeyVaultRbacAuthorization",
             "type": "Microsoft.Common.CheckBox",
             "label": "Enable Key Vault RBAC authorization",
             "toolTip": "Enables Azure RBAC instead of access policies to authorize access to the Key Vault used to store the remote hub storage key. Required by some organizations for policy compliance (e.g., Cloud Adoption Framework guardrails). Enable this if you are deploying to a subscription that enforces this requirement.",
@@ -1020,7 +1020,7 @@
       "remoteHubStorageUri": "[if(equals(basics('analyticsBackend').analyticsEngine, 'remote'), basics('analyticsBackend').remoteHubStorageUri, '')]",
       "remoteHubStorageKey": "[if(equals(basics('analyticsBackend').analyticsEngine, 'remote'), basics('analyticsBackend').remoteHubStorageKey, '')]",
       "enablePurgeProtection": "[if(equals(basics('analyticsBackend').analyticsEngine, 'remote'), coalesce(basics('analyticsBackend').enablePurgeProtection, false), false)]",
-      "enableRbacAuthorization": "[if(equals(basics('analyticsBackend').analyticsEngine, 'remote'), coalesce(basics('analyticsBackend').enableRbacAuthorization, false), false)]",
+      "enableKeyVaultRbacAuthorization": "[if(equals(basics('analyticsBackend').analyticsEngine, 'remote'), coalesce(basics('analyticsBackend').enableKeyVaultRbacAuthorization, false), false)]",
       "tagsByResource": "[steps('tags').tagsByResource]"
     }
   }

--- a/src/templates/finops-hub/createUiDefinition.json
+++ b/src/templates/finops-hub/createUiDefinition.json
@@ -203,7 +203,14 @@
             "name": "enablePurgeProtection",
             "type": "Microsoft.Common.CheckBox",
             "label": "Enable Key Vault purge protection",
-            "toolTip": "Enables purge protection for the Key Vault used to store the remote hub storage key. Purge protection prevents permanent deletion of the Key Vault for 90 days after deletion. Note: If the key is lost, you can regenerate it from the remote hub's storage account.",
+            "toolTip": "Enables purge protection for the Key Vault used to store the remote hub storage key. Purge protection prevents permanent deletion of the Key Vault for 90 days after deletion. Note: If the key is lost, you can regenerate it from the remote hub's storage account. This cannot be disabled once enabled.",
+            "visible": "[equals(basics('analyticsBackend').analyticsEngine, 'remote')]"
+          },
+          {
+            "name": "enableRbacAuthorization",
+            "type": "Microsoft.Common.CheckBox",
+            "label": "Enable Key Vault RBAC authorization",
+            "toolTip": "Enables Azure RBAC instead of access policies to authorize access to the Key Vault used to store the remote hub storage key. Required by some organizations for policy compliance (e.g., Cloud Adoption Framework guardrails). Enable this if you are deploying to a subscription that enforces this requirement.",
             "visible": "[equals(basics('analyticsBackend').analyticsEngine, 'remote')]"
           }
         ],
@@ -1013,6 +1020,7 @@
       "remoteHubStorageUri": "[if(equals(basics('analyticsBackend').analyticsEngine, 'remote'), basics('analyticsBackend').remoteHubStorageUri, '')]",
       "remoteHubStorageKey": "[if(equals(basics('analyticsBackend').analyticsEngine, 'remote'), basics('analyticsBackend').remoteHubStorageKey, '')]",
       "enablePurgeProtection": "[if(equals(basics('analyticsBackend').analyticsEngine, 'remote'), coalesce(basics('analyticsBackend').enablePurgeProtection, false), false)]",
+      "enableRbacAuthorization": "[if(equals(basics('analyticsBackend').analyticsEngine, 'remote'), coalesce(basics('analyticsBackend').enableRbacAuthorization, false), false)]",
       "tagsByResource": "[steps('tags').tagsByResource]"
     }
   }

--- a/src/templates/finops-hub/main.bicep
+++ b/src/templates/finops-hub/main.bicep
@@ -26,8 +26,11 @@ param storageSku string = 'Premium_LRS'
 @description('Optional. Enable infrastructure encryption on the storage account. Default = false.')
 param enableInfrastructureEncryption bool = false
 
-@description('Optional. Enable purge protection for the Key Vault. Default: false.')
+@description('Optional. Enable purge protection for the Key Vault. Once enabled on a vault, purge protection cannot be disabled. Default: false.')
 param enablePurgeProtection bool = false
+
+@description('Optional. Enable Azure RBAC for authorizing access to the Key Vault instead of access policies. Required by some organizations for policy compliance (e.g., Cloud Adoption Framework guardrails). Switching an existing vault from access policies to RBAC has migration implications, so this defaults to false for backward compatibility with existing deployments; review before enabling on an upgrade. Default: false.')
+param enableRbacAuthorization bool = false
 
 @description('Optional. Storage account to push data to for ingestion into a remote hub.')
 param remoteHubStorageUri string = ''
@@ -179,6 +182,7 @@ module hub 'modules/hub.bicep' = {
     storageSku: storageSku
     enableInfrastructureEncryption: enableInfrastructureEncryption
     enablePurgeProtection: enablePurgeProtection
+    enableRbacAuthorization: enableRbacAuthorization
     enableManagedExports: enableManagedExports
     enableRecommendations: enableRecommendations
     enableAHBRecommendations: enableAHBRecommendations

--- a/src/templates/finops-hub/main.bicep
+++ b/src/templates/finops-hub/main.bicep
@@ -30,7 +30,7 @@ param enableInfrastructureEncryption bool = false
 param enablePurgeProtection bool = false
 
 @description('Optional. Enable Azure RBAC for authorizing access to the Key Vault instead of access policies. Required by some organizations for policy compliance (e.g., Cloud Adoption Framework guardrails). Switching an existing vault from access policies to RBAC has migration implications, so this defaults to false for backward compatibility with existing deployments; review before enabling on an upgrade. Default: false.')
-param enableRbacAuthorization bool = false
+param enableKeyVaultRbacAuthorization bool = false
 
 @description('Optional. Storage account to push data to for ingestion into a remote hub.')
 param remoteHubStorageUri string = ''
@@ -182,7 +182,7 @@ module hub 'modules/hub.bicep' = {
     storageSku: storageSku
     enableInfrastructureEncryption: enableInfrastructureEncryption
     enablePurgeProtection: enablePurgeProtection
-    enableRbacAuthorization: enableRbacAuthorization
+    enableKeyVaultRbacAuthorization: enableKeyVaultRbacAuthorization
     enableManagedExports: enableManagedExports
     enableRecommendations: enableRecommendations
     enableAHBRecommendations: enableAHBRecommendations

--- a/src/templates/finops-hub/modules/fx/hub-app.bicep
+++ b/src/templates/finops-hub/modules/fx/hub-app.bicep
@@ -83,8 +83,9 @@ var storageInfrastructureEncryptionProperties = !app.hub.options.storageInfrastr
   }
 }
 
-// KeyVault access policies
-var keyVaultAccessPolicies = [
+// KeyVault access policies -- only used when the vault uses the legacy access-policy auth model
+// (RBAC-authorized vaults must have an empty accessPolicies array; Azure rejects a non-empty array otherwise)
+var keyVaultAccessPolicies = app.hub.options.keyVaultEnableRbacAuthorization ? [] : [
   {
     #disable-next-line BCP318 // Null safety warning for conditional resource access // Null safety warning for conditional resource access
     objectId: dataFactory.identity.principalId
@@ -92,6 +93,10 @@ var keyVaultAccessPolicies = [
     permissions: { secrets: ['get'] }
   }
 ]
+
+// Built-in role definition IDs used for Key Vault RBAC role assignments
+// Key Vault Secrets User -- https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#key-vault-secrets-user
+var keyVaultSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6'
 
 
 //==============================================================================
@@ -484,7 +489,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-02-01' = if (usesKeyVault) {
     softDeleteRetentionInDays: 90
     // Use null instead of false when purge protection is disabled - Azure requires null to indicate the property should not be set
     enablePurgeProtection: app.hub.options.keyVaultEnablePurgeProtection ? true : null
-    enableRbacAuthorization: false
+    enableRbacAuthorization: app.hub.options.keyVaultEnableRbacAuthorization
     createMode: 'default'
     tenantId: subscription().tenantId
     accessPolicies: keyVaultAccessPolicies
@@ -492,6 +497,18 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-02-01' = if (usesKeyVault) {
       bypass: 'AzureServices'
       defaultAction: app.hub.options.privateRouting ? 'Deny' : 'Allow'
     }
+  }
+}
+
+// Grant ADF identity RBAC access to read secrets when the vault uses RBAC instead of access policies
+resource keyVaultRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (usesKeyVault && usesDataFactory && app.hub.options.keyVaultEnableRbacAuthorization) {
+  name: guid(keyVault.id, keyVaultSecretsUserRoleId, dataFactory.id)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    #disable-next-line BCP318 // Null safety warning for conditional resource access
+    principalId: dataFactory.identity.principalId
+    principalType: 'ServicePrincipal'
   }
 }
 

--- a/src/templates/finops-hub/modules/fx/hub-types.bicep
+++ b/src/templates/finops-hub/modules/fx/hub-types.bicep
@@ -71,6 +71,7 @@ type HubRoutingProperties = {
     enableTelemetry: 'Indicates whether telemetry should be enabled for deployments.'
     keyVaultSku: 'KeyVault SKU. Allowed values: "standard", "premium".'
     keyVaultEnablePurgeProtection: 'Indicates whether purge protection is enabled for the Key Vault. When enabled, deleted Key Vault and its secrets cannot be permanently deleted until the retention period expires, which is required for compliance in some environments.'
+    keyVaultEnableRbacAuthorization: 'Indicates whether the Key Vault uses Azure RBAC instead of access policies to authorize access to secrets. When enabled, access policies are ignored and callers need an RBAC role assignment (e.g., Key Vault Secrets User) on the vault, which is required for compliance in some environments.'
     networkAddressPrefix: 'Address prefix for the FinOps hub isolated virtual network, if private network routing is enabled.'
     natGateway: 'Indicates whether a NAT Gateway should be deployed for controlled outbound internet access. When enabled, subnets disable Azure default outbound access and route through the NAT Gateway.'
     privateRouting: 'Indicates whether private network routing is enabled.'
@@ -96,6 +97,7 @@ type HubProperties = {
     enableTelemetry: bool
     keyVaultSku: string
     keyVaultEnablePurgeProtection: bool
+    keyVaultEnableRbacAuthorization: bool
     networkAddressPrefix: string
     natGateway: bool
     privateRouting: bool
@@ -192,6 +194,7 @@ func newHubInternal(
   storageSku string,
   keyVaultSku string,
   keyVaultEnablePurgeProtection bool,
+  keyVaultEnableRbacAuthorization bool,
   enableInfrastructureEncryption bool,
   enablePublicAccess bool,
   enableNatGateway bool,
@@ -213,6 +216,7 @@ func newHubInternal(
     enableTelemetry: isTelemetryEnabled ?? true
     keyVaultSku: keyVaultSku
     keyVaultEnablePurgeProtection: keyVaultEnablePurgeProtection
+    keyVaultEnableRbacAuthorization: keyVaultEnableRbacAuthorization
     networkAddressPrefix: networkAddressPrefix
     natGateway: !enablePublicAccess && enableNatGateway
     privateRouting: !enablePublicAccess
@@ -253,6 +257,7 @@ func newHub(
   storageSku string,
   keyVaultSku string,
   keyVaultEnablePurgeProtection bool,
+  keyVaultEnableRbacAuthorization bool,
   enableInfrastructureEncryption bool,
   enablePublicAccess bool,
   enableNatGateway bool,
@@ -268,6 +273,7 @@ func newHub(
   storageSku,
   keyVaultSku,
   keyVaultEnablePurgeProtection,
+  keyVaultEnableRbacAuthorization,
   enableInfrastructureEncryption,
   enablePublicAccess,
   enableNatGateway,

--- a/src/templates/finops-hub/modules/hub.bicep
+++ b/src/templates/finops-hub/modules/hub.bicep
@@ -34,8 +34,11 @@ param enableInfrastructureEncryption bool = false
 ])
 param keyVaultSku string = 'premium'
 
-@description('Optional. Enable purge protection for the Key Vault. Default: false.')
+@description('Optional. Enable purge protection for the Key Vault. Once enabled on a vault, purge protection cannot be disabled. Default: false.')
 param enablePurgeProtection bool = false
+
+@description('Optional. Enable Azure RBAC for authorizing access to the Key Vault instead of access policies. Required by some organizations for policy compliance (e.g., Cloud Adoption Framework guardrails). Switching an existing vault from access policies to RBAC has migration implications, so this defaults to false for backward compatibility with existing deployments; review before enabling on an upgrade. Default: false.')
+param enableRbacAuthorization bool = false
 
 @description('Optional. Remote storage account for ingestion dataset.')
 param remoteHubStorageUri string = ''
@@ -195,6 +198,7 @@ var hub = newHub(
   storageSku,
   keyVaultSku,
   enablePurgeProtection,
+  enableRbacAuthorization,
   enableInfrastructureEncryption,
   enablePublicAccess,
   enableNatGateway,

--- a/src/templates/finops-hub/modules/hub.bicep
+++ b/src/templates/finops-hub/modules/hub.bicep
@@ -38,7 +38,7 @@ param keyVaultSku string = 'premium'
 param enablePurgeProtection bool = false
 
 @description('Optional. Enable Azure RBAC for authorizing access to the Key Vault instead of access policies. Required by some organizations for policy compliance (e.g., Cloud Adoption Framework guardrails). Switching an existing vault from access policies to RBAC has migration implications, so this defaults to false for backward compatibility with existing deployments; review before enabling on an upgrade. Default: false.')
-param enableRbacAuthorization bool = false
+param enableKeyVaultRbacAuthorization bool = false
 
 @description('Optional. Remote storage account for ingestion dataset.')
 param remoteHubStorageUri string = ''
@@ -198,7 +198,7 @@ var hub = newHub(
   storageSku,
   keyVaultSku,
   enablePurgeProtection,
-  enableRbacAuthorization,
+  enableKeyVaultRbacAuthorization,
   enableInfrastructureEncryption,
   enablePublicAccess,
   enableNatGateway,


### PR DESCRIPTION
## Summary

Adds an `enableRbacAuthorization` parameter to the FinOps hub Bicep templates that switches the remote-hub Key Vault from the legacy access-policy model to Azure RBAC. This is required by Cloud Adoption Framework (CAF) / Enterprise-Scale landing zone Azure Policy guardrails (e.g., "Enforce recommended guardrails for Azure Key Vault"), which flag vaults that use access policies instead of RBAC.

Fixes #1067

## What changed

- **`src/templates/finops-hub/modules/fx/hub-app.bicep`** — the Key Vault resource now sets `enableRbacAuthorization: app.hub.options.keyVaultEnableRbacAuthorization` instead of a hardcoded `false`. When RBAC is enabled:
  - `accessPolicies` is forced to an empty array (Azure rejects a non-empty `accessPolicies` array when `enableRbacAuthorization: true`).
  - A new `keyVaultRoleAssignment` resource grants the Data Factory managed identity the built-in **Key Vault Secrets User** role (`4633458b-17de-408a-b874-0445c86b69e6`) on the vault — the RBAC equivalent of the `secrets: ['get']` access policy it previously relied on. This is the *only* identity that reads secrets from this vault (verified below), so it's the only equivalent role assignment needed.
- **`src/templates/finops-hub/modules/fx/hub-types.bicep`** — added `keyVaultEnableRbacAuthorization` to `HubProperties.options` and threaded it through `newHubInternal`/`newHub`.
- **`src/templates/finops-hub/modules/hub.bicep`** and **`main.bicep`** — added an `enableRbacAuthorization bool = false` parameter, following the exact pattern already used for `enablePurgeProtection`.
- **`createUiDefinition.json`** — added a matching "Enable Key Vault RBAC authorization" checkbox next to the existing purge protection checkbox, gated to the remote-hub analytics engine path (the only path that deploys this vault).
- **`docs-mslearn/toolkit/changelog.md`** — added an entry under Unreleased.

Purge protection (`enablePurgeProtection` / `enableSoftDelete`) was **already fully implemented** on this branch (not something I needed to add) — `enableSoftDelete: true` is hardcoded, and `enablePurgeProtection` is already wired end-to-end as an opt-in parameter defaulting to `false`, following the exact convention I followed for RBAC here.

## Investigation: what currently depends on access policies

I traced every consumer of the Key Vault (`Microsoft.KeyVault/vaults` in `src/templates/finops-hub/modules/fx/hub-app.bicep:471`, only deployed when the `RemoteHub` app requests the `'KeyVault'` feature — `modules/Microsoft.FinOpsHubs/RemoteHub/app.bicep:52`):

1. **Data Factory's `AzureKeyVault` linked service** (`hub-app.bicep:201`, `linkedService_keyVault`) — ADF authenticates as its own system-assigned managed identity at runtime to read the `remoteHubStorage` connection secret via `AzureKeyVaultSecret`. This is the **only** data-plane secret reader, and it's exactly what the pre-existing `keyVaultAccessPolicies` var (`secrets: ['get']`) granted. Now granted via RBAC (`Key Vault Secrets User`) when `enableRbacAuthorization: true`.
2. **The `keyVault_secret` module** (`fx/hub-vault.bicep`, invoked from `RemoteHub/app.bicep:59`) writes the storage key as a nested ARM `Microsoft.KeyVault/vaults/secrets` resource. This is a management-plane (ARM) write authorized by the *deploying principal's* Azure RBAC role on the resource group (e.g., Contributor), not by the vault's own access-policy/RBAC-authorization setting — so it is unaffected either way.
3. No other hub app (`Core`, `Exports`, `Analytics`, `AzureResourceGraph`, etc.) references this Key Vault at all.

So the only identity needing a new role assignment is Data Factory's managed identity, which I added.

## PR #1349 (closed, not merged)

Read `gh pr diff 1349` before starting. It only added `enablePurgeProtection` (12 lines across `main.bicep`/`hub.bicep`/`keyVault.bicep`) against the **pre-reorganization** template layout — those exact file paths (`modules/keyVault.bicep`) no longer exist; the Key Vault resource now lives in `modules/fx/hub-app.bicep` as part of the namespace-based `fx`/`Microsoft.FinOpsHubs` restructuring. It didn't touch RBAC at all, and its purge-protection change has since been superseded by a more complete implementation already on `dev`/`v15-prep`. I did not build on it — nothing to build on for RBAC, and the purge-protection piece it targeted was already done more thoroughly elsewhere.

## Design decision: opt-in, not forced-on

Both `enableRbacAuthorization` and `enablePurgeProtection` are **irreversible per Azure's API contract**:
- Once `enablePurgeProtection: true` is set on a vault, it cannot be reverted.
- Switching `enableRbacAuthorization` from `false` to `true` on an *existing* vault immediately stops honoring access policies; any identity not covered by an equivalent RBAC role assignment loses access with no rollback path (short of recreating the vault).

Because the FinOps hub template supports redeploying over existing hub instances (upgrade scenario), forcing either property on unconditionally would silently break already-deployed hubs that don't opt in, with no way back. I followed the existing precedent set by `enablePurgeProtection` (already opt-in, defaulting to `false`, surfaced identically in `main.bicep`/`hub.bicep`/`createUiDefinition.json`) and applied the same pattern to `enableRbacAuthorization`. Organizations that need CAF/Enterprise-Scale compliance can set both parameters to `true` explicitly; organizations upgrading an existing hub are not force-migrated into a breaking, irreversible change they didn't ask for.

I believe this is the safer default, but it does mean the compliance gap in #1067 isn't closed *by default* — only when explicitly enabled. If maintainers prefer defaulting new deployments to `true` while keeping upgrades safe, that would need a way to distinguish first-deploy from redeploy, which Bicep can't do natively (no reliable "does this resource already exist" check without a `existing` lookup that fails hard on first deploy). Flagging this as an open discussion point for reviewers.

## Verification

- `bicep build src/templates/finops-hub/main.bicep --stdout` — clean, no errors (2 pre-existing unrelated warnings in `Recommendations/app.bicep`, confirmed present before this change via `git stash`).
- `bicep build` on `hub.bicep`, `hub-app.bicep`, and `hub-types.bicep` individually — all clean.
- `pwsh -Command "./src/scripts/Test-PowerShell.ps1 -Lint"` — 3418/3418 passed, including `ms.date` frontmatter checks (already current at `08/12/2026`, no update needed).
- Did not run a live `az deployment ... what-if` — no Azure credentials available in this environment. Everything else that could be verified statically was.

## Open questions for reviewers

1. Should new (first-time) deployments default `enableRbacAuthorization`/`enablePurgeProtection` to `true` while upgrades stay opt-in? Flagged above as not straightforwardly expressible in Bicep.
2. Confirm `Key Vault Secrets User` is the right role scope (read-only `get`/`list` on secrets) rather than `Key Vault Secrets Officer` — I matched the existing access policy's `secrets: ['get']` scope exactly, so `Secrets User` (read-only) seemed correct, but worth a second look given ADF also needs to enumerate the linked service's secret at authoring/refresh time.

## Test plan

- [x] Lint tests (PowerShell / bicep build)
- [ ] PS -WhatIf / az validate (no Azure credentials in this environment)
- [ ] Manually deployed + verified
- [ ] Unit tests
- [ ] Integration tests