### PR TITLE
Bump pinned Az PowerShell module versions in CI workflows

### DIFF
--- a/.github/workflows/aoe-cd-dev.yml
+++ b/.github/workflows/aoe-cd-dev.yml
@@ -24,12 +24,12 @@ jobs:
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module -Name Az.Accounts -RequiredVersion 2.19.0 -Force
-          Install-Module -Name Az.Resources -RequiredVersion 6.16.2 -Force
-          Install-Module -Name Az.Storage -RequiredVersion 6.2.0 -Force
-          Install-Module -Name Az.OperationalInsights -RequiredVersion 3.2.0 -Force
-          Install-Module -Name Az.Sql -RequiredVersion 4.14.1 -Force
-          Install-Module -Name Az.Automation -RequiredVersion 1.10.0 -Force
+          Install-Module -Name Az.Accounts -RequiredVersion 5.5.2 -Force
+          Install-Module -Name Az.Resources -RequiredVersion 10.1.0 -Force
+          Install-Module -Name Az.Storage -RequiredVersion 9.7.2 -Force
+          Install-Module -Name Az.OperationalInsights -RequiredVersion 3.4.1 -Force
+          Install-Module -Name Az.Sql -RequiredVersion 7.0.0 -Force
+          Install-Module -Name Az.Automation -RequiredVersion 1.12.1 -Force
           Install-Module -Name Microsoft.Graph.Authentication,Microsoft.Graph.Identity.DirectoryManagement -Force
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/aoe-cd-prod.yml
+++ b/.github/workflows/aoe-cd-prod.yml
@@ -24,12 +24,12 @@ jobs:
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module -Name Az.Accounts -RequiredVersion 2.19.0 -Force
-          Install-Module -Name Az.Resources -RequiredVersion 6.16.2 -Force
-          Install-Module -Name Az.Storage -RequiredVersion 6.2.0 -Force
-          Install-Module -Name Az.OperationalInsights -RequiredVersion 3.2.0 -Force
-          Install-Module -Name Az.Sql -RequiredVersion 4.14.1 -Force
-          Install-Module -Name Az.Automation -RequiredVersion 1.10.0 -Force
+          Install-Module -Name Az.Accounts -RequiredVersion 5.5.2 -Force
+          Install-Module -Name Az.Resources -RequiredVersion 10.1.0 -Force
+          Install-Module -Name Az.Storage -RequiredVersion 9.7.2 -Force
+          Install-Module -Name Az.OperationalInsights -RequiredVersion 3.4.1 -Force
+          Install-Module -Name Az.Sql -RequiredVersion 7.0.0 -Force
+          Install-Module -Name Az.Automation -RequiredVersion 1.12.1 -Force
           Install-Module -Name Microsoft.Graph.Authentication,Microsoft.Graph.Identity.DirectoryManagement -Force
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/aoe-cd-test.yml
+++ b/.github/workflows/aoe-cd-test.yml
@@ -24,12 +24,12 @@ jobs:
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module -Name Az.Accounts -RequiredVersion 2.19.0 -Force
-          Install-Module -Name Az.Resources -RequiredVersion 6.16.2 -Force
-          Install-Module -Name Az.Storage -RequiredVersion 6.2.0 -Force
-          Install-Module -Name Az.OperationalInsights -RequiredVersion 3.2.0 -Force
-          Install-Module -Name Az.Sql -RequiredVersion 4.14.1 -Force
-          Install-Module -Name Az.Automation -RequiredVersion 1.10.0 -Force
+          Install-Module -Name Az.Accounts -RequiredVersion 5.5.2 -Force
+          Install-Module -Name Az.Resources -RequiredVersion 10.1.0 -Force
+          Install-Module -Name Az.Storage -RequiredVersion 9.7.2 -Force
+          Install-Module -Name Az.OperationalInsights -RequiredVersion 3.4.1 -Force
+          Install-Module -Name Az.Sql -RequiredVersion 7.0.0 -Force
+          Install-Module -Name Az.Automation -RequiredVersion 1.12.1 -Force
           Install-Module -Name Microsoft.Graph.Authentication,Microsoft.Graph.Identity.DirectoryManagement -Force
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/ftk-pr-cleanup.yml
+++ b/.github/workflows/ftk-pr-cleanup.yml
@@ -23,8 +23,8 @@ jobs:
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module -Name Az.Accounts -RequiredVersion 2.19.0 -Force
-          Install-Module -Name Az.Resources -RequiredVersion 6.16.2 -Force
+          Install-Module -Name Az.Accounts -RequiredVersion 5.5.2 -Force
+          Install-Module -Name Az.Resources -RequiredVersion 10.1.0 -Force
 
       - name: Azure login
         uses: azure/login@v2

