### PR TITLE
fix(powershell): bump Az.Accounts/Az.Resources floor in hub module manifest

### DIFF
--- a/.build/BuildHelper/Build-PsModule.ps1
+++ b/.build/BuildHelper/Build-PsModule.ps1
@@ -58,11 +58,11 @@ function Build-PsModule
         RequiredModules   = @(
             @{
                 ModuleName    = 'Az.Accounts'
-                ModuleVersion = '2.17.0'
+                ModuleVersion = '5.4.0'
             },
             @{
                 ModuleName    = 'Az.Resources'
-                ModuleVersion = '6.5.1'
+                ModuleVersion = '9.1.0'
             }
         )
         IconUri           = 'https://raw.githubusercontent.com/microsoft/finops-toolkit/4747859b1c800f49d5b0c3cd7894a40fe8641c3a/src/images/FinOpsToolkit.svg'


### PR DESCRIPTION
## Summary

Fixes #945. The generated `FinOpsToolkit` PowerShell module manifest (built by `.build/BuildHelper/Build-PsModule.ps1`) declares a `RequiredModules` floor of `Az.Accounts 2.17.0` / `Az.Resources 6.5.1`. This is what `New-FinOpsCostExport`, `Deploy-FinOpsHub`, and the other FinOps toolkit deployment cmdlets depend on — and it's well behind what's actually installed/tested today, which is the source of the stale Az PowerShell version warning reported in #945.

This PR raises the floor to `Az.Accounts 5.4.0` / `Az.Resources 9.1.0` — the exact versions installed and genuinely testable in this environment (not a speculative bump to some newer, untested version).

**Scope note:** per prior discussion on this issue (see #2250, which was rejected as off-target), this change touches *only* the FinOps hub PowerShell deployment surface. It does not touch CI workflow pins or the Optimization Engine.

## Cmdlets validated (touch Az.Accounts/Az.Resources)

- `Private/Invoke-Rest.ps1` — `Get-AzAccessToken`, `Get-AzContext`
- `Private/Save-FinOpsHubTemplate.ps1` — `Get-AzContext`
- `Public/Add-FinOpsHubScope.ps1` — `Get-AzResource`
- `Public/Add-FinOpsServicePrincipal.ps1` — `Get-AzContext`
- `Public/Deploy-FinOpsHub.ps1` — `Get-AzResourceGroup`, `New-AzResourceGroup`, `New-AzResourceGroupDeployment`
- `Public/Get-FinOpsCostExport.ps1` — `Get-AzContext`
- `Public/Get-FinOpsHub.ps1` — `Get-AzContext`, `Get-AzResource`
- `Public/New-FinOpsCostExport.ps1` — `Get-AzContext`, `Get-AzResourceProvider`
- `Public/Register-FinOpsHubProviders.ps1` — `Get-AzResourceProvider`
- `Public/Remove-FinOpsCostExport.ps1` — `Get-AzContext`
- `Public/Remove-FinOpsHub.ps1` — `Get-AzContext`, `Get-AzResource`, `Remove-AzResource`
- `Public/Remove-FinOpsHubScope.ps1` — `Get-AzResource`
- `Public/Start-FinOpsCostExport.ps1` — `Get-AzContext`

## Validation (differential, before/after)

Ran the full Unit + Lint Pester suite (`./src/scripts/Test-PowerShell.ps1 -Unit -Lint`) against `Az.Accounts 5.4.0` / `Az.Resources 9.1.0` (the actually-installed versions), once on unmodified HEAD (baseline) and once with this change applied.

| | Passed | Failed | Skipped |
|---|---|---|---|
| Baseline (before) | 5597 | 2 | 119 |
| After (this change) | 5597 | 2 | 119 |

The 2 failures are identical in both runs (`Should checkout the PR branch`, `Should use changed-files action` in `Action.UpdateMsLearnDates.Tests.ps1`) — pre-existing, unrelated to Az.Accounts/Az.Resources, and out of scope for this fix.

Also confirmed the module builds cleanly against the new floor (`Build-PsModule` generates a manifest with the updated `RequiredModules`).

**Integration tests were not run** — they require live Azure authentication (`Connect-AzAccount`) that isn't available in this environment, so they're out of scope for this validation pass.

## Test plan

- [x] Baseline Unit+Lint run on unmodified branch: 5597 passed / 2 failed / 119 skipped
- [x] Post-change Unit+Lint run: 5597 passed / 2 failed / 119 skipped (identical, zero regressions)
- [x] Module builds and generates manifest with updated `RequiredModules`
- [ ] Integration tests (out of scope here — requires live Azure credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)