### PR TITLE
feat(hubs): add opt-in parameter to disable shared key access on hub storage accounts

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -29,6 +29,7 @@ The following section lists features and enhancements that are currently in deve
 
 - **Added**
   - Added VNet and private network modes, including opt-in NAT Gateway support for private mode; NAT Gateway incurs additional cost when enabled ([#2163](https://github.com/microsoft/finops-toolkit/pull/2163)).
+  - Added an opt-in `disableStorageSharedKeyAccess` parameter (and matching `-DisableStorageSharedKeyAccess` switch in [Deploy-FinOpsHub](powershell/hubs/deploy-finopshub.md)) to disable Shared Key (storage account key) authentication on hub storage accounts. Data Factory already authenticates using managed identity and RBAC, so enabling this does not affect data ingestion. Default: false, to avoid changing the authentication model on existing deployments ([#2312](https://github.com/microsoft/finops-toolkit/issues/2312)).
 - **Changed**
   - Clarified that the FinOps toolkit exclusively manages the FinOps hub virtual network and documented customer-managed private endpoints as the preferred private-access topology, with virtual network peering as a secondary option ([#2156](https://github.com/microsoft/finops-toolkit/issues/2156)).
   - Replaced redundant `tolower()` comparisons in hub KQL with case-insensitive operators (`has`, `=~`, `!~`) so the engine can use the term index instead of scanning every row ([#2213](https://github.com/microsoft/finops-toolkit/issues/2213)).

--- a/src/powershell/Public/Deploy-FinOpsHub.ps1
+++ b/src/powershell/Public/Deploy-FinOpsHub.ps1
@@ -34,6 +34,9 @@
     .PARAMETER EnablePurgeProtection
     Optional. Enable purge protection for the Key Vault. Default = false.
 
+    .PARAMETER DisableStorageSharedKeyAccess
+    Optional. Disable Shared Key (storage account key) authentication on hub storage accounts. When enabled, only Microsoft Entra ID and managed identity authentication are allowed. Data Factory already authenticates using managed identity and RBAC, so this does not affect data ingestion. Default = false.
+
     .PARAMETER RemoteHubStorageUri
     Optional. Storage account to push data to for ingestion into a remote hub.
 
@@ -144,6 +147,10 @@ function Deploy-FinOpsHub
         [Parameter()]
         [switch]
         $EnablePurgeProtection,
+
+        [Parameter()]
+        [switch]
+        $DisableStorageSharedKeyAccess,
 
         [Parameter()]
         [string]
@@ -320,6 +327,11 @@ function Deploy-FinOpsHub
             if ($Version -eq 'latest' -or [version]$Version -ge '13.0')
             {
                 $parameterSplat.TemplateParameterObject.Add('enablePurgeProtection', $EnablePurgeProtection.IsPresent)
+            }
+
+            if ($Version -eq 'latest' -or [version]$Version -ge '16.0')
+            {
+                $parameterSplat.TemplateParameterObject.Add('disableStorageSharedKeyAccess', $DisableStorageSharedKeyAccess.IsPresent)
             }
 
             # Only pass enableNatGateway when private mode is requested. This keeps public/vnet

--- a/src/powershell/Tests/Unit/Deploy-FinOpsHub.Tests.ps1
+++ b/src/powershell/Tests/Unit/Deploy-FinOpsHub.Tests.ps1
@@ -268,5 +268,38 @@ InModuleScope 'FinOpsToolkit' {
                 } -Times 1
             }
         }
+
+        Context 'Storage shared key access' {
+            BeforeAll {
+                Mock -CommandName 'Get-AzResourceGroup' -MockWith { return @{ ResourceGroupName = $rgName } }
+                Mock -CommandName 'New-AzResourceGroup'
+                Mock -CommandName 'Save-FinOpsHubTemplate'
+                Mock -CommandName 'Initialize-FinOpsHubDeployment'
+                $templateFile = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath 'FinOps/finops-hub-v1.0.0/main.bicep'
+                Mock -CommandName 'Get-ChildItem' -MockWith { return @{ FullName = $templateFile } }
+                Mock -CommandName 'New-AzResourceGroupDeployment'
+            }
+
+            It 'Should default to allowing Shared Key access' {
+                { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -Version 'latest' } | Should -Not -Throw
+                Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
+                    $TemplateParameterObject.disableStorageSharedKeyAccess -eq $false
+                } -Times 1
+            }
+
+            It 'Should pass disableStorageSharedKeyAccess when -DisableStorageSharedKeyAccess is specified' {
+                { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -DisableStorageSharedKeyAccess -Version 'latest' } | Should -Not -Throw
+                Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
+                    $TemplateParameterObject.disableStorageSharedKeyAccess -eq $true
+                } -Times 1
+            }
+
+            It 'Should not pass disableStorageSharedKeyAccess when targeting a version older than 16.0' {
+                { Deploy-FinOpsHub -Name $hubName -ResourceGroup $rgName -Location $location -DisableStorageSharedKeyAccess -Version '15.0' } | Should -Not -Throw
+                Should -Invoke -CommandName 'New-AzResourceGroupDeployment' -ParameterFilter {
+                    -not $TemplateParameterObject.ContainsKey('disableStorageSharedKeyAccess')
+                } -Times 1
+            }
+        }
     }
 }

--- a/src/templates/finops-hub/createUiDefinition.json
+++ b/src/templates/finops-hub/createUiDefinition.json
@@ -879,6 +879,28 @@
             "visible": true
           },
           {
+            "name": "storageSecurity",
+            "type": "Microsoft.Common.Section",
+            "label": "Storage account security",
+            "elements": [
+              {
+                "name": "disableStorageSharedKeyAccessIntro",
+                "type": "Microsoft.Common.TextBlock",
+                "visible": true,
+                "options": {
+                  "text": "Data Factory always connects to hub storage accounts using its managed identity, so disabling Shared Key access does not affect data ingestion. This can be changed after deployment."
+                }
+              },
+              {
+                "name": "disableStorageSharedKeyAccess",
+                "type": "Microsoft.Common.CheckBox",
+                "label": "Disable Shared Key access",
+                "toolTip": "Disables Shared Key (storage account key) authentication on hub storage accounts, requiring Microsoft Entra ID or managed identity authentication instead. Recommended for compliance requirements that prohibit key-based storage access."
+              }
+            ],
+            "visible": true
+          },
+          {
             "name": "managedExports",
             "type": "Microsoft.Common.Section",
             "label": "Managed exports",
@@ -998,6 +1020,7 @@
       "fabricQueryUri": "[if(equals(basics('analyticsBackend').analyticsEngine, 'fabric'), basics('analyticsBackend').fabricQueryUri, '')]",
       "fabricCapacityUnits": "[if(equals(basics('analyticsBackend').analyticsEngine, 'fabric'), basics('analyticsBackend').fabricCapacity, '')]",
       "enableInfrastructureEncryption": "[steps('advanced').storage.enableInfrastructureEncryption]",
+      "disableStorageSharedKeyAccess": "[steps('advanced').storageSecurity.disableStorageSharedKeyAccess]",
       "enableManagedExports": "[steps('advanced').managedExports.enableManagedExports]",
       "enableRecommendations": "[steps('recommendations').enableRecommendations]",
       "enableAHBRecommendations": "[steps('recommendations').optional.enableAHBRecommendations]",

--- a/src/templates/finops-hub/main.bicep
+++ b/src/templates/finops-hub/main.bicep
@@ -26,6 +26,9 @@ param storageSku string = 'Premium_LRS'
 @description('Optional. Enable infrastructure encryption on the storage account. Default = false.')
 param enableInfrastructureEncryption bool = false
 
+@description('Optional. Disable Shared Key (storage account key) authentication on hub storage accounts. When enabled, only Microsoft Entra ID and managed identity authentication are allowed. Data Factory already authenticates using managed identity and RBAC, so this does not affect data ingestion. Default = false.')
+param disableStorageSharedKeyAccess bool = false
+
 @description('Optional. Enable purge protection for the Key Vault. Default: false.')
 param enablePurgeProtection bool = false
 
@@ -178,6 +181,7 @@ module hub 'modules/hub.bicep' = {
     // eventGridLocation: eventGridLocation
     storageSku: storageSku
     enableInfrastructureEncryption: enableInfrastructureEncryption
+    disableStorageSharedKeyAccess: disableStorageSharedKeyAccess
     enablePurgeProtection: enablePurgeProtection
     enableManagedExports: enableManagedExports
     enableRecommendations: enableRecommendations

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Core/infrastructure.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Core/infrastructure.bicep
@@ -378,7 +378,7 @@ resource scriptStorageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = i
   tags: getHubTags(hub, 'Microsoft.Storage/storageAccounts')
   properties: {
     supportsHttpsTrafficOnly: true
-    allowSharedKeyAccess: true
+    allowSharedKeyAccess: !hub.options.disableStorageSharedKeyAccess
     isHnsEnabled: false
     minimumTlsVersion: 'TLS1_2'
     allowBlobPublicAccess: false

--- a/src/templates/finops-hub/modules/fx/hub-app.bicep
+++ b/src/templates/finops-hub/modules/fx/hub-app.bicep
@@ -372,7 +372,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = if (use
   properties: {
     ...storageInfrastructureEncryptionProperties
     supportsHttpsTrafficOnly: true
-    allowSharedKeyAccess: true
+    allowSharedKeyAccess: !app.hub.options.disableStorageSharedKeyAccess
     isHnsEnabled: true
     minimumTlsVersion: 'TLS1_2'
     allowBlobPublicAccess: false

--- a/src/templates/finops-hub/modules/fx/hub-types.bicep
+++ b/src/templates/finops-hub/modules/fx/hub-types.bicep
@@ -77,6 +77,7 @@ type HubRoutingProperties = {
     natGateway: 'Indicates whether a NAT Gateway should be deployed for controlled outbound internet access. When enabled, the script and Data Explorer subnets route outbound traffic through the NAT Gateway.'
     privateRouting: 'Indicates whether private network routing is enabled.'
     publisherIsolation: 'Indicates whether FinOps hub resources should be separated by publisher for advanced security.'
+    disableStorageSharedKeyAccess: 'Indicates whether Shared Key (storage account key) authentication is disabled on hub storage accounts. When enabled, only Microsoft Entra ID and managed identity authentication are allowed. This does not affect Data Factory, which already authenticates via managed identity and RBAC.'
     storageInfrastructureEncryption: 'Indicates whether infrastructure encryption is enabled for the storage account.'
     storageSku: 'Storage account SKU. Allowed values: "Premium_LRS", "Premium_ZRS".'
   }
@@ -102,6 +103,7 @@ type HubProperties = {
     natGateway: bool
     privateRouting: bool
     publisherIsolation: bool
+    disableStorageSharedKeyAccess: bool
     storageInfrastructureEncryption: bool
     storageSku: string
   }
@@ -195,6 +197,7 @@ func newHubInternal(
   keyVaultSku string,
   keyVaultEnablePurgeProtection bool,
   enableInfrastructureEncryption bool,
+  disableStorageSharedKeyAccess bool,
   enablePublicAccess bool,
   enableNatGateway bool,
   networkName string,
@@ -219,6 +222,7 @@ func newHubInternal(
     natGateway: !enablePublicAccess && enableNatGateway
     privateRouting: !enablePublicAccess
     publisherIsolation: false  // TODO: Expose publisher isolation option
+    disableStorageSharedKeyAccess: disableStorageSharedKeyAccess
     storageInfrastructureEncryption: enableInfrastructureEncryption
     storageSku: storageSku
   }
@@ -257,6 +261,7 @@ func newHub(
   keyVaultSku string,
   keyVaultEnablePurgeProtection bool,
   enableInfrastructureEncryption bool,
+  disableStorageSharedKeyAccess bool,
   enablePublicAccess bool,
   enableNatGateway bool,
   networkAddressPrefix string,
@@ -272,6 +277,7 @@ func newHub(
   keyVaultSku,
   keyVaultEnablePurgeProtection,
   enableInfrastructureEncryption,
+  disableStorageSharedKeyAccess,
   enablePublicAccess,
   enableNatGateway,
   '${safeStorageName(name)}-vnet-${location}',    // networkName, cSpell:ignore vnet

--- a/src/templates/finops-hub/modules/hub.bicep
+++ b/src/templates/finops-hub/modules/hub.bicep
@@ -27,6 +27,9 @@ param storageSku string = 'Premium_LRS'
 @description('Optional. Enable infrastructure encryption on the storage account. Default = false.')
 param enableInfrastructureEncryption bool = false
 
+@description('Optional. Disable Shared Key (storage account key) authentication on hub storage accounts. When enabled, only Microsoft Entra ID and managed identity authentication are allowed. Data Factory already authenticates using managed identity and RBAC, so this does not affect data ingestion. Default = false.')
+param disableStorageSharedKeyAccess bool = false
+
 @description('Optional. SKU to use for the KeyVault instance, if enabled. Allowed values: "standard", "premium". Default: "premium".')
 @allowed([
   'premium'
@@ -196,6 +199,7 @@ var hub = newHub(
   keyVaultSku,
   enablePurgeProtection,
   enableInfrastructureEncryption,
+  disableStorageSharedKeyAccess,
   enablePublicAccess,
   enableNatGateway,
   virtualNetworkAddressPrefix,


### PR DESCRIPTION
## Summary

Adds an opt-in `disableStorageSharedKeyAccess` parameter (default `false`, preserving current behavior) to disable Shared Key (storage account key) authentication on FinOps hub storage accounts.

- Threaded through `main.bicep` → `hub.bicep` → `HubProperties.options` → both storage account resources:
  - The publisher/ingestion storage account in `modules/fx/hub-app.bicep`.
  - The private-routing script storage account in `modules/Microsoft.FinOpsHubs/Core/infrastructure.bicep`.
- Exposed in the portal UI (`createUiDefinition.json`) as a new "Storage account security" section under **Advanced**.
- Exposed in PowerShell as a `-DisableStorageSharedKeyAccess` switch on `Deploy-FinOpsHub`, version-gated for template v16+ (mirrors the `-EnablePurgeProtection` pattern).
- Added a changelog entry under the FinOps hubs "Unreleased" (v16) section.
- Added PowerShell unit tests covering the default, the switch, and the version gate.

**Why this is safe by default:** Data Factory already authenticates to hub storage accounts using its managed identity plus Storage Blob Data Contributor RBAC (not the storage account key), and the deployment-script storage account also uses managed identity. So nothing internally depends on Shared Key access, and disabling it has no propagation-delay or irreversibility caveat — `allowSharedKeyAccess` is a freely mutable property, unlike Key Vault purge protection.

Closes #2312

## Test plan

- [x] `bicep build src/templates/finops-hub/main.bicep` compiles cleanly (only pre-existing, unrelated linter warnings).
- [x] Verified the compiled ARM JSON correctly threads `disableStorageSharedKeyAccess` from `main.bicep` down through `hub.bicep`, `newHub`/`newHubInternal`, and into both `allowSharedKeyAccess` resource properties.
- [x] Validated `createUiDefinition.json` is well-formed JSON.
- [ ] PowerShell Pester tests (`Deploy-FinOpsHub.Tests.ps1`) were added but not executed in this environment (`pwsh` unavailable) — please confirm they pass in CI.
- [ ] Manual portal deployment through the new "Storage account security" UI section.

🤖 [AI]

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>