--- a/.github/workflows/ftk-pr-deploy.yml
+++ b/.github/workflows/ftk-pr-deploy.yml
@@ -25,9 +25,9 @@ on:
     types: [labeled]
 
 env:
-  AZ_ACCOUNTS_VERSION: '2.19.0'
-  AZ_RESOURCES_VERSION: '6.16.2'
-  AZ_STORAGE_VERSION: '6.2.0'
+  AZ_ACCOUNTS_VERSION: '5.5.2'
+  AZ_RESOURCES_VERSION: '10.1.0'
+  AZ_STORAGE_VERSION: '9.7.2'
 
 concurrency:
   group: ftk-pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/opendata-instance-size-flexibility.yml
+++ b/.github/workflows/opendata-instance-size-flexibility.yml
@@ -31,7 +31,7 @@ jobs:
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module -Name Az.Accounts -RequiredVersion 2.19.0 -Force
+          Install-Module -Name Az.Accounts -RequiredVersion 5.5.2 -Force
 
       - name: Login via Az module
         uses: azure/login@264ef4588d3ca547fea5296679ee9f8a4766d4df # hf_447_release


### PR DESCRIPTION
## Summary

Issue #945 reports the deployment scripts printing Az PowerShell's built-in outdated-version warning ("You're using Az version 8.0.0. The latest version of Az is 12.2.0..."). That message is emitted by `Az.Accounts` itself at runtime, comparing the locally installed `Az` module against PSGallery — it is not text this repo generates, so there's no code path in `src/scripts/` or `src/powershell/` that "prints" it or that can be patched directly.

What *is* fixable in-repo: several CI workflows pin specific, multi-year-stale `Az.*` module versions via `Install-Module -RequiredVersion` / `AZ_*_VERSION` env vars, which would themselves trigger that same nag during CI runs (and give contributors who copy those pins into local scripts an outdated baseline). This PR bumps every one of those pins to the current PSGallery stable release, consistently across all files that reference them:

| Module | Old | New |
|---|---|---|
| `Az.Accounts` | 2.19.0 | 5.5.2 |
| `Az.Resources` | 6.16.2 | 10.1.0 |
| `Az.Storage` | 6.2.0 | 9.7.2 |
| `Az.OperationalInsights` | 3.2.0 | 3.4.1 |
| `Az.Sql` | 4.14.1 | 7.0.0 |
| `Az.Automation` | 1.10.0 | 1.12.1 |

Files updated:
- `.github/workflows/ftk-pr-deploy.yml` (env vars `AZ_ACCOUNTS_VERSION`, `AZ_RESOURCES_VERSION`, `AZ_STORAGE_VERSION`, consumed by all deploy jobs + cache keys)
- `.github/workflows/ftk-pr-cleanup.yml`
- `.github/workflows/opendata-instance-size-flexibility.yml`
- `.github/workflows/aoe-cd-dev.yml`, `aoe-cd-test.yml`, `aoe-cd-prod.yml`

No other `RequiredVersion`/`MinimumVersion`/`RequiredModules` pins exist elsewhere in the repo (checked `src/scripts/`, `src/powershell/`, all `.psd1` manifests). Docs (`docs/powershell.md`, `docs-mslearn/**`) use unpinned `Install-Module -Name Az.Accounts` / `Az.Resources`, which is already correct and untouched.

References but does not close #945, since the actual user-facing warning is Az PowerShell's own runtime nag based on whatever `Az` version is installed on the machine running the deployment script — not something this repo enforces or can silence in code. Recommend closing #945 once this merges, with a note in the issue that the fix is "keep CI pins current" rather than "suppress the nag."

## Test plan

- [x] `pwsh -Command "./src/scripts/Test-PowerShell.ps1 -Lint"` — 3418/3418 passed
- [x] Diffs reviewed — mechanical version-string substitutions only, no structural YAML changes
- [x] Verified no remaining references to the old version strings across `.github/workflows/`