### PR TITLE
Fix Power BI Costs query type mismatch on VCPUs/vCores cast

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -3,7 +3,7 @@ title: FinOps toolkit changelog
 description: Review the latest features and enhancements in the FinOps toolkit, including updates to FinOps hubs, Power BI reports, and more.
 author: MSBrett
 ms.author: brettwil
-ms.date: 09/07/2026
+ms.date: 09/08/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -57,6 +57,8 @@ The following section lists features and enhancements that are currently in deve
 
 - **Changed**
   - Switched the InstanceSizeFlexibility table in the storage and KQL shared datasets from the retired `ccmstorageprod` AutofitComboMeterData.csv to the FinOps toolkit [Instance size flexibility](open-data.md#instance-size-flexibility) open data file, joined to reservation recommendations on the unique ARM SKU name ([#2090](https://github.com/microsoft/finops-toolkit/issues/2090)).
+- **Fixed**
+  - Fixed the storage-based Costs query failing to refresh with `Type mismatch (DISP_E_TYPEMISMATCH 0x80020005)` when a row's SKU details didn't carry a clean numeric VCPUs/vCores value (for example, a Marketplace or reservation purchase row). The value is now coerced to null instead of throwing ([#2297](https://github.com/microsoft/finops-toolkit/issues/2297)).
 
 ### [Optimization Engine](optimization-engine/overview.md)
 

--- a/src/power-bi/storage/Shared.Dataset/definition/tables/Costs.tmdl
+++ b/src/power-bi/storage/Shared.Dataset/definition/tables/Costs.tmdl
@@ -1683,14 +1683,15 @@ table Costs
 				// TODO: Add SQL AHB handling
 					AHB = Table.RemoveColumns(
 						Table.AddColumn(Table.AddColumn(Table.AddColumn(Table.AddColumn(Table.AddColumn(Table.AddColumn(Table.AddColumn(
-							Table.TransformColumnTypes(
+							Table.TransformColumns(
 								Table.ExpandRecordColumn(
 									Table.ReplaceErrorValues(Table.AddColumn(ExtractedTags, "tmp_SkuDetails", each [x_SkuDetailsDictionary]), {{"tmp_SkuDetails", null}}),
 									"tmp_SkuDetails",
 									{"UsageType",      "ImageType",      "ServiceType", "VMName",     "VMProperties",      "VCPUs",       "ReservationOrderId",         "ReservationId",         "VMCapacityReservationId", "AHB",        "vCores",        "ServerSku"},
 									{"x_SkuUsageType", "x_SkuImageType", "x_SkuType",   "tmp_VMName", "x_SkuVMProperties", "tmp_VMvCPUs", "tmp_AddlReservationOrderId", "tmp_AddlReservationId", "x_CapacityCommitmentId",  "tmp_SQLAHB", "tmp_SQLvCores", "tmp_ServerSku"}
 								),
-								{{"tmp_VMvCPUs", Int64.Type}, {"tmp_SQLvCores", Int64.Type}}
+								// Coerce to Int64, degrading any non-numeric/unexpected VCPUs/vCores value (e.g. on a Marketplace, reservation, or other non-VM/SQL charge row) to null instead of throwing a type mismatch error on refresh
+								{{"tmp_VMvCPUs", each try Int64.From(_) otherwise null, Int64.Type}, {"tmp_SQLvCores", each try Int64.From(_) otherwise null, Int64.Type}}
 							),
 							"x_ResourceMachineName",   each if _isNotBlank([tmp_VMName]) then [tmp_VMName] else null),
 							"x_SkuCoreCount",               each if [tmp_VMvCPUs] <> null then [tmp_VMvCPUs] else if [tmp_SQLvCores] <> null then [tmp_SQLvCores] else null, Int64.Type),


### PR DESCRIPTION
<!--
⚠️⚠️⚠️ BEFORE YOU SUBMIT ⚠️⚠️⚠️
1. Use a clear PR title that describes the change (this will be in the release notes).
2. Complete all TODO items below.

✨ TIP: Small PRs close faster. Try multiple, small PRs.
-->

## 🛠️ Description

The storage-based Power BI `Costs` query cast `tmp_VMvCPUs`/`tmp_SQLvCores` (values extracted from the free-form `x_SkuDetails` JSON blob) straight to `Int64.Type` via `Table.TransformColumnTypes`. That blob's shape varies by charge type (VM usage, Marketplace/SaaS purchase, reservation purchase, etc.), so on a row where the `VCPUs`/`vCores` field isn't a clean number, the cast produced an `Error` value instead of throwing during query evaluation. When that error-valued cell was loaded into the model as an `Int64` column, Power BI surfaced it during refresh as:

```
OLE DB or ODBC error: Type mismatch (DISP_E_TYPEMISMATCH 0x80020005)
```

A single month often has no such rows, so it refreshes fine; a full-year refresh pulls in the row that trips it, matching the report.

This switches the cast to `Table.TransformColumns` with a `try ... otherwise null` guard, mirroring the existing defensive pattern used for `x_SkuTerm` (#2175) — an unparseable or missing value now degrades to `null` instead of failing the whole refresh.

Fixes #2297

## 📷 Screenshots

N/A (Power Query/M change, no visual change)

## 📋 Checklist

### 🔬 How did you test this change?

> - [ ] 🤏 Lint tests
> - [ ] 🤞 PS -WhatIf / az validate
> - [ ] 👍 Manually deployed + verified
> - [ ] 💪 Unit tests
> - [ ] 🙌 Integration tests

No automated test coverage exists for Power Query/M logic in this repo, and I don't have a Power BI Desktop environment connected to the reporter's storage account to reproduce the failure live, so this hasn't been verified against real failing data. I read through the full `Costs.tmdl` M query and confirmed the `Table.TransformColumnTypes` call at the reported line is the only unguarded numeric cast on a value sourced from the SKU details JSON blob, and confirmed the replacement `Table.TransformColumns` syntax is valid M.

### 📦 Deploy to test?

> - [ ] Hubs + ADX (managed)
> - [ ] Hubs + Fabric (manual) — URI: <!-- paste eventhouse query URI -->
> - [ ] Hubs (manual)
> - [ ] Hubs (no data)
> - [ ] Workbooks
> - [ ] Alerts

### 🙋‍♀️ Do any of the following that apply?

> - [x] 🤏 The change is less than 20 lines of code.

### 📑 Did you update `docs/changelog.md`?

> - [x] ✅ Updated changelog (required for `dev` PRs)

### 📖 Did you update documentation?

> - [ ] ✅ Public docs in `docs` (required for `dev`)
> - [ ] ✅ Public docs in `docs-mslearn` (required for `dev`)
> - [ ] ✅ Internal dev docs in `docs-wiki` (required for `dev`)
> - [ ] ✅ Internal dev docs in `src` (required for `dev`)
> - [x] ❎ Docs not needed (small/internal change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
