### PR TITLE
[Open Data] Update instance size flexibility ratios (August 2026)

### DIFF
--- a/src/open-data/InstanceSizeFlexibility.csv
+++ b/src/open-data/InstanceSizeFlexibility.csv
@@ -676,6 +676,7 @@
 "NP Series","Standard_NP10s","10"
 "NP Series","Standard_NP20s","20"
 "NP Series","Standard_NP40s","40"
+"NVadsA10_v5 DedicatedHost","nvadsa10v5_type1","72"
 "NVadsA10_v5 Linux","Standard_NV12ads_A10_v5","12"
 "NVadsA10_v5 Linux","Standard_NV18ads_A10_v5","21.12"
 "NVadsA10_v5 Linux","Standard_NV36adms_A10_v5","59.76"


### PR DESCRIPTION
## Summary

Weekly automated update of instance size flexibility (ISF) ratios from the
[Azure Reservations Catalogs API](https://learn.microsoft.com/azure/cost-management-billing/reservations/instance-size-flexibility#extract-instance-size-flexibility-ratios-using-azure-catalogs-api).

This file maps each ARM SKU to its instance size flexibility group and ratio,
replacing the deprecated `AutofitComboMeterData.csv` and `isfratioblob.csv` files
that were hosted on `ccmstorageprod.blob.core.windows.net` (retired 30 Aug 2026).

## Why this is opened by hand

The **Update Instance Size Flexibility** workflow could not open this PR itself — `gh pr create` is blocked by the org policy that disallows GitHub Actions from creating pull requests. The fetch and the branch push both succeeded, so the data is good; only the PR call failed. #2294 fixes the workflow so future runs surface a PR link instead.

The 17, 24 and 31 August runs each pushed a branch with this same single-row change. This PR is opened from the 31 August branch, which is exactly one commit ahead of `dev` and not behind it. The other two branches have been deleted as redundant.

## Change

One added row:

```csv
"NVadsA10_v5 DedicatedHost","nvadsa10v5_type1","72"
```

A new dedicated-host entry for the NVadsA10_v5 family — an addition, with no modifications or removals to existing rows.

## Test plan

- [x] Reviewed the diff: one added line, no rows modified or removed, no drop in group/SKU count
- [ ] Spot-check `nvadsa10v5_type1` against the Azure Pricing Calculator

🤖 Data generated by the **Update Instance Size Flexibility** workflow
