### PR TITLE
fix(ci): stop no-op label events from cancelling PR deployments

### DIFF
--- a/.github/workflows/ftk-pr-deploy.yml
+++ b/.github/workflows/ftk-pr-deploy.yml
@@ -29,8 +29,13 @@ env:
   AZ_RESOURCES_VERSION: '6.16.2'
   AZ_STORAGE_VERSION: '6.2.0'
 
+# Deploy runs for the same PR share one group so a new push cancels the
+# in-flight deployment. Label events that are NOT 'Needs: Deployment' are no-ops
+# (see the check-options condition below), so they get a unique, throwaway group
+# — otherwise an unrelated bot label would cancel a running deployment and leave
+# only skipped jobs behind, which reads as "deployment not requested".
 concurrency:
-  group: ftk-pr-${{ github.event.pull_request.number }}
+  group: "ftk-pr-${{ github.event.pull_request.number }}${{ (github.event_name == 'pull_request_target' && github.event.label.name != 'Needs: Deployment') && format('-noop-{0}', github.run_id) || '' }}"
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## 🛠️ Description

The PR Deploy workflow shared one concurrency group across both its `pull_request` and `pull_request_target` triggers, with `cancel-in-progress: true`:

```yaml
group: ftk-pr-${{ github.event.pull_request.number }}
```

Any bot label landing while a test deployment was running entered that same group and **cancelled the deployment**. The label run then skipped every job, because `check-options` requires `github.event.label.name == 'Needs: Deployment'`.

Observed on #2291: a `pull_request` edit started deploy run `34090567648` at 06:22:51; a bot label started `pull_request_target` run `34090602148` 28 seconds later and killed it. The PR was left showing cancelled/skipped deploy jobs, which reads as "deployment not requested" rather than "deployment was killed".

**Fix:** label events that are *not* `Needs: Deployment` get a unique, throwaway group, so they cancel nothing. Real deployments stay in the shared per-PR group.

| Event | Group | Effect |
| --- | --- | --- |
| `pull_request` (opened/synchronize/edited) | `ftk-pr-<n>` | synchronize cancels the prior deployment ✅ |
| `pull_request_target`, label = `Needs: Deployment` | `ftk-pr-<n>` | shares the group — a later push still cancels it ✅ |
| `pull_request_target`, any other label | `ftk-pr-<n>-noop-<run_id>` | unique per run, cancels nothing ✅ |

Suffixing the group with `github.event_name` was rejected as the fix: it would split *all* `pull_request_target` runs off, so a new push would no longer cancel an in-flight fork deployment and two labels could stack concurrent deployments.

Verified: the workflow YAML parses (the `Needs: Deployment` literal requires the group value to be quoted), all 7 jobs are intact, and no other workflow uses a `ftk-pr-*` concurrency group.

Fixes #

## 📋 Checklist

### 🔬 How did you test this change?

> - [x] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

### 📦 Deploy to test?

> - [ ] Hubs + ADX (managed)
> - [ ] Hubs + Fabric (manual) — URI:
> - [ ] Hubs (manual)
> - [ ] Hubs (no data)
> - [ ] Workbooks
> - [ ] Alerts

### 🙋‍♀️ Do any of the following that apply?

> - [ ] 🚨 This is a breaking change.
> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [ ] ✅ Updated changelog (required for `dev` PRs)
> - [ ] ➡️ Will add log in a future PR (feature branch PRs only)
> - [x] ❎ Log not needed (small/internal change)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [ ] ➡️ Will add docs in a future PR (feature branch PRs only)
> - [x] ❎ Docs not needed (small/internal change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
