### PR TITLE
[AOE] Fix schema for ReservationId field in Log Analytics table

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -3,7 +3,7 @@ title: FinOps toolkit changelog
 description: Review the latest features and enhancements in the FinOps toolkit, including updates to FinOps hubs, Power BI reports, and more.
 author: MSBrett
 ms.author: brettwil
-ms.date: 09/02/2026
+ms.date: 09/07/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -65,8 +65,7 @@ The following section lists features and enhancements that are currently in deve
 - **Changed**
   - Switched the reservations and benefits workbooks from the retired `ccmstorageprod` isfratioblob.csv to the FinOps toolkit [Instance size flexibility](open-data.md#instance-size-flexibility) open data file ([#2090](https://github.com/microsoft/finops-toolkit/issues/2090)).
 - **Fixed**
-  - Fixed regression in the `AzureConsumptionV1_CL` schema breaking the Reservations Usage workbook
-  ([#2301](https://github.com/microsoft/finops-toolkit/issues/2301)).
+  - Fixed a regression in the `AzureOptimizationConsumptionV1_CL` schema that was breaking the Reservations Usage workbook ([#2301](https://github.com/microsoft/finops-toolkit/issues/2301)).
 
 ### [PowerShell module](powershell/powershell-commands.md)
 

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -64,6 +64,9 @@ The following section lists features and enhancements that are currently in deve
   - Added a comprehensive [Azure Optimization Engine reference](optimization-engine/reference.md) for runbooks, schedules, variables, Log Analytics tables, and SQL Database tables ([#1271](https://github.com/microsoft/finops-toolkit/issues/1271)).
 - **Changed**
   - Switched the reservations and benefits workbooks from the retired `ccmstorageprod` isfratioblob.csv to the FinOps toolkit [Instance size flexibility](open-data.md#instance-size-flexibility) open data file ([#2090](https://github.com/microsoft/finops-toolkit/issues/2090)).
+- **Fixed**
+  - Fixed regression in the AzureConsutmpionV1_CL schema breaking the Reservations Usage workbook
+  ([#2301](https://github.com/microsoft/finops-toolkit/issues/2301)).
 
 ### [PowerShell module](powershell/powershell-commands.md)
 

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -65,7 +65,7 @@ The following section lists features and enhancements that are currently in deve
 - **Changed**
   - Switched the reservations and benefits workbooks from the retired `ccmstorageprod` isfratioblob.csv to the FinOps toolkit [Instance size flexibility](open-data.md#instance-size-flexibility) open data file ([#2090](https://github.com/microsoft/finops-toolkit/issues/2090)).
 - **Fixed**
-  - Fixed regression in the AzureConsutmpionV1_CL schema breaking the Reservations Usage workbook
+  - Fixed regression in the `AzureConsumptionV1_CL` schema breaking the Reservations Usage workbook
   ([#2301](https://github.com/microsoft/finops-toolkit/issues/2301)).
 
 ### [PowerShell module](powershell/powershell-commands.md)

--- a/src/optimization-engine/Setup-LogAnalyticsTablesAndDCRs.ps1
+++ b/src/optimization-engine/Setup-LogAnalyticsTablesAndDCRs.ps1
@@ -338,7 +338,7 @@ $tableSchemas = @{
         @{ name = "PublisherName_s"; type = "string" }
         @{ name = "PublisherType_s"; type = "string" }
         @{ name = "Quantity_s"; type = "string" }
-        @{ name = "ReservationId_s"; type = "string" }
+        @{ name = "ReservationId_g"; type = "string" }
         @{ name = "ReservationName_s"; type = "string" }
         @{ name = "ResourceGroup"; type = "string" }
         @{ name = "ResourceId"; type = "string" }


### PR DESCRIPTION
## 🛠️ Description

This pull request addresses a regression affecting the `AzureConsumptionV1_CL` schema and updates the data type of the `ReservationId` field. The most important changes are as follows:

**Bug Fixes:**
* Fixed a regression in the `AzureConsumptionV1_CL` schema that was breaking the Reservations Usage workbook.

**Schema Updates:**
* Changed the data type of the `ReservationId` field in the Log Analytics table schema from `string` (`ReservationId_s`) to `guid` (`ReservationId_g`) in `Setup-LogAnalyticsTablesAndDCRs.ps1`.

Fixes #2301

## 📋 Checklist

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [X] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 📦 Deploy to test?

> - [ ] Hubs + ADX (managed)
> - [ ] Hubs + Fabric (manual) — URI: <!-- paste eventhouse query URI -->
> - [ ] Hubs (manual)
> - [ ] Hubs (no data)
> - [ ] Workbooks
> - [ ] Alerts

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [X] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [X] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [ ] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [X] ❎ Docs not needed (small/internal change)
