### PR TITLE
feat(hubs): add support for MCA price sheet schema 2024-08-01

### DIFF
--- a/docs-mslearn/toolkit/changelog.md
+++ b/docs-mslearn/toolkit/changelog.md
@@ -29,6 +29,7 @@ The following section lists features and enhancements that are currently in deve
 
 - **Added**
   - Added VNet and private network modes, including opt-in NAT Gateway support for private mode; NAT Gateway incurs additional cost when enabled ([#2163](https://github.com/microsoft/finops-toolkit/pull/2163)).
+  - Added support for the Microsoft Customer Agreement (MCA) `2024-08-01` price sheet schema, which Cost Management now uses by default. The new `productOrderName` field populates `x_SkuOrderName`, matching the existing FOCUS cost details mapping; EA exports are unaffected and continue to use the `2023-05-01` schema ([#2311](https://github.com/microsoft/finops-toolkit/issues/2311)).
 - **Changed**
   - Clarified that the FinOps toolkit exclusively manages the FinOps hub virtual network and documented customer-managed private endpoints as the preferred private-access topology, with virtual network peering as a secondary option ([#2156](https://github.com/microsoft/finops-toolkit/issues/2156)).
   - Replaced redundant `tolower()` comparisons in hub KQL with case-insensitive operators (`has`, `=~`, `!~`) so the engine can use the term index instead of scanning every row ([#2213](https://github.com/microsoft/finops-toolkit/issues/2213)).

--- a/docs-mslearn/toolkit/hubs/configure-scopes.md
+++ b/docs-mslearn/toolkit/hubs/configure-scopes.md
@@ -3,7 +3,7 @@ title: Configure scopes for FinOps hubs
 description: Connect FinOps hubs to billing accounts and subscriptions by configuring Cost Management exports manually or give FinOps hubs access to manage exports for you.
 author: flanakin
 ms.author: micflan
-ms.date: 05/14/2026
+ms.date: 09/09/2026
 ms.topic: how-to
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/hubs/configure-scopes.md
+++ b/docs-mslearn/toolkit/hubs/configure-scopes.md
@@ -116,7 +116,7 @@ Cost Management provides the following 5 types of exports:
 FinOps hubs support the following dataset types, versions, and API versions:
 
 - FocusCost: 1.2-preview, 1.0r2, 1.0, 1.0-preview(v1)
-- PriceSheet: 2023-05-01
+- PriceSheet: 2023-05-01 (EA and MCA), 2024-08-01 (MCA only)
 - ReservationDetails: 2023-03-01
 - ReservationRecommendations: 2023-05-01
 - ReservationTransactions: 2023-05-01

--- a/docs-mslearn/toolkit/hubs/data-model.md
+++ b/docs-mslearn/toolkit/hubs/data-model.md
@@ -3,7 +3,7 @@ title: FinOps hubs data model
 description: Learn about the tables and functions available in FinOps hubs to build your own queries, reports, and dashboards.
 author: flanakin
 ms.author: micflan
-ms.date: 04/01/2026
+ms.date: 09/09/2026
 ms.topic: reference
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/hubs/data-model.md
+++ b/docs-mslearn/toolkit/hubs/data-model.md
@@ -672,6 +672,7 @@ Columns in the **Prices** managed dataset include:
 | x_SkuRegion                          | String    | Source: Microsoft.                                |
 | x_SkuServiceFamily                   | String    | Source: Microsoft.                                |
 | x_SkuOfferId                         | String    | Source: Microsoft, EA only.                       |
+| x_SkuOrderName                       | String    | Source: Microsoft, MCA 2024-08-01+ only.          |
 | x_SkuPartNumber                      | String    | Source: Microsoft, EA only.                       |
 | x_SkuTerm                            | Int       | Source: Microsoft.                                |
 | x_SkuTier                            | Real      | Source: Microsoft, MCA only.                      |

--- a/docs-mslearn/toolkit/hubs/data-processing.md
+++ b/docs-mslearn/toolkit/hubs/data-processing.md
@@ -188,7 +188,7 @@ Transforms:
 
 Supported datasets:
 
-- Microsoft PriceSheet: `2023-05-01` (EA and MCA)
+- Microsoft PriceSheet: `2023-05-01` (EA and MCA), `2024-08-01` (MCA only)
 
 Transforms:
 
@@ -217,6 +217,10 @@ Transforms:
     - Renamed `x_SkuMeterName` to `SkuMeter`.
   - Implemented the following columns when not set by Cost Management:
     - `CommitmentDiscountUnit`
+- v16+:
+  - Added support for the MCA `2024-08-01` price sheet schema, which replaces `discount` and `includedQuantity` with `productOrderName` ([#2311](https://github.com/microsoft/finops-toolkit/issues/2311)).
+    - Added `x_SkuOrderName` from `productOrderName`, matching the `ProductOrderName` -> `x_SkuOrderName` mapping already used for cost details.
+    - EA price sheet exports are unaffected and remain on the `2023-05-01` schema.
 
 ### Recommendation data transforms
 
@@ -351,7 +355,7 @@ To ingest CSV file from Cost Management exports, save files in a specific folder
 <a name="datasets"></a>FinOps hubs support the following dataset types, versions, and API versions:
 
 - FocusCost: `1.2-preview`, `1.0r2`, `1.0`, `1.0-preview(v1)`
-- PriceSheet: `2023-05-01`
+- PriceSheet: `2023-05-01` (EA and MCA), `2024-08-01` (MCA only)
 - ReservationDetails: `2023-03-01`
 - ReservationRecommendations: `2023-05-01`
 - ReservationTransactions: `2023-05-01`

--- a/docs-mslearn/toolkit/hubs/data-processing.md
+++ b/docs-mslearn/toolkit/hubs/data-processing.md
@@ -3,7 +3,7 @@ title: FinOps hubs data processing
 description: Learn how FinOps hubs process data, including scope setup, data normalization, and optimization, to enhance cost management and analysis.
 author: flanakin
 ms.author: micflan
-ms.date: 04/01/2026
+ms.date: 09/09/2026
 ms.topic: concept-article
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/docs-mslearn/toolkit/hubs/template.md
+++ b/docs-mslearn/toolkit/hubs/template.md
@@ -122,6 +122,7 @@ Resources use the following naming convention: `<hubName>-<purpose>-<unique-suff
       - `schemas/focuscost_1.0-preview(v1).json` – FOCUS 1.0-preview schema definition for parquet conversion.
       - `schemas/pricesheet_2023-05-01_ea.json` – Price sheet EA schema definition version 2023-05-01 for parquet conversion.
       - `schemas/pricesheet_2023-05-01_mca.json` – Price sheet MCA schema definition version 2023-05-01 for parquet conversion.
+      - `schemas/pricesheet_2024-08-01_mca.json` – Price sheet MCA schema definition version 2024-08-01 for parquet conversion.
       - `schemas/reservationdetails_2023-03-01.json` – Reservation details schema definition version 2023-03-01 for parquet conversion.
       - `schemas/reservationrecommendations_2023-05-01_ea.json` – Reservation recommendations EA schema definition version 2023-05-01 for parquet conversion.
       - `schemas/reservationrecommendations_2023-05-01_mca.json` – Reservation recommendations MCA schema definition version 2023-05-01 for parquet conversion.

--- a/docs-mslearn/toolkit/hubs/template.md
+++ b/docs-mslearn/toolkit/hubs/template.md
@@ -3,7 +3,7 @@ title: FinOps hub template
 description: Learn about what's included in the FinOps hub template including parameters, resources, and outputs.
 author: flanakin
 ms.author: micflan
-ms.date: 08/24/2026
+ms.date: 09/09/2026
 ms.topic: concept-article
 ms.service: finops
 ms.subservice: finops-toolkit

--- a/src/powershell/Tests/Lint/PriceSheetSchemaVersion.Tests.ps1
+++ b/src/powershell/Tests/Lint/PriceSheetSchemaVersion.Tests.ps1
@@ -1,0 +1,97 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+    .SYNOPSIS
+    Checks whether FinOps hubs still ingests the latest published Cost Management price sheet
+    dataset schema versions.
+
+    .DESCRIPTION
+    FinOps hubs ingests specific Cost Management price sheet dataset schema versions via the
+    schema mapping files under Microsoft.CostManagement/Exports/schemas and the Prices_raw /
+    Prices_transform_* KQL in Microsoft.FinOpsHubs/Analytics. Microsoft can change the default
+    price sheet schema version at any time -- for example, MCA moved from 2023-05-01 to
+    2024-08-01 as its default (see https://github.com/microsoft/finops-toolkit/issues/2311) --
+    and hubs silently fails to map exports using a version it doesn't know about.
+
+    This test is informational only and must NEVER fail the build. It does a best-effort live
+    check against the Microsoft Learn Cost Management dataset schema index and reports (via
+    Write-Warning) when a price sheet schema version newer than what hubs supports is published,
+    so a human can decide whether to add support. A network failure, an unparsable page, or a
+    genuinely newer version are all reported as warnings, never as test failures -- this test
+    can't block a PR or a release.
+#>
+
+Describe 'Price sheet schema version currency (non-blocking)' {
+
+    BeforeDiscovery {
+        $repoRoot = (Get-Item -Path $PSScriptRoot).Parent.Parent.Parent.Parent.FullName
+        $schemasPath = Join-Path $repoRoot 'src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/schemas'
+
+        # Price sheet dataset schema versions FinOps hubs currently has a schema mapping file
+        # for (Microsoft.CostManagement/Exports/schemas/pricesheet_<version>_<ea|mca>.json) and
+        # ingestion support for (Prices_raw / Prices_transform_* in Microsoft.FinOpsHubs/Analytics).
+        # Update this list -- and add the corresponding mapping file and KQL support -- when
+        # adding support for a new version.
+        $supportedVersions = @{
+            EA  = @('2023-05-01')
+            MCA = @('2023-05-01', '2024-08-01')
+        }
+
+        $schemaIndexUri = 'https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/schema-index'
+    }
+
+    It 'Should warn (never fail) when Microsoft publishes a price sheet schema version hubs does not support' {
+        # IMPORTANT: This check is informational only and must NEVER fail CI or block a PR, even
+        # when:
+        #  - the network call fails (offline runner, DNS/proxy issue, docs site unavailable)
+        #  - the docs page layout changes and a version can't be parsed out of it
+        #  - a schema mapping file is unexpectedly missing for a version this test thinks is supported
+        #  - a genuinely newer version has been published that hubs doesn't support yet
+        # In every case, the finding is reported with Write-Warning and the test still passes.
+        try
+        {
+            foreach ($contract in $supportedVersions.Keys)
+            {
+                foreach ($version in $supportedVersions[$contract])
+                {
+                    $mappingFile = Join-Path $schemasPath "pricesheet_${version}_$($contract.ToLower()).json"
+                    if (-not (Test-Path -Path $mappingFile))
+                    {
+                        Write-Warning "FinOps hubs claims to support $contract price sheet schema '$version' but is missing the expected schema mapping file: $mappingFile"
+                    }
+                }
+            }
+
+            $response = Invoke-WebRequest -Uri $schemaIndexUri -UseBasicParsing -TimeoutSec 15
+
+            # Collapse HTML to whitespace-separated text so a table row's cells (which may be
+            # split across tags and lines in the source) read in order, e.g.:
+            # "Price sheet MCA 2024-08-01"
+            $text = ($response.Content -replace '<[^>]+>', ' ') -replace '\s+', ' '
+
+            foreach ($contract in 'EA', 'MCA')
+            {
+                $match = [regex]::Match($text, "Price sheet\s+$contract\s+(\d{4}-\d{2}-\d{2})")
+                if (-not $match.Success)
+                {
+                    Write-Warning "Could not find a $contract price sheet dataset version on $schemaIndexUri -- the page layout may have changed. Check manually against https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/schema-index."
+                    continue
+                }
+
+                $latestVersion = $match.Groups[1].Value
+                if ($latestVersion -notin $supportedVersions[$contract])
+                {
+                    Write-Warning "Microsoft now publishes $contract price sheet schema '$latestVersion', which FinOps hubs doesn't ingest yet (currently supports: $($supportedVersions[$contract] -join ', ')). Consider adding a pricesheet_${latestVersion}_$($contract.ToLower()).json schema mapping file and corresponding KQL support. See https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/schema-index."
+                }
+            }
+        }
+        catch
+        {
+            Write-Warning "Skipped the live price sheet schema version check -- could not reach or parse $($schemaIndexUri): $($_.Exception.Message)"
+        }
+
+        # This test is informational only: it must always pass, regardless of what was found above.
+        $true | Should -BeTrue
+    }
+}

--- a/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep
+++ b/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/app.bicep
@@ -75,6 +75,7 @@ module schemaFiles '../../fx/hub-storage.bicep' = {
       'schemas/focuscost_1.0-preview(v1).json': loadTextContent('./schemas/focuscost_1.0-preview(v1).json')
       'schemas/pricesheet_2023-05-01_ea.json': loadTextContent('./schemas/pricesheet_2023-05-01_ea.json')
       'schemas/pricesheet_2023-05-01_mca.json': loadTextContent('./schemas/pricesheet_2023-05-01_mca.json')
+      'schemas/pricesheet_2024-08-01_mca.json': loadTextContent('./schemas/pricesheet_2024-08-01_mca.json')
       'schemas/reservationdetails_2023-03-01.json': loadTextContent('./schemas/reservationdetails_2023-03-01.json')
       'schemas/reservationrecommendations_2023-05-01_ea.json': loadTextContent('./schemas/reservationrecommendations_2023-05-01_ea.json')
       'schemas/reservationrecommendations_2023-05-01_mca.json': loadTextContent('./schemas/reservationrecommendations_2023-05-01_mca.json')

--- a/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/schemas/pricesheet_2024-08-01_mca.json
+++ b/src/templates/finops-hub/modules/Microsoft.CostManagement/Exports/schemas/pricesheet_2024-08-01_mca.json
@@ -1,0 +1,112 @@
+{
+  "additionalColumns": [],
+  "translator": {
+    "type": "TabularTranslator",
+    "mappings": [
+      {
+        "source": { "name": "BillingAccountId", "type": "String" },
+        "sink": { "name": "BillingAccountId" }
+      },
+      {
+        "source": { "name": "BillingAccountName", "type": "String" },
+        "sink": { "name": "BillingAccountName" }
+      },
+      {
+        "source": { "name": "BillingProfileId", "type": "String" },
+        "sink": { "name": "BillingProfileId" }
+      },
+      {
+        "source": { "name": "BillingProfileName", "type": "String" },
+        "sink": { "name": "BillingProfileName" }
+      },
+      {
+        "source": { "name": "ServiceFamily", "type": "String" },
+        "sink": { "name": "ServiceFamily" }
+      },
+      {
+        "source": { "name": "Product", "type": "String" },
+        "sink": { "name": "Product" }
+      },
+      {
+        "source": { "name": "ProductId", "type": "String" },
+        "sink": { "name": "ProductId" }
+      },
+      {
+        "source": { "name": "ProductOrderName", "type": "String" },
+        "sink": { "name": "ProductOrderName" }
+      },
+      {
+        "source": { "name": "SkuId", "type": "String" },
+        "sink": { "name": "SkuId" }
+      },
+      {
+        "source": { "name": "UnitOfMeasure", "type": "String" },
+        "sink": { "name": "UnitOfMeasure" }
+      },
+      {
+        "source": { "name": "MeterId", "type": "String" },
+        "sink": { "name": "MeterId" }
+      },
+      {
+        "source": { "name": "MeterName", "type": "String" },
+        "sink": { "name": "MeterName" }
+      },
+      {
+        "source": { "name": "MeterType", "type": "String" },
+        "sink": { "name": "MeterType" }
+      },
+      {
+        "source": { "name": "MeterCategory", "type": "String" },
+        "sink": { "name": "MeterCategory" }
+      },
+      {
+        "source": { "name": "MeterSubCategory", "type": "String" },
+        "sink": { "name": "MeterSubCategory" }
+      },
+      {
+        "source": { "name": "MeterRegion", "type": "String" },
+        "sink": { "name": "MeterRegion" }
+      },
+      {
+        "source": { "name": "TierMinimumUnits", "type": "String" },
+        "sink": { "name": "TierMinimumUnits" }
+      },
+      {
+        "source": { "name": "EffectiveStartDate", "type": "DateTimeOffset" },
+        "sink": { "name": "EffectiveStartDate" }
+      },
+      {
+        "source": { "name": "EffectiveEndDate", "type": "DateTimeOffset" },
+        "sink": { "name": "EffectiveEndDate" }
+      },
+      {
+        "source": { "name": "UnitPrice", "type": "Decimal" },
+        "sink": { "name": "UnitPrice" }
+      },
+      {
+        "source": { "name": "BasePrice", "type": "Decimal" },
+        "sink": { "name": "BasePrice" }
+      },
+      {
+        "source": { "name": "MarketPrice", "type": "Decimal" },
+        "sink": { "name": "MarketPrice" }
+      },
+      {
+        "source": { "name": "Currency", "type": "String" },
+        "sink": { "name": "Currency" }
+      },
+      {
+        "source": { "name": "BillingCurrency", "type": "String" },
+        "sink": { "name": "BillingCurrency" }
+      },
+      {
+        "source": { "name": "Term", "type": "String" },
+        "sink": { "name": "Term" }
+      },
+      {
+        "source": { "name": "PriceType", "type": "String" },
+        "sink": { "name": "PriceType" }
+      }
+    ]
+  }
+}

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/HubSetup_v1_0.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/HubSetup_v1_0.kql
@@ -289,6 +289,7 @@ Prices_v1_0()
         x_SkuRegion,
         x_SkuServiceFamily,
         x_SkuOfferId,
+        x_SkuOrderName,
         x_SkuPartNumber,
         x_SkuTerm,
         x_SkuTier,

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/HubSetup_v1_2.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/HubSetup_v1_2.kql
@@ -434,6 +434,7 @@ Prices_v1_2()
         x_SkuRegion,
         x_SkuServiceFamily,
         x_SkuOfferId,
+        x_SkuOrderName,
         x_SkuPartNumber,
         x_SkuTerm,
         x_SkuTier,

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_RawTables.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_RawTables.kql
@@ -672,6 +672,7 @@
 // Supported versions:
 // - MS EA 2023-05-01  -- See https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/price-sheet-ea
 // - MS MCA 2023-05-01 -- See https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/price-sheet-mca
+// - MS MCA 2024-08-01 -- See https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/price-sheet-mca
 //======================================================================================================================
 
 // Prices_raw table -- Create the table if it doesn't exist
@@ -708,6 +709,7 @@
     Product:            string,   // Azure EA + MCA
     ProductId:          string,   // Azure MCA
     ProductID:          string,   // Azure EA
+    ProductOrderName:   string,   // Azure MCA 2024-08-01+
     ServiceFamily:      string,   // Azure EA + MCA
     SkuId:              string,   // Azure MCA
     SkuID:              string,   // Azure EA
@@ -751,6 +753,7 @@
     { "Column": "Product",            "Properties": { "Field": "Product" } },
     { "Column": "ProductId",          "Properties": { "Field": "ProductId" } },
     { "Column": "ProductID",          "Properties": { "Field": "ProductID" } },
+    { "Column": "ProductOrderName",   "Properties": { "Field": "ProductOrderName" } },
     { "Column": "ServiceFamily",      "Properties": { "Field": "ServiceFamily" } },
     { "Column": "SkuId",              "Properties": { "Field": "SkuId" } },
     { "Column": "SkuID",              "Properties": { "Field": "SkuID" } },

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_0.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_0.kql
@@ -13,6 +13,7 @@
 // Supported versions:
 // - MS EA 2023-05-01  -- See https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/price-sheet-ea
 // - MS MCA 2023-05-01 -- See https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/price-sheet-mca
+// - MS MCA 2024-08-01 -- See https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/price-sheet-mca
 //======================================================================================================================
 
 // Prices_transform_v1_0 function
@@ -185,6 +186,7 @@ Prices_transform_v1_0()
         x_SkuRegion,
         x_SkuServiceFamily,
         x_SkuOfferId,
+        x_SkuOrderName = ProductOrderName,
         x_SkuPartNumber,
         x_SkuTerm,
         x_SkuTier,
@@ -242,6 +244,7 @@ Prices_transform_v1_0()
     x_SkuRegion:                          string,    // Azure
     x_SkuServiceFamily:                   string,    // Azure
     x_SkuOfferId:                         string,    // Azure EA
+    x_SkuOrderName:                       string,    // Azure MCA 2024-08-01+
     x_SkuPartNumber:                      string,    // Azure EA
     x_SkuTerm:                            int,       // Azure
     x_SkuTier:                            decimal,   // Azure MCA

--- a/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_2.kql
+++ b/src/templates/finops-hub/modules/Microsoft.FinOpsHubs/Analytics/scripts/IngestionSetup_v1_2.kql
@@ -12,6 +12,7 @@
 // Supported versions:
 // - MS EA 2023-05-01  -- See https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/price-sheet-ea
 // - MS MCA 2023-05-01 -- See https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/price-sheet-mca
+// - MS MCA 2024-08-01 -- See https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/price-sheet-mca
 //======================================================================================================================
 
 // Prices_transform_v1_2 function
@@ -190,6 +191,7 @@ Prices_transform_v1_2()
         x_SkuRegion,
         x_SkuServiceFamily,
         x_SkuOfferId,
+        x_SkuOrderName = ProductOrderName,
         x_SkuPartNumber,
         x_SkuTerm,
         x_SkuTier,
@@ -249,6 +251,7 @@ Prices_transform_v1_2()
     x_SkuRegion:                          string,    // Azure
     x_SkuServiceFamily:                   string,    // Azure
     x_SkuOfferId:                         string,    // Azure EA
+    x_SkuOrderName:                       string,    // Azure MCA 2024-08-01+
     x_SkuPartNumber:                      string,    // Azure EA
     x_SkuTerm:                            int,       // Azure
     x_SkuTier:                            real,      // Azure MCA


### PR DESCRIPTION
## Summary

Cost Management now defaults new Microsoft Customer Agreement (MCA) price sheet exports to schema `2024-08-01`, which removed `discount` and `includedQuantity` and added `productOrderName`. FinOps hubs only had ingestion/mapping support for the older `2023-05-01` schema, so exports created (or rolled over) with the new default silently failed to map into Data Explorer. EA price sheet exports are untouched and remain on `2023-05-01`.

- Added `schemas/pricesheet_2024-08-01_mca.json`, an export schema mapping file following the existing per-version/per-agreement-type pattern (`Microsoft.CostManagement/Exports/app.bicep` dynamically resolves `pricesheet_<version>_<ea|mca>.json` based on the export manifest's dataset version and an MCA-column probe).
- Added `ProductOrderName` to the `Prices_raw` table/mapping and to the `Prices_transform_v1_0()`/`Prices_transform_v1_2()` KQL, populating a new `x_SkuOrderName` column -- the same `ProductOrderName` -> `x_SkuOrderName` mapping FOCUS cost details already use, so the column is now consistent between `Costs` and `Prices`. Threaded the new column through `HubSetup_v1_0.kql`/`HubSetup_v1_2.kql`'s `Prices_v1_0()`/`Prices_v1_2()` views.
- Added a **non-blocking** Pester test (`Tests/Lint/PriceSheetSchemaVersion.Tests.ps1`) that does a best-effort live check against the [Cost Management dataset schema index](https://learn.microsoft.com/azure/cost-management-billing/dataset-schema/schema-index) and warns if Microsoft publishes a price sheet version hubs doesn't support yet. It can never fail the build -- a network failure, unparsable page, or a genuinely newer version are all reported via `Write-Warning` only, and the `It` block always asserts `$true`.
- Updated hubs docs: changelog (Unreleased), `data-model.md` (new `x_SkuOrderName` column), `data-processing.md` (supported dataset versions + a new `v16+` transform bullet), `template.md` (new schema file in the config layout reference), and `configure-scopes.md` (supported dataset versions).

### Design decisions / investigated but not changed

- **`discount` and `includedQuantity` removal**: neither field was ever mapped for MCA in the existing `pricesheet_2023-05-01_mca.json` (only EA maps `IncludedQuantity`, and no version mapped `discount`), so their removal from `2024-08-01` has no ingestion impact.
- **`ManagedExports/app.bicep` and `New-FinOpsCostExport.ps1`**: both explicitly pin `dataVersion = "2023-05-01"` when hubs creates a price sheet export, for both EA and MCA. Since that's an explicit, still-supported version, hub-managed exports keep working unchanged and don't need updating. The gap this PR closes is for price sheet exports that don't pin a version explicitly and pick up Cost Management's new MCA default.
- **Power BI semantic model (`Shared.Dataset/definition/tables/Prices.tmdl`)**: already exposes a curated subset of `Prices` columns (not the full FOCUS schema), so I didn't add `x_SkuOrderName` there to avoid a broader, riskier report-side change outside this issue's scope. Happy to follow up if maintainers want it surfaced in Power BI too.

### Verification

- `bicep build` on `Microsoft.CostManagement/Exports/app.bicep` compiles cleanly.
- New JSON schema mapping file validated for syntax.
- Could not run the PowerShell/Pester suite in this sandbox (no `pwsh` execution available in this environment) -- please run `Test.PowerShell.All` in CI to confirm the new lint test behaves as expected (it should pass and print no warnings, since hubs already supports every version the live check currently finds).

Closes #2311

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>