### PR TITLE
Accept SHA-pinned action refs in update-mslearn-dates workflow tests

### DIFF
--- a/src/powershell/Tests/Unit/Action.UpdateMsLearnDates.Tests.ps1
+++ b/src/powershell/Tests/Unit/Action.UpdateMsLearnDates.Tests.ps1
@@ -57,10 +57,10 @@ Describe 'update-mslearn-dates GitHub Action' {
     }
 
     Context 'Workflow steps' {
-        # Third-party actions are pinned to a full 40-character commit SHA (with the
-        # human-readable version in a trailing comment) rather than a floating @vN tag,
-        # so these assertions accept either form. Matching only @vN made the suite fail
-        # the moment the workflows were hardened.
+        # Actions are pinned to a full 40-character commit SHA (with the human-readable
+        # version in a trailing comment) rather than a floating @vN tag, so these
+        # assertions accept either form. Matching only @vN made the suite fail the
+        # moment the workflows were hardened.
         It 'Should checkout the PR branch' {
             $workflowContent | Should -Match 'uses:\s*actions/checkout@(?:[0-9a-f]{40}|v\d+)'
             $workflowContent | Should -Match 'ref:\s*\$\{\{\s*github\.head_ref\s*\}\}'

--- a/src/powershell/Tests/Unit/Action.UpdateMsLearnDates.Tests.ps1
+++ b/src/powershell/Tests/Unit/Action.UpdateMsLearnDates.Tests.ps1
@@ -57,13 +57,17 @@ Describe 'update-mslearn-dates GitHub Action' {
     }
 
     Context 'Workflow steps' {
+        # Third-party actions are pinned to a full 40-character commit SHA (with the
+        # human-readable version in a trailing comment) rather than a floating @vN tag,
+        # so these assertions accept either form. Matching only @vN made the suite fail
+        # the moment the workflows were hardened.
         It 'Should checkout the PR branch' {
-            $workflowContent | Should -Match 'uses:\s*actions/checkout@v\d+'
+            $workflowContent | Should -Match 'uses:\s*actions/checkout@(?:[0-9a-f]{40}|v\d+)'
             $workflowContent | Should -Match 'ref:\s*\$\{\{\s*github\.head_ref\s*\}\}'
         }
 
         It 'Should use changed-files action' {
-            $workflowContent | Should -Match 'uses:\s*tj-actions/changed-files@v\d+'
+            $workflowContent | Should -Match 'uses:\s*tj-actions/changed-files@(?:[0-9a-f]{40}|v\d+)'
         }
 
         It 'Should filter changed-files to docs-mslearn markdown' {


### PR DESCRIPTION
## 🐛 Problem

The **Pester** job is failing on `dev`, and therefore on every open PR.

Two assertions in `src/powershell/Tests/Unit/Action.UpdateMsLearnDates.Tests.ps1` require a floating `@vN` tag:

```powershell
$workflowContent | Should -Match 'uses:\s*actions/checkout@v\d+'
$workflowContent | Should -Match 'uses:\s*tj-actions/changed-files@v\d+'
```

Pinning the workflows to full-length commit SHAs rewrote those refs in `.github/workflows/update-mslearn-dates.yml`:

```yaml
uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
```

Neither matches `@v\d+`, so both assertions fail:

```
[-] Should checkout the PR branch
    Expected regular expression 'uses:\s*actions/checkout@v\d+' to match ...
[-] Should use changed-files action
    Expected regular expression 'uses:\s*tj-actions/changed-files@v\d+' to match ...
```

## 🔧 Solution

Widen both patterns to accept either a 40-character SHA pin or a version tag:

```powershell
'uses:\s*actions/checkout@(?:[0-9a-f]{40}|v\d+)'
'uses:\s*tj-actions/changed-files@(?:[0-9a-f]{40}|v\d+)'
```

The tests' intent — that the workflow checks out the PR branch and uses `changed-files` — is preserved, and the suite now passes whether an action is SHA-pinned or tag-referenced, so re-pinning in future won't break it again.

These are the only two version-tag assertions of this kind in the test suite; I grepped for others and found none.

## 🧪 Validation

- `Action.UpdateMsLearnDates.Tests.ps1` + `Action.UpdateMsLearnDates.AwkParity.Tests.ps1`: **34 pass, 0 fail** (was 2 failing).
- Confirmed the failures reproduce on a clean `dev` worktree before the change, so this is a `dev` breakage rather than a PR-specific one.
- PSScriptAnalyzer output is unchanged from `dev` (the one pre-existing `PSUseDeclaredVarsMoreThanAssignments` on line 7 is untouched).

Test-only change; no workflow or product code is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